### PR TITLE
Handle push error

### DIFF
--- a/plugin-modernizer-core/src/main/jte/pr-title-UpgradeNextMajorParentVersion.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-UpgradeNextMajorParentVersion.jte
@@ -1,0 +1,5 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import org.openrewrite.Recipe
+@param Plugin plugin
+@param Recipe recipe
+Require ${plugin.getMetadata().getJenkinsVersion()} and Java 17

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -112,4 +112,25 @@ public class TemplateUtilsTest {
         // Assert
         assertEquals("Require 2.462.3", result);
     }
+
+    @Test
+    public void testFriendlyPrTitleUpgradeNextMajorParentVersion() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata metadata = mock(PluginMetadata.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn(metadata).when(plugin).getMetadata();
+        doReturn("2.479.1").when(metadata).getJenkinsVersion();
+        doReturn("io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
+
+        // Assert
+        assertEquals("Require 2.479.1 and Java 17", result);
+    }
 }


### PR DESCRIPTION
And add todo to change email address.

Instead of getting the user primary email (and grant additional) permission we should always use the nonreply address.

I will test this in an other PR

![test](https://github.com/user-attachments/assets/261219c5-4aa2-4407-af64-07058dc4a637)
