### PR TITLE
Optimize far jar

### DIFF
--- a/plugin-modernizer-cli/pom.xml
+++ b/plugin-modernizer-cli/pom.xml
@@ -27,6 +27,23 @@
       <groupId>io.jenkins.plugin-modernizer</groupId>
       <artifactId>plugin-modernizer-core</artifactId>
       <version>${changelist}</version>
+      <!-- We never use OpenRewrite directly from CLI because of maven invoker which will download the core module and it's dependencies -->
+      <exclusions>
+        <exclusion>
+          <groupId>org.openrewrite</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- We only use the Recipe class and Xml.Tag from the CLI -->
+    <!-- TODO : We should be able to break this dependencies by introducing our own interfaces -->
+    <dependency>
+      <groupId>org.openrewrite</groupId>
+      <artifactId>rewrite-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.openrewrite</groupId>
+      <artifactId>rewrite-xml</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -133,6 +133,12 @@
     <dependency>
       <groupId>org.openrewrite.recipe</groupId>
       <artifactId>rewrite-testing-frameworks</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.testcontainers</groupId>
+          <artifactId>testcontainers</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -139,11 +139,6 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>uk.org.webcompere</groupId>
-      <artifactId>system-stubs-jupiter</artifactId>
-      <version>2.1.7</version>
-    </dependency>
-    <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-impl</artifactId>
       <scope>runtime</scope>
@@ -157,6 +152,12 @@
     <dependency>
       <groupId>org.openrewrite</groupId>
       <artifactId>rewrite-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>uk.org.webcompere</groupId>
+      <artifactId>system-stubs-jupiter</artifactId>
+      <version>2.1.7</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -264,10 +264,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -280,6 +276,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This is partial implementation of https://github.com/jenkins-infra/plugin-modernizer-tool/issues/435

This reduce from 180Mib to 50Mib

I'm sure we can easily reduce it to 50% or much more

I identifiy some dependency we must break 

CLI --> openrewrite-core (The `Recipe` class) Like here https://github.com/jenkins-infra/plugin-modernizer-tool/blob/main/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/converter/RecipeConverter.java#L4
CLI --> openrewrite-xml (The `org.openrewrite.xml.tree.Xml` class) like here https://github.com/jenkins-infra/plugin-modernizer-tool/blob/main/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFlag.java#L8