### PR TITLE
feat(pom): Remediation of the missing `relativePath` XML element

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -115,9 +115,13 @@ public enum PreconditionError {
                 }
             },
             plugin -> {
-                // TODO: Implement remediation function (See
-                // https://github.com/jenkinsci/plugin-modernizer-tool/pull/307)
-                return false;
+                PomModifier pomModifier = new PomModifier(
+                        plugin.getLocalRepository().resolve("pom.xml").toString());
+                pomModifier.addRelativePath();
+                pomModifier.savePom(
+                        plugin.getLocalRepository().resolve("pom.xml").toString());
+                plugin.withoutErrors();
+                return true;
             },
             "Missing relative path in pom file preventing parent download");
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -115,13 +115,18 @@ public enum PreconditionError {
                 }
             },
             plugin -> {
-                PomModifier pomModifier = new PomModifier(
-                        plugin.getLocalRepository().resolve("pom.xml").toString());
-                pomModifier.addRelativePath();
-                pomModifier.savePom(
-                        plugin.getLocalRepository().resolve("pom.xml").toString());
-                plugin.withoutErrors();
-                return true;
+                try {
+                    PomModifier pomModifier = new PomModifier(
+                            plugin.getLocalRepository().resolve("pom.xml").toString());
+                    pomModifier.addRelativePath();
+                    pomModifier.savePom(
+                            plugin.getLocalRepository().resolve("pom.xml").toString());
+                    plugin.withoutErrors();
+                    return true;
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return false;
+                }
             },
             "Missing relative path in pom file preventing parent download");
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -275,7 +275,12 @@ public class PomModifier {
      */
     public void addRelativePath() {
         NodeList parentList = document.getElementsByTagName("parent");
-        if (parentList.getLength() > 0) {
+        if (parentList.getLength() == 0) {
+            LOG.warn("No parent tag found in POM file");
+            return;
+        }
+
+        try {
             Node parentNode = parentList.item(0);
             NodeList childNodes = parentNode.getChildNodes();
             boolean relativePathExists = false;
@@ -284,13 +289,18 @@ public class PomModifier {
                 if (node.getNodeType() == Node.ELEMENT_NODE
                         && node.getNodeName().equals("relativePath")) {
                     relativePathExists = true;
+                    LOG.debug("relativePath tag already exists");
                     break;
                 }
             }
             if (!relativePathExists) {
                 Element relativePathElement = document.createElement("relativePath");
                 parentNode.appendChild(relativePathElement);
+                LOG.debug("Added relativePath tag to parent");
             }
+        } catch (Exception e) {
+            LOG.error("Error adding relativePath tag: " + e.getMessage(), e);
+            throw new RuntimeException("Failed to add relativePath tag", e);
         }
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -269,6 +269,30 @@ public class PomModifier {
     }
 
     /**
+     * Adds a self-closing <relativePath/> tag to the parent tag in the POM file.
+     */
+    public void addRelativePath() {
+        NodeList parentList = document.getElementsByTagName("parent");
+        if (parentList.getLength() > 0) {
+            Node parentNode = parentList.item(0);
+            NodeList childNodes = parentNode.getChildNodes();
+            boolean relativePathExists = false;
+            for (int i = 0; i < childNodes.getLength(); i++) {
+                Node node = childNodes.item(i);
+                if (node.getNodeType() == Node.ELEMENT_NODE
+                        && node.getNodeName().equals("relativePath")) {
+                    relativePathExists = true;
+                    break;
+                }
+            }
+            if (!relativePathExists) {
+                Element relativePathElement = document.createElement("relativePath");
+                parentNode.appendChild(relativePathElement);
+            }
+        }
+    }
+
+    /**
      * Saves the modified POM file to the specified output path.
      *
      * @param outputPath the path to save the POM file

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -271,7 +271,7 @@ public class PomModifier {
     }
 
     /**
-     * Adds a self-closing <relativePath/> tag to the parent tag in the POM file.
+     * Adds a self-closing relativePath tag to the parent tag in the POM file.
      */
     public void addRelativePath() {
         NodeList parentList = document.getElementsByTagName("parent");

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -303,8 +303,10 @@ public class PomModifier {
         try {
             TransformerFactory transformerFactory = TransformerFactory.newInstance();
             transformerFactory.setFeature("http://javax.xml.XMLConstants/feature/secure-processing", true);
+            transformerFactory.setAttribute("indent-number", 2);
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
             DOMSource source = new DOMSource(document);
             StreamResult result = new StreamResult(new File(outputPath));
             transformer.transform(source, result);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -53,6 +53,8 @@ public class PomModifier {
             dbFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             dbFactory.setXIncludeAware(false);
             dbFactory.setExpandEntityReferences(false);
+            // Ignore whitespace
+            dbFactory.setIgnoringElementContentWhitespace(true);
             DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
             document = dBuilder.parse(pomFile);
             document.getDocumentElement().normalize();

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifierTest.java
@@ -168,4 +168,26 @@ public class PomModifierTest {
             assertTrue(url.startsWith("https://"), "URL should start with https://");
         }
     }
+
+    /**
+     * Tests the addRelativePath method of PomModifier.
+     *
+     * @throws Exception if an error occurs during the test
+     */
+    @Test
+    public void testAddRelativePath() throws Exception {
+        PomModifier pomModifier = new PomModifier(OUTPUT_POM_PATH);
+        pomModifier.addRelativePath();
+        pomModifier.savePom(OUTPUT_POM_PATH);
+
+        DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder dBuilder = dbFactory.newDocumentBuilder();
+        Document doc = dBuilder.parse(new File(OUTPUT_POM_PATH));
+        doc.getDocumentElement().normalize();
+
+        NodeList relativePathList = doc.getElementsByTagName("relativePath");
+        assertEquals(1, relativePathList.getLength(), "There should be one relativePath element");
+        Node relativePathNode = relativePathList.item(0);
+        assertTrue(relativePathNode.getTextContent().isEmpty(), "The relativePath element should be self-closing");
+    }
 }

--- a/plugin-modernizer-core/src/test/resources/test-pom.xml
+++ b/plugin-modernizer-core/src/test/resources/test-pom.xml
@@ -4,7 +4,6 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>1.554.1</version>
-    <relativePath />
   </parent>
 
   <properties>


### PR DESCRIPTION
I have added a new method to insert a self-closing `<relativePath/>` tag into `pom.xml` files, and I've updated the related files accordingly.

### Modified Files

* **PomModifier.java**
  - Introduced the `addRelativePath` method to facilitate the addition of a self-closing `<relativePath/>` tag in the `pom.xml`.

* **PreconditionError.java**
  - Updated an existing TODO comment with a new call to the `addRelativePath` method. This enhancement improves the remediation process for the `MISSING_RELATIVE_PATH` error.

* **PomModifierTest.java**
  - Added the `testAddRelativePath` method, which tests the functionality of the newly added feature to ensure it correctly inserts the `<relativePath/>` tag.

## Summary

- **New Features**
	- Improved error handling related to the absence of a relative path in POM files by enabling automatic remediation during the modernization process.
	- Developed a method to automatically add a `<relativePath/>` tag to the POM file when it is missing, which enhances the management of POM files.

- **Tests**
	- Incorporated a new test to confirm the effectiveness of the `<relativePath/>` tag insertion functionality in the POM file.