### PR TITLE
Run only one recipe per execution

### DIFF
--- a/.gitpod/init.sh
+++ b/.gitpod/init.sh
@@ -45,7 +45,7 @@ echo -e "If you want to use another GitHub handle, please set the ${color_green}
 echo -e "\nWe propose you to work with two Jenkins plugin repositories: ${color_cyan}badge-plugin${color_reset} and ${color_cyan}build-timestamp-plugin${color_reset}."
 echo -e "You could, though, use other plugin repositories as well (like ${color_cyan}plot-plugin${color_reset}) by entering their name in the following ${color_cyan}java${color_reset} command."
 echo -e "\nYou can now proceed with the modernizer tool thanks to the following commands:"
-echo -e "${color_cyan}java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --dry-run --plugins badge,build-timestamp --recipes AddPluginsBom,AddCodeOwner --export-datatables${color_reset}"
+echo -e "${color_cyan}java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --dry-run --plugins badge,build-timestamp --recipe AddCodeOwner --export-datatables${color_reset}"
 
 echo -e "\nBy the way, you can copy/paste from/to the terminal to execute the commands. Enjoy! 🚀"
 echo -e "See ${color_blue}https://www.gitpod.io/docs/configure/user-settings/browser-settings#browser-settings${color_reset} to know more.\n"

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To activate app authentication, just set the following CLI argument
 ## CLI Options
 - `--plugins` or `-p`: (optional) Name(s) of plugin directory cloned inside the `test-plugins` directory.
 
-- `--recipes` or `-r`: (required) Name(s) of recipes to apply to the plugins.
+- `--recipe` or `-r`: (required) Name of recipe to apply to the plugins.
 
 - `--plugin-file` or `-f`: (optional) Path to the text file that contains a list of plugins. (see example [plugin file](docs/example-plugins.txt))
 
@@ -143,7 +143,7 @@ Plugins can be passed to the CLI tool in two ways:
 Pass the plugin names directly using the `-p` or `--plugins option`. The expected input format for plugins is `artifact ID`.
 
 ```shell
-java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins git,git-client,jobcacher --recipes AddPluginsBom,AddCodeOwner
+java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins git,git-client,jobcacher --recipe AddPluginsBom
 ```
 Here, `git`, `git-client`, and `jobcacher` are plugin artifact IDs (also known as plugin names), while `AddPluginsBom` and `AddCodeOwners` are recipe names. For more details about available recipes, refer to the [recipe_data.yaml](plugin-modernizer-core/src/main/resources/recipe_data.yaml) file.
 
@@ -153,7 +153,7 @@ Pass the path to a file that contains plugin names. The expected input format fo
 See example [plugin file](docs/example-plugins.txt)
 
 ```shell
-java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugin-file path/to/plugin-file --recipes AddPluginsBom,AddCodeOwner
+java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugin-file path/to/plugin-file --recipe AddPluginsBom
 ```
 
 ## Configuring Environmental Variables
@@ -172,14 +172,14 @@ java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT
 ### without dry-run
 
 ```shell
-java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins git,git-client,jobcacher --recipes AddPluginsBom,AddCodeOwner
+java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins git,git-client,jobcacher --recipe AddPluginsBom
 ```
 The above command creates pull requests in the respective remote repositories after applying the changes.
 
 ### with dry-run
 
 ```shell
-java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins git,git-client,jobcacher --recipes AddPluginsBom,AddCodeOwner --dry-run
+java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins git,git-client,jobcacher --recipe AddPluginsBom --dry-run
 ```
 
 The above command generates patch files instead of applying changes directly. These patch files are saved in `/target/rewrite/rewrite.patch` inside each plugin directory. No pull requests will be created.
@@ -190,7 +190,7 @@ The above command generates patch files instead of applying changes directly. Th
 ### with export-datatables
 
 ```shell
-java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins git,git-client,jobcacher --recipes AddPluginsBom,AddCodeOwner --export-datatables
+java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --plugins git,git-client,jobcacher --recipe AddPluginsBom --export-datatables
 ```
 
 The above command creates a report of the changes made through OpenRewrite in csv format. The report will be generated in `target/rewrite/datatables` inside the plugin directory.
@@ -222,7 +222,7 @@ docker run \
   -e GH_OWNER=${GH_OWNER} \
   -v $(pwd)/plugins.txt:/plugins.txt \
   ghcr.io/jenkins-infra/plugin-modernizer-tool:main \
-  --plugin-file /plugins.txt --recipes AddPluginsBom,AddCodeOwner
+  --plugin-file /plugins.txt --recipe AddCodeOwner
 ```
 
 ### Explanation
@@ -232,7 +232,7 @@ docker run \
 - `-v $(pwd)/plugins.txt:/plugins.txt`: Mounts the plugins.txt file from the current directory to the Docker container.
 - `ghcr.io/jenkins-infra/plugin-modernizer-tool:main`: Specifies the Docker image to use.
 - `--plugin-file /plugins.txt`: Specifies the path to the plugin file inside the Docker container.
-- `--recipes AddPluginsBom,AddCodeOwner`: Specifies the recipes to apply.
+- `--recipe AddPluginsBom,`: Specifies the recipe to apply.
 
 This command will run the Plugin Modernizer Tool inside the Docker container using the specified environment variables and plugin file.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     env_file:
       - .env
     command:
-      - --recipes ${RECIPES}
+      - --recipe ${RECIPE}
       - --plugins ${PLUGINS}
       - --debug
       - --dry-run

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -72,12 +72,11 @@ public class Main implements Runnable {
     private PluginOptions pluginOptions;
 
     @Option(
-            names = {"-r", "--recipes"},
+            names = {"-r", "--recipe"},
             required = true,
-            description = "List of Recipes to be applied.",
-            split = ",",
+            description = "Recipe to be applied.",
             converter = RecipeConverter.class)
-    private List<Recipe> recipes;
+    private Recipe recipe;
 
     @Option(
             names = {"-g", "--github-owner"},
@@ -197,7 +196,7 @@ public class Main implements Runnable {
                 .withGitHubAppSourceInstallationId(githubAppSourceInstallationId)
                 .withGitHubAppTargetInstallationId(githubAppTargetInstallationId)
                 .withPlugins(pluginOptions != null ? pluginOptions.plugins : new ArrayList<>())
-                .withRecipes(recipes)
+                .withRecipe(recipe)
                 .withDryRun(dryRun)
                 .withSkipPush(skipPush)
                 .withSkipBuild(skipBuild)

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/MainTest.java
@@ -70,12 +70,9 @@ public class MainTest {
         String[] args = {"-p", "plugin1,plugin2", "-r", "FetchMetadata"};
         commandLine.execute(args);
 
-        List<Recipe> recipes = main.setup().getRecipes();
-        assertNotNull(recipes);
-        assertEquals(1, recipes.size());
-        assertEquals(
-                "io.jenkins.tools.pluginmodernizer.FetchMetadata",
-                recipes.get(0).getName());
+        Recipe recipe = main.setup().getRecipe();
+        assertNotNull(recipe);
+        assertEquals("io.jenkins.tools.pluginmodernizer.FetchMetadata", recipe.getName());
     }
 
     @Test
@@ -83,12 +80,9 @@ public class MainTest {
         String[] args = {"-p", "plugin1,plugin2", "-r", "io.jenkins.tools.pluginmodernizer.FetchMetadata"};
         commandLine.execute(args);
 
-        List<Recipe> recipes = main.setup().getRecipes();
-        assertNotNull(recipes);
-        assertEquals(1, recipes.size());
-        assertEquals(
-                "io.jenkins.tools.pluginmodernizer.FetchMetadata",
-                recipes.get(0).getName());
+        Recipe recipe = main.setup().getRecipe();
+        assertNotNull(recipe);
+        assertEquals("io.jenkins.tools.pluginmodernizer.FetchMetadata", recipe.getName());
     }
 
     @Test
@@ -163,32 +157,14 @@ public class MainTest {
 
     @Test
     public void testSkipPullRequestOptions() throws IOException {
-        String[] args = {
-            "-p",
-            "plugin1,plugin2",
-            "-r",
-            "FetchMetadata",
-            "--skip-push",
-            "--recipes",
-            "FetchMetadata",
-            "--skip-pull-request"
-        };
+        String[] args = {"-p", "plugin1,plugin2", "--skip-push", "--recipe", "FetchMetadata", "--skip-pull-request"};
         commandLine.execute(args);
         assertTrue(main.setup().isSkipPullRequest());
     }
 
     @Test
     public void testCleanLocalData() throws IOException {
-        String[] args = {
-            "-p",
-            "plugin1,plugin2",
-            "-r",
-            "FetchMetadata",
-            "--skip-push",
-            "--recipes",
-            "FetchMetadata",
-            "--clean-local-data"
-        };
+        String[] args = {"-p", "plugin1,plugin2", "--skip-push", "--recipe", "FetchMetadata", "--clean-local-data"};
         commandLine.execute(args);
         assertTrue(main.setup().isRemoveLocalData());
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -14,7 +14,7 @@ public class Config {
 
     private final String version;
     private final List<Plugin> plugins;
-    private final List<Recipe> recipes;
+    private final Recipe recipe;
     private final URL jenkinsUpdateCenter;
     private final URL jenkinsPluginVersions;
     private final URL pluginHealthScore;
@@ -41,7 +41,7 @@ public class Config {
             Long githubAppSourceInstallationId,
             Long githubAppTargetInstallationId,
             List<Plugin> plugins,
-            List<Recipe> recipes,
+            Recipe recipe,
             URL jenkinsUpdateCenter,
             URL jenkinsPluginVersions,
             URL pluginHealthScore,
@@ -62,7 +62,7 @@ public class Config {
         this.githubAppSourceInstallationId = githubAppSourceInstallationId;
         this.githubAppTargetInstallationId = githubAppTargetInstallationId;
         this.plugins = plugins;
-        this.recipes = recipes;
+        this.recipe = recipe;
         this.jenkinsUpdateCenter = jenkinsUpdateCenter;
         this.jenkinsPluginVersions = jenkinsPluginVersions;
         this.pluginHealthScore = pluginHealthScore;
@@ -103,8 +103,8 @@ public class Config {
         return plugins;
     }
 
-    public List<Recipe> getRecipes() {
-        return recipes;
+    public Recipe getRecipe() {
+        return recipe;
     }
 
     /**
@@ -112,7 +112,7 @@ public class Config {
      * @return True if only fetching metadata
      */
     public boolean isFetchMetadataOnly() {
-        return recipes.size() == 1 && recipes.get(0).getName().equals(Settings.FETCH_METADATA_RECIPE.getName());
+        return recipe.getName().equals(Settings.FETCH_METADATA_RECIPE.getName());
     }
 
     public URL getJenkinsUpdateCenter() {
@@ -186,7 +186,7 @@ public class Config {
         private Long githubAppSourceInstallationId;
         private Long githubAppTargetInstallationId;
         private List<Plugin> plugins;
-        private List<Recipe> recipes;
+        private Recipe recipe;
         private URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
         private URL jenkinsPluginVersions = Settings.DEFAULT_PLUGIN_VERSIONS;
         private URL pluginStatsInstallations = Settings.DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL;
@@ -232,8 +232,8 @@ public class Config {
             return this;
         }
 
-        public Builder withRecipes(List<Recipe> recipes) {
-            this.recipes = recipes;
+        public Builder withRecipe(Recipe recipe) {
+            this.recipe = recipe;
             return this;
         }
 
@@ -327,7 +327,7 @@ public class Config {
                     githubAppSourceInstallationId,
                     githubAppTargetInstallationId,
                     plugins,
-                    recipes,
+                    recipe,
                     jenkinsUpdateCenter,
                     jenkinsPluginVersions,
                     pluginHealthScore,

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -507,6 +507,7 @@ public class GHService {
                         .setMode(ResetCommand.ResetType.HARD)
                         .setRef("origin/" + defaultBranch)
                         .call();
+                git.clean().setCleanDirectories(true).setDryRun(false).call();
                 Ref ref = git.checkout()
                         .setCreateBranch(false)
                         .setName(defaultBranch)
@@ -571,7 +572,7 @@ public class GHService {
         }
         try (Git git = Git.open(plugin.getLocalRepository().toFile())) {
             git.getRepository().scanForRepoChanges();
-            String commitMessage = TemplateUtils.renderCommitMessage(plugin, config.getRecipes());
+            String commitMessage = TemplateUtils.renderCommitMessage(plugin, config.getRecipe());
             LOG.debug("Commit message: {}", commitMessage);
             Status status = git.status().call();
             if (status.hasUncommittedChanges()) {
@@ -702,8 +703,8 @@ public class GHService {
         refreshToken(config.getGithubAppTargetInstallationId());
 
         // Renders parts and log then even if dry-run
-        String prTitle = TemplateUtils.renderPullRequestTitle(plugin, config.getRecipes());
-        String prBody = TemplateUtils.renderPullRequestBody(plugin, config.getRecipes());
+        String prTitle = TemplateUtils.renderPullRequestTitle(plugin, config.getRecipe());
+        String prBody = TemplateUtils.renderPullRequestBody(plugin, config.getRecipe());
         LOG.debug("Pull request title: {}", prTitle);
         LOG.debug("Pull request body: {}", prBody);
         LOG.debug("Draft mode: {}", config.isDraft());

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -11,8 +11,6 @@ import io.jenkins.tools.pluginmodernizer.core.model.PluginProcessingException;
 import io.jenkins.tools.pluginmodernizer.core.utils.PluginService;
 import jakarta.inject.Inject;
 import java.util.List;
-import java.util.stream.Collectors;
-import org.openrewrite.Recipe;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,8 +52,7 @@ public class PluginModernizer {
 
         // Debug config
         LOG.debug("Plugins: {}", config.getPlugins());
-        LOG.debug(
-                "Recipes: {}", config.getRecipes().stream().map(Recipe::getName).collect(Collectors.joining(", ")));
+        LOG.debug("Recipe: {}", config.getRecipe().getName());
         LOG.debug("GitHub owner: {}", config.getGithubOwner());
         LOG.debug("Update Center Url: {}", config.getJenkinsUpdateCenter());
         LOG.debug("Plugin versions Url: {}", config.getJenkinsPluginVersions());
@@ -340,6 +337,13 @@ public class PluginModernizer {
                     else {
                         LOG.info("Pull request was open on "
                                 + plugin.getRemoteRepository(this.ghService).getHtmlUrl());
+
+                        // Display changes depending on the recipe
+                        if (config.getRecipe()
+                                .getName()
+                                .equals("io.jenkins.tools.pluginmodernizer.UpgradeBomVersion")) {
+                            LOG.info("New BOM version: {}", plugin.getMetadata().getBomVersion());
+                        }
                     }
                 }
             }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -6,7 +6,6 @@ import gg.jte.TemplateOutput;
 import gg.jte.output.StringOutput;
 import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
-import java.util.List;
 import java.util.Map;
 import org.openrewrite.Recipe;
 import org.slf4j.Logger;
@@ -27,31 +26,31 @@ public class TemplateUtils {
     /**
      * Render the pull request body
      * @param plugin Plugin to modernize
-     * @param recipes List of recipes to apply
+     * @param recipe Recipe to apply
      * @return The rendered pull request body
      */
-    public static String renderPullRequestBody(Plugin plugin, List<Recipe> recipes) {
-        return renderTemplate("pr-body.jte", Map.of("plugin", plugin, "recipes", recipes));
+    public static String renderPullRequestBody(Plugin plugin, Recipe recipe) {
+        return renderTemplate("pr-body.jte", Map.of("plugin", plugin, "recipe", recipe));
     }
 
     /**
      * Render the commit message
      * @param plugin Plugin to modernize
-     * @param recipes List of recipes to apply
+     * @param recipe Recipe to apply
      * @return The rendered commit message
      */
-    public static String renderCommitMessage(Plugin plugin, List<Recipe> recipes) {
-        return renderTemplate("commit.jte", Map.of("plugin", plugin, "recipes", recipes));
+    public static String renderCommitMessage(Plugin plugin, Recipe recipe) {
+        return renderTemplate("commit.jte", Map.of("plugin", plugin, "recipe", recipe));
     }
 
     /**
      * Render the pull request title
      * @param plugin Plugin to modernize
-     * @param recipes List of recipes to apply
+     * @param recipe Recipe to apply
      * @return The rendered pull request title
      */
-    public static String renderPullRequestTitle(Plugin plugin, List<Recipe> recipes) {
-        return renderTemplate("pr-title.jte", Map.of("plugin", plugin, "recipes", recipes));
+    public static String renderPullRequestTitle(Plugin plugin, Recipe recipe) {
+        return renderTemplate("pr-title.jte", Map.of("plugin", plugin, "recipe", recipe));
     }
 
     /**

--- a/plugin-modernizer-core/src/main/jte/commit.jte
+++ b/plugin-modernizer-core/src/main/jte/commit.jte
@@ -1,7 +1,6 @@
 @import io.jenkins.tools.pluginmodernizer.core.model.Plugin
 @import org.openrewrite.Recipe
-@import java.util.List
 @import static io.jenkins.tools.pluginmodernizer.core.config.Settings.RECIPE_FQDN_PREFIX
 @param Plugin plugin
-@param List<Recipe> recipes
-Applied recipes ${recipes.stream().map(r -> r.getName().replaceAll(RECIPE_FQDN_PREFIX + ".", "")).collect(java.util.stream.Collectors.joining(", "))}
+@param Recipe recipe
+Applied recipe ${recipe.getName().replaceAll(RECIPE_FQDN_PREFIX + ".", "")}

--- a/plugin-modernizer-core/src/main/jte/pr-body.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body.jte
@@ -1,15 +1,12 @@
 @import io.jenkins.tools.pluginmodernizer.core.model.Plugin
 @import org.openrewrite.Recipe
-@import java.util.List
 @param Plugin plugin
-@param List<Recipe> recipes
+@param Recipe recipe
 Hello `${plugin.getName()}` developers!
 
 This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool) tool. The tool has applied the following recipes to modernize the plugin:
-@for(var recipe : recipes)
 <details>
     <summary>${recipe.getDisplayName()}</summary>
     <p><em>${recipe.getName()}</em></p>
     <blockquote>${recipe.getDescription()}</blockquote>
 </details>
-@endfor

--- a/plugin-modernizer-core/src/main/jte/pr-title.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title.jte
@@ -1,8 +1,6 @@
-@import io.jenkins.tools.pluginmodernizer.core.config.Settings
 @import io.jenkins.tools.pluginmodernizer.core.model.Plugin
 @import org.openrewrite.Recipe
-@import java.util.List
 @import static io.jenkins.tools.pluginmodernizer.core.config.Settings.RECIPE_FQDN_PREFIX
 @param Plugin plugin
-@param List<Recipe> recipes
-Applied recipes ${recipes.stream().map(r -> r.getName().replaceAll(RECIPE_FQDN_PREFIX + ".", "")).collect(java.util.stream.Collectors.joining(", "))}
+@param Recipe recipe
+Applied recipes ${recipe.getName().replaceAll(RECIPE_FQDN_PREFIX + ".", "")}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
@@ -10,7 +10,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -25,9 +24,8 @@ public class ConfigTest {
         String githubOwner = "test-owner";
         List<Plugin> plugins =
                 Stream.of("plugin1", "plugin2").map(Plugin::build).toList();
-        List<Recipe> recipes = Arrays.asList(Mockito.mock(Recipe.class), Mockito.mock(Recipe.class));
-        Mockito.doReturn("recipe1").when(recipes.get(0)).getName();
-        Mockito.doReturn("recipe2").when(recipes.get(1)).getName();
+        Recipe recipe = Mockito.mock(Recipe.class);
+        Mockito.doReturn("recipe1").when(recipe).getName();
         URL jenkinsUpdateCenter = new URL("https://updates.jenkins.io/current/update-center.actual.json");
         Path cachePath = Paths.get("/path/to/cache");
         Path mavenHome = Paths.get("/path/to/maven");
@@ -37,7 +35,7 @@ public class ConfigTest {
                 .withVersion(version)
                 .withGitHubOwner(githubOwner)
                 .withPlugins(plugins)
-                .withRecipes(recipes)
+                .withRecipe(recipe)
                 .withJenkinsUpdateCenter(jenkinsUpdateCenter)
                 .withCachePath(cachePath)
                 .withMavenHome(mavenHome)
@@ -52,7 +50,7 @@ public class ConfigTest {
         assertEquals(version, config.getVersion());
         assertEquals(githubOwner, config.getGithubOwner());
         assertEquals(plugins, config.getPlugins());
-        assertEquals(recipes, config.getRecipes());
+        assertEquals(recipe, config.getRecipe());
         assertEquals(jenkinsUpdateCenter, config.getJenkinsUpdateCenter());
         assertEquals(cachePath, config.getCachePath());
         assertEquals(mavenHome, config.getMavenHome());
@@ -71,7 +69,7 @@ public class ConfigTest {
 
         assertNull(config.getVersion());
         assertNull(config.getPlugins());
-        assertNull(config.getRecipes());
+        assertNull(config.getRecipe());
         assertEquals(Settings.DEFAULT_UPDATE_CENTER_URL, config.getJenkinsUpdateCenter());
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());
         assertEquals(Settings.DEFAULT_MAVEN_HOME, config.getMavenHome());
@@ -95,7 +93,7 @@ public class ConfigTest {
 
         assertEquals(version, config.getVersion());
         assertEquals(plugins, config.getPlugins());
-        assertNull(config.getRecipes());
+        assertNull(config.getRecipe());
         assertEquals(Settings.DEFAULT_UPDATE_CENTER_URL, config.getJenkinsUpdateCenter());
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());
         assertEquals(Settings.DEFAULT_MAVEN_HOME, config.getMavenHome());
@@ -112,7 +110,7 @@ public class ConfigTest {
 
         assertNull(config.getVersion());
         assertNull(config.getPlugins());
-        assertNull(config.getRecipes());
+        assertNull(config.getRecipe());
         assertEquals(Settings.DEFAULT_UPDATE_CENTER_URL, config.getJenkinsUpdateCenter());
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());
         assertEquals(Settings.DEFAULT_MAVEN_HOME, config.getMavenHome());

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
@@ -38,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openrewrite.Recipe;
 
 @ExtendWith({MockitoExtension.class})
 public class GHServiceTest {
@@ -610,11 +611,14 @@ public class GHServiceTest {
     public void shouldOpenPullRequest() throws Exception {
 
         // Mocks
+        Recipe recipe = Mockito.mock(Recipe.class);
         GHRepository repository = Mockito.mock(GHRepository.class);
         GHPullRequest pr = Mockito.mock(GHPullRequest.class);
         GHPullRequestQueryBuilder prQuery = Mockito.mock(GHPullRequestQueryBuilder.class);
         PagedIterable<?> prQueryList = Mockito.mock(PagedIterable.class);
 
+        doReturn(recipe).when(config).getRecipe();
+        doReturn("recipe1").when(recipe).getName();
         doReturn(null).when(config).getGithubAppTargetInstallationId();
         doReturn(false).when(config).isDraft();
         doReturn(true).when(plugin).hasChangesPushed();
@@ -638,11 +642,14 @@ public class GHServiceTest {
     public void shouldOpenDraftPullRequest() throws Exception {
 
         // Mocks
+        Recipe recipe = Mockito.mock(Recipe.class);
         GHRepository repository = Mockito.mock(GHRepository.class);
         GHPullRequest pr = Mockito.mock(GHPullRequest.class);
         GHPullRequestQueryBuilder prQuery = Mockito.mock(GHPullRequestQueryBuilder.class);
         PagedIterable<?> prQueryList = Mockito.mock(PagedIterable.class);
 
+        doReturn(recipe).when(config).getRecipe();
+        doReturn("recipe1").when(recipe).getName();
         doReturn(null).when(config).getGithubAppTargetInstallationId();
         doReturn(true).when(config).isDraft();
         doReturn(true).when(plugin).hasChangesPushed();


### PR DESCRIPTION
This simplify at lot and will allow to work on new feature like user friendly PR title or discard https://github.com/jenkins-infra/plugin-modernizer-tool/issues/370

This PR also fix one bug when a repo was containing unversionned files (like a rewrite.yml) causing build issue.

A `git clean` is now done after a `git --reset hard`

I will also take a not about the collection of the metadata after the modernization. This should probably done before opening the PR (and not after). Or maybe we can just patch the PR title