### PR TITLE
Rename parent-pom to pom

### DIFF
--- a/plugin-modernizer-cli/pom.xml
+++ b/plugin-modernizer-cli/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.jenkins.plugin-modernizer</groupId>
-    <artifactId>plugin-modernizer-parent-pom</artifactId>
+    <artifactId>plugin-modernizer-pom</artifactId>
     <version>${changelist}</version>
   </parent>
 

--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.jenkins.plugin-modernizer</groupId>
-    <artifactId>plugin-modernizer-parent-pom</artifactId>
+    <artifactId>plugin-modernizer-pom</artifactId>
     <version>${changelist}</version>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <groupId>io.jenkins.plugin-modernizer</groupId>
-  <artifactId>plugin-modernizer-parent-pom</artifactId>
+  <artifactId>plugin-modernizer-pom</artifactId>
   <version>${changelist}</version>
   <packaging>pom</packaging>
   <name>Plugin Modernizer Parent</name>


### PR DESCRIPTION
No need to specify parent, pom is enough

And wondering if magically it fixes permission issue

https://github.com/jenkins-infra/repository-permissions-updater/pull/4127/files#diff-fc4047510f5e367e5511180a4da22064a9664ba4e829e36604125741cccb2bcb

I'm wondering if `*` would match `pom` but not `parent-pom` due to the dash ?