### PR TITLE
Bootstrap integration tests

### DIFF
--- a/plugin-modernizer-cli/pom-it.xml
+++ b/plugin-modernizer-cli/pom-it.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>io.jenkins.plugin-modernizer</groupId>
+  <artifactId>plugin-modernizer-it</artifactId>
+  <version>${changelist}</version>
+  <properties>
+    <changelist>999999-SNAPSHOT</changelist>
+    <maven.test.skip>true</maven.test.skip>
+    <skipTests>true</skipTests> <!-- No test for this pom, only exec plugin -->
+    <exec.executable>java</exec.executable>
+    <exec.args>-jar target/jenkins-plugin-modernizer-${project.version}.jar ${test.cliArgs}</exec.args>
+    <test.cliArgs>--version</test.cliArgs>
+  </properties>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>exec</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+                <executable>${exec.executable}</executable>
+                <arguments>
+                    ${exec.args}
+                </arguments>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/plugin-modernizer-cli/pom.xml
+++ b/plugin-modernizer-cli/pom.xml
@@ -40,6 +40,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-invoker</artifactId>
+      <version>3.3.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
@@ -83,11 +88,36 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <excludes>
+            <exclude>**/*ITCase.java</exclude>
+          </excludes>
           <environmentVariables>
             <MAVEN_HOME>${project.build.directory}/apache-maven-${maven.version}</MAVEN_HOME>
             <M2_HOME>${project.build.directory}/apache-maven-${maven.version}</M2_HOME>
           </environmentVariables>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <useModulePath>false</useModulePath>
+              <includes>
+                <include>**/*ITCase.java</include>
+              </includes>
+              <environmentVariables>
+                <MAVEN_HOME>${project.build.directory}/apache-maven-${maven.version}</MAVEN_HOME>
+              </environmentVariables>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -1,0 +1,130 @@
+package io.jenkins.tools.pluginmodernizer.cli;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Properties;
+import org.apache.maven.shared.invoker.DefaultInvocationRequest;
+import org.apache.maven.shared.invoker.DefaultInvoker;
+import org.apache.maven.shared.invoker.InvocationRequest;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.Invoker;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for the command line interface
+ */
+public class CommandLineITCase {
+
+    /**
+     * Logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(CommandLineITCase.class);
+
+    @TempDir
+    private Path outputPath;
+
+    @Test
+    public void testVersion() throws Exception {
+        LOG.info("Running testVersion");
+        Invoker invoker = buildInvoker();
+        InvocationRequest request = buildRequest("--version");
+        InvocationResult result = invoker.execute(request);
+        assertAll(
+                () -> assertEquals(0, result.getExitCode()),
+                () -> assertTrue(Files.readAllLines(outputPath.resolve("stdout.txt")).stream()
+                        .anyMatch(line -> line.matches("plugin modernizer (.*) (.*)"))));
+    }
+
+    @Test
+    public void testListRecipes() throws Exception {
+        LOG.info("Running testListRecipes");
+        Invoker invoker = buildInvoker();
+        InvocationRequest request = buildRequest("recipes");
+        InvocationResult result = invoker.execute(request);
+        assertAll(
+                () -> assertEquals(0, result.getExitCode()),
+                () -> assertTrue(Files.readAllLines(outputPath.resolve("stdout.txt")).stream()
+                        .anyMatch(
+                                line -> line.matches(".*FetchMetadata - Extracts metadata from a Jenkins plugin.*"))));
+    }
+
+    /**
+     * Build the invoker
+     * @return the invoker
+     */
+    private Invoker buildInvoker() {
+        Path javaHome = Path.of(System.getenv("JAVA_HOME"));
+        assertNotNull(javaHome, "JAVA_HOME is not set");
+        Path mavenHome = Path.of(System.getenv("MAVEN_HOME"));
+        assertNotNull(mavenHome, "MAVEN_HOME is not set");
+        Invoker invoker = new DefaultInvoker();
+        invoker.setMavenHome(Path.of(System.getenv("MAVEN_HOME")).toFile());
+        invoker.setMavenHome(mavenHome.toFile());
+        return invoker;
+    }
+
+    /**
+     * Build the request
+     * @return the request
+     */
+    private InvocationRequest buildRequest(String args) {
+        Path javaHome = Path.of(System.getenv("JAVA_HOME"));
+        assertNotNull(javaHome, "JAVA_HOME is not set");
+
+        InvocationRequest request = new DefaultInvocationRequest();
+        request.setPomFile(new File("pom-it.xml"));
+        request.addArg("verify");
+
+        // Add properties
+        Properties properties = new Properties();
+        String changeList = System.getProperty("set.changelist");
+        if (changeList != null) {
+            properties.put("set.changelist", "true");
+        }
+        properties.put("exec.executable", javaHome.resolve("bin/java").toString());
+        properties.put("test.cliArgs", args);
+        request.setProperties(properties);
+
+        // Other options
+        request.setBatchMode(true);
+        request.setNoTransferProgress(true);
+        request.setJavaHome(javaHome.toFile());
+        request.setOutputHandler(line -> {
+            try {
+                Files.write(
+                        outputPath.resolve("stdout.txt"),
+                        (line + System.lineSeparator()).getBytes(),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND);
+            } catch (Exception e) {
+                LOG.error("Error writing to stdout", e);
+                throw new RuntimeException(e);
+            }
+            LOG.info(line);
+        });
+        request.setErrorHandler(line -> {
+            try {
+                Files.write(
+                        outputPath.resolve("stderr.txt"),
+                        (line + System.lineSeparator()).getBytes(),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND);
+            } catch (Exception e) {
+                LOG.error("Error writing to stderr", e);
+                throw new RuntimeException(e);
+            }
+            LOG.error(line);
+        });
+        return request;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,8 @@
     <jakarta.inject.version>2.0.1</jakarta.inject.version>
     <jwt.version>0.12.6</jwt.version>
     <bouncycastle.version>1.79</bouncycastle.version>
+    <maven.surefire.version>3.5.2</maven.surefire.version>
+    <maven.failsafe.version>3.5.2</maven.failsafe.version>
   </properties>
 
   <dependencyManagement>
@@ -307,6 +309,16 @@
   <build>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven.surefire.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven.failsafe.version}</version>
+        </plugin>
         <plugin>
           <groupId>org.openrewrite.maven</groupId>
           <artifactId>rewrite-maven-plugin</artifactId>


### PR DESCRIPTION
with `--version and `recipes` subcommand

We need to optimize stdout to capture only interesting output (not blocking can be improved later)

Perhaps by a dedicated logback config ?

![Screenshot from 2024-12-14 11-17-57](https://github.com/user-attachments/assets/1b9d3bcc-98e5-45c5-8397-08e13bb44b5d)
