### PR TITLE
Add HomeBrew Formula template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ build/
 ### JReleaser ###
 *.log
 out
+results

--- a/homebrew/formula.rb.tpl
+++ b/homebrew/formula.rb.tpl
@@ -1,0 +1,17 @@
+class PluginModernizer < Formula
+    desc "Plugin Modernizer"
+    version "{{projectVersion}}".split(".")[0]
+    homepage "https://github.com/jenkins-infra/plugin-modernizer-tool"
+    url "https://repo.jenkins-ci.org/artifactory/releases/io/jenkins/plugin-modernizer/{{distributionName}}-cli/{{projectVersion}}/{{distributionName}}-cli-{{projectVersion}}.jar"
+    sha256 "{{distributionChecksumSha256}}"
+    license "MIT"
+
+    def install
+      libexec.install "{{distributionName}}-cli-{{projectVersion}}.jar"
+      bin.write_jar_script libexec/"{{distributionName}}-cli-{{projectVersion}}.jar", "plugin-modernizer"
+    end
+
+    test do
+      system bin/"plugin-modernizer", "--version"
+    end
+  end

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -28,9 +28,25 @@ release:
     uploadAssets: RELEASE
 
 distributions:
-  plugin-modernizer-cli:
+  plugin-modernizer:
     active: RELEASE
     type: SINGLE_JAR
     stereotype: CLI
     artifacts:
-      - path: plugin-modernizer-cli/target/jenkins-plugin-modernizer-{{projectVersion}}.jar
+      - path: "{{distributionName}}-cli/target/jenkins-plugin-modernizer-{{projectVersion}}.jar"
+
+packagers:
+  brew:
+    active: RELEASE
+    templateDirectory: homebrew
+    formulaName: PluginModernizer
+    repository:
+      active: RELEASE
+      owner: jonesbusy
+      name: homebrew-tap
+      tagName: '{{distributionName}}-{{tagName}}'
+    extraProperties:
+      skipLicenseFile: true
+    skipTemplates:
+      - cask.rb.tpl
+      - README.md.tpl


### PR DESCRIPTION
Relates to https://github.com/jenkins-infra/homebrew-tap/pull/1

I will update the URL from Artifactory to GitHub releases when the CD flow is fixed

But tested the `publish` locally on my own tap

It's possible that the `jreleaser.yaml` need to be adapted with credentials and `publish` task. An other PR will follow

![Screenshot from 2024-12-08 07-05-58](https://github.com/user-attachments/assets/bd7de2fe-ccff-44f3-be87-e88a948120cf)
