### PR TITLE
Include build date on version

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/PomVersionProvider.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/PomVersionProvider.java
@@ -10,10 +10,18 @@ public class PomVersionProvider implements CommandLine.IVersionProvider {
 
     @Override
     public String[] getVersion() throws Exception {
-        return new String[] {getVersionFromProperties()};
+        return new String[] {
+            "plugin modernizer %s (%s)".formatted(getValue("project.version"), getValue("build.timestamp")),
+        };
     }
 
-    private String getVersionFromProperties() throws IOException {
+    /**
+     * Get a value from the pom.properties file
+     * @param property the property to get
+     * @return the value of the property
+     * @throws IOException if the file is not found
+     */
+    private String getValue(String property) throws IOException {
         Properties properties = new Properties();
         try (InputStream input = getClass().getClassLoader().getResourceAsStream("pom.properties")) {
             if (input == null) {
@@ -22,11 +30,11 @@ public class PomVersionProvider implements CommandLine.IVersionProvider {
             properties.load(input);
         }
 
-        String version = properties.getProperty("project.version");
-        if (version == null || version.isEmpty()) {
-            throw new ModernizerException("Version not found in pom.properties");
+        String value = properties.getProperty(property);
+        if (value == null || value.isEmpty()) {
+            throw new ModernizerException("%s not found in pom.properties".formatted(property));
         }
 
-        return version;
+        return value;
     }
 }

--- a/plugin-modernizer-cli/src/main/resources/pom.properties
+++ b/plugin-modernizer-cli/src/main/resources/pom.properties
@@ -1,1 +1,2 @@
 project.version = ${project.version}
+build.timestamp = ${maven.build.timestamp}

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,8 @@
 
   <properties>
 
+    <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+
     <!-- Reproducible builds -->
     <project.build.outputTimestamp>2024-01-01T00:00:00Z</project.build.outputTimestamp>
 


### PR DESCRIPTION
Useful information when we distribute it

Format is now

```
plugin modernizer 888.v02298b_910723 (2024-12-08T09:23:53Z)
```