### PR TITLE
Add JReleaser and workflows

### DIFF
--- a/.github/workflows/jreleaser.yaml
+++ b/.github/workflows/jreleaser.yaml
@@ -1,0 +1,58 @@
+name: jrelease
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up Maven
+        run: |
+          wget --no-verbose https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz
+          echo $CHECKSUM apache-maven-$MAVEN_VERSION-bin.tar.gz | sha512sum --check
+          tar xzf apache-maven-$MAVEN_VERSION-bin.tar.gz
+          rm apache-maven-$MAVEN_VERSION-bin.tar.gz
+          sudo mv apache-maven-$MAVEN_VERSION /opt/maven
+          sudo rm -f /usr/bin/mvn
+          sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn
+          mvn --version
+        env:
+          MAVEN_VERSION: 3.9.9
+          # https://downloads.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz.sha512
+          CHECKSUM: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
+
+      - name: Build package
+        id: build
+        run: |
+          export MAVEN_OPTS=-Djansi.force=true
+          mvn -B -V -e -s $GITHUB_ACTION_PATH/settings.xml -ntp -Dstyle.color=always -Dset.changelist -Pquick-build -P\!consume-incrementals clean package
+          VERSION=$(mvn -q -Dset.changelist -Dignore.dirt -DforceStdout org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version)
+          echo "VERSION=$VERSION"
+          echo "version=$VERSION" >> $GITHUB_STATE
+
+      - name: Run JReleaser
+        with:
+          arguments: release
+        uses: jreleaser/release-action@v2
+        env:
+          JJRELEASER_PROJECT_VERSION: ${{ state.version }}
+          JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ build/
 
 ### ENV ###
 .env
+
+### JReleaser ###
+*.log
+out

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -1,0 +1,37 @@
+project:
+  name: plugin-modernizer-tool
+  description: Plugin Modernizer Tool
+  versionPattern: CUSTOM
+  longDescription: Plugin Modernizer Tool
+  authors:
+    - Jenkins Project
+  license: MIT
+  links:
+    homepage: https://github.com/jenkins-infra/plugin-modernizer-tool
+  java:
+    groupId: io.jenkins.plugin-modernizer
+    version: 17
+  inceptionYear: 2024
+
+release:
+  github:
+    enabled: true
+    owner: jonesbusy
+    overwrite: false
+    tagName: "{{projectVersion}}"
+    releaseName: "{{tagName}}"
+    changelog:
+      enabled: false
+    milestone:
+      close: false
+    update:
+      enabled: true
+    uploadAssets: RELEASE
+
+distributions:
+  plugin-modernizer-cli:
+    active: RELEASE
+    type: SINGLE_JAR
+    stereotype: CLI
+    artifacts:
+      - path: plugin-modernizer-cli/target/jenkins-plugin-modernizer-{{projectVersion}}.jar


### PR DESCRIPTION
This is a requirement for https://github.com/jenkins-infra/plugin-modernizer-tool/issues/239 (Homebrew distribution)

I did some test from my machine but didn't fully test the workflow until merged on main

The idea is

- Keep the `cd` workflow that create the release, upload to artifactory (I need to optimize to only deploy the parent pom and core module. The CLI is a far jar of ~100Mib and is a waste of resource to deploy it to Artifactory Jenkins
- Use `jrelease` to distribute the CLI jar on github (this is this PR) and homebrew

jrelease is configured to not overide the release or changelog but only upload assets

![Screenshot from 2024-12-07 13-05-32](https://github.com/user-attachments/assets/682bf0db-e184-4700-abd2-3c5fc5889158)

I will perform more tests when merged
