### PR TITLE
Ensure to match binary name

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -9,7 +9,8 @@ import picocli.CommandLine;
 import picocli.CommandLine.Command;
 
 @Command(
-        name = "Plugin Modernizer",
+        name = "plugin-modernizer",
+        description = "Plugin Modernizer. A tool to modernize Jenkins plugins",
         synopsisSubcommandLabel = "COMMAND",
         subcommands = {
             ValidateCommand.class,


### PR DESCRIPTION
When distributing to homebrew the cli is called `plugin-modernizer`

The name must match because I would like to setup the auto-completion when installed via homebrew. This will be an other PR

to test 
```
java -cp plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar picocli.AutoComplete io.jenkins.tools.pluginmodernizer.cli.Main
source plugin-modernizer_completion
```

![completion](https://github.com/user-attachments/assets/5b7d6f87-45a6-4e54-974a-0fb9959d359a)

![completion2](https://github.com/user-attachments/assets/4d622112-b26d-4eaa-8313-3af50360dc85)

Not sure yet how this will need to be packaged

Probably this also need to be tweaker to include the list of recipe when using the `--recipe`. Because right now it doesn't work out of the box