### PR TITLE
Split global options

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,13 +94,6 @@ From there you need to save both ID of installation (found on URL)
 
 `https://github.com/organizations/<org>/settings/installations/<installation ID>`
 
-To activate app authentication, just set the following CLI argument
-
-`--github-app-id <app-id>` or `GH_APP_ID` environment variable
-`--github-app-source-installation-id <installation-id>` or `GH_APP_SOURCE_INSTALLATION_ID` environment variable
-`--github-app-target-installation-id <installation-id>` or `GH_APP_TARGET_INSTALLATION_ID` environment variable
-`--github-app-private-key <path-to-private-key>` or `GH_APP_PRIVATE_KEY` environment variable
-
 # Subcommands
 
 - `validate`: Validate the configuration and environment variables (work in progress)
@@ -109,36 +102,63 @@ To activate app authentication, just set the following CLI argument
 - `build-metadata`: Collect metadata for the given plugin and have them on the local cache
 - `recipes`: List available recipes
 
-## CLI Options
-- `--plugins` or `-p`: (optional) Name(s) of plugin directory cloned inside the `test-plugins` directory.
+## Global option
 
-- `--recipe` or `-r`: (required) Name of recipe to apply to the plugins.
+- `--debug` or `-d`: (optional) Enables debug mode. Defaults to false.
 
-- `--plugin-file` or `-f`: (optional) Path to the text file that contains a list of plugins. (see example [plugin file](docs/example-plugins.txt))
-
-- `--skip-push` (optional) Skips pushing changes to the remote repository. Always enabled in dry-run mode.
-
-- `--skip-pull-request` (optional) Skips creating pull requests in the remote repository. Always enabled in dry-run mode.
-
-- `--clean-local-data` (optional) Deletes the local plugin directory before and after the process is completed.
-
-- `--clean-forks` (optional) Remove forked repositories before and after the modernization process. Might cause data loss if you have other changes pushed on those forks. Forks with open pull request targeting original repo are not removed to prevent closing unmerged pull requests.
-
-- `--export-datatables` or `-e`: (optional) Creates a report or summary of the changes made through OpenRewrite in CSV format. The report will be generated at `target/rewrite/datatables` inside the plugin directory.
-
-- `--debug` or `-d`: (optional) Enables debug mode.
-
-- `--jenkins-update-center`: (optional) Sets main update center; will override JENKINS_UC environment variable. If not set via CLI option or environment variable, will default to url in [properties file](plugin-modernizer-core/src/main/resources/urls.properties)
-
-- `--jenkins-plugins-stats-installations-url` (optional) Set the URL for the Jenkins Plugins Stats installations API. If not set via CLI option or environment variable, will default to url in [properties file](plugin-modernizer-core/src/main/resources/urls.properties)
 
 - `--cache-path` or `-c`: (optional) Custom path to the cache directory. Defaults to `${user.home}/.cache/jenkins-plugin-modernizer-cli`.
 
-- `--github-owner` or `-g`: (optional) GitHub owner for forked repositories. Can also be set via the environment variable `GH_OWNER` or `GITHUB_OWNER`.
 
 - `--maven-home` or `-m`: (optional) Path to the Maven home directory. Required if both `MAVEN_HOME` and `M2_HOME` environment variables are not set. The minimum required version is 3.9.7.
 
+
+- `--clean-local-data` (optional) Deletes the local plugin directory before running the tool.
+
+
 - `--version` or `-v`: (optional) Displays the version of the Plugin Modernizer tool.
+
+
+- `--help` or `-h`: (optional) Displays the help
+
+## GitHub options
+
+- `--github-owner` or `-g`: (Mandatory or optional if using GitHub app authentication) GitHub owner for forked repositories. Can also be set via the environment variable `GH_OWNER` or `GITHUB_OWNER`. Default to owner of the `GH_TOKEN`.
+
+
+- `--github-app-id <app-id>`: (optional) The GitHub application if using app authentication. Defaults to `GH_APP_ID` environment variable if set.
+
+
+- `--github-app-source-installation-id <installation-id>`: (optional) The GitHub app installation id for forked repositories. Defaults `GH_APP_SOURCE_INSTALLATION_ID` environment variable if set.
+
+
+- `--github-app-target-installation-id <installation-id>`: (optional) The GitHub app installation id for repositories. Defaults `GH_APP_TARGET_INSTALLATION_ID` environment variable if set.- `--github-app-private-key <path-to-private-key>`: (optional)  or `GH_APP_PRIVATE_KEY` environment variable
+
+# Run option
+
+- `--plugins` or `-p`: (optional) Name(s) of plugin directory cloned inside the `test-plugins` directory.
+
+
+- `--plugin-file` or `-f`: (optional) Path to the text file that contains a list of plugins. (see example [plugin file](docs/example-plugins.txt))
+
+
+- `--recipe` or `-r`: (required) Name of recipe to apply to the plugins.
+
+
+- `--clean-forks` (optional) Remove forked repositories before and after the modernization process. Might cause data loss if you have other changes pushed on those forks. Forks with open pull request targeting original repo are not removed to prevent closing unmerged pull requests.
+
+
+- `--jenkins-update-center`: (optional) Sets main update center; will override JENKINS_UC environment variable. If not set via CLI option or environment variable, will default https://updates.jenkins.io/current/update-center.actual.json
+
+- `--jenkins-plugin-info`: (optional) Set the URL for the Jenkins Plugin Info API. If not set via CLI option or environment variable, will default to https://updates.jenkins.io/current/plugin-versions.json
+
+- `--jenkins-plugins-stats-installations-url` (optional) Set the URL for the Jenkins Plugins Stats installations API. If not set via CLI option or environment variable, will default to url in [properties file](plugin-modernizer-core/src/main/resources/urls.properties)
+
+
+- `--plugin-health-score-url` (optional) Set the URL for the Plugin Health Score API. If not set via CLI option or environment variable, will default to https://plugin-health.jenkins.io/api/scores
+
+
+- `--github-api-url` (optional) Set the URL for the GitHub API. If not set via CLI option or environment variable, will default to `https://api.github.com`. Automatically set if `GH_HOST` environment variable is set.
 
 ## Plugin Input Format
 

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -1,10 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.cli;
 
-import io.jenkins.tools.pluginmodernizer.cli.command.BuildMetadataCommand;
-import io.jenkins.tools.pluginmodernizer.cli.command.DryRunCommand;
-import io.jenkins.tools.pluginmodernizer.cli.command.ListRecipesCommand;
-import io.jenkins.tools.pluginmodernizer.cli.command.RunCommand;
-import io.jenkins.tools.pluginmodernizer.cli.command.ValidateCommand;
+import io.jenkins.tools.pluginmodernizer.cli.command.*;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -19,6 +15,7 @@ import picocli.CommandLine.Command;
             BuildMetadataCommand.class,
             DryRunCommand.class,
             RunCommand.class,
+            CleanupCommand.class
         },
         mixinStandardHelpOptions = true,
         versionProvider = VersionProvider.class)

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
@@ -1,13 +1,11 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
-import com.google.inject.Guice;
+import io.jenkins.tools.pluginmodernizer.cli.options.EnvOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.PluginOptions;
-import io.jenkins.tools.pluginmodernizer.core.GuiceModule;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
-import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -35,17 +33,23 @@ public class BuildMetadataCommand implements ICommand {
     @CommandLine.Mixin
     private GlobalOptions options;
 
+    /**
+     * Environment options
+     */
+    @CommandLine.Mixin
+    private EnvOptions envOptions;
+
     @Override
     public Config setup(Config.Builder builder) {
-        return builder.withPlugins(pluginOptions != null ? pluginOptions.getEffectivePlugins() : new ArrayList<>())
-                .withRecipe(Settings.FETCH_METADATA_RECIPE)
-                .build();
+        options.config(builder);
+        envOptions.config(builder);
+        pluginOptions.config(builder);
+        return builder.withRecipe(Settings.FETCH_METADATA_RECIPE).build();
     }
 
     @Override
     public Integer call() throws Exception {
-        PluginModernizer modernizer = Guice.createInjector(new GuiceModule(setup(options.getBuilderForOptions())))
-                .getInstance(PluginModernizer.class);
+        PluginModernizer modernizer = getModernizer();
         modernizer.start();
         return 0;
     }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CleanupCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CleanupCommand.java
@@ -1,0 +1,50 @@
+package io.jenkins.tools.pluginmodernizer.cli.command;
+
+import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+/**
+ * Cleanup command
+ */
+@CommandLine.Command(name = "cleanup", description = "Cleanup local cache data")
+public class CleanupCommand implements ICommand {
+
+    /**
+     * Logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(CleanupCommand.class);
+
+    /**
+     * Global options for all commands
+     */
+    @CommandLine.Mixin
+    private GlobalOptions options;
+
+    @CommandLine.Option(
+            names = {"--dry-run"},
+            description = "Dry run. Do not remove anything.")
+    private boolean dryRun;
+
+    @Override
+    public Config setup(Config.Builder builder) {
+        options.config(builder);
+        builder.withDryRun(dryRun);
+        return builder.build();
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        PluginModernizer modernizer = getModernizer();
+        if (modernizer.isDryRun()) {
+            LOG.info("Would remove path: {}", modernizer.getCachePath());
+        } else {
+            modernizer.cleanCache();
+            LOG.info("Removed path: {}", modernizer.getCachePath());
+        }
+        return 0;
+    }
+}

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
@@ -1,15 +1,12 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
-import com.google.inject.Guice;
 import io.jenkins.tools.pluginmodernizer.cli.converter.RecipeConverter;
 import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.PluginOptions;
-import io.jenkins.tools.pluginmodernizer.core.GuiceModule;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
 import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
-import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -49,19 +46,15 @@ public class DryRunCommand implements ICommand {
 
     @Override
     public Config setup(Config.Builder builder) {
-        return builder.withPlugins(pluginOptions != null ? pluginOptions.getEffectivePlugins() : new ArrayList<>())
-                .withDryRun(true)
-                .withSkipPush(true)
-                .withSkipPush(true)
-                .withRecipe(recipe)
-                .build();
+        options.config(builder);
+        pluginOptions.config(builder);
+        return builder.withDryRun(true).withRecipe(recipe).build();
     }
 
     @Override
     public Integer call() throws Exception {
         LOG.info("Run Plugin Modernizer in dry-run mode");
-        PluginModernizer modernizer = Guice.createInjector(new GuiceModule(setup(options.getBuilderForOptions())))
-                .getInstance(PluginModernizer.class);
+        PluginModernizer modernizer = getModernizer();
         try {
             modernizer.validate();
         } catch (ModernizerException e) {

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ICommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ICommand.java
@@ -1,6 +1,9 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
+import com.google.inject.Guice;
+import io.jenkins.tools.pluginmodernizer.core.GuiceModule;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
 import java.util.concurrent.Callable;
 
 /**
@@ -15,5 +18,13 @@ public interface ICommand extends Callable<Integer> {
      */
     default Config setup(Config.Builder builder) {
         return builder.build();
+    }
+
+    /**
+     * Get the modernizer instance
+     * @return the modernizer instance
+     */
+    default PluginModernizer getModernizer() {
+        return Guice.createInjector(new GuiceModule(setup(Config.builder()))).getInstance(PluginModernizer.class);
     }
 }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ListRecipesCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ListRecipesCommand.java
@@ -1,9 +1,8 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
 import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
-import io.jenkins.tools.pluginmodernizer.core.config.Settings;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
 import picocli.CommandLine;
 
 /**
@@ -12,20 +11,19 @@ import picocli.CommandLine;
 @CommandLine.Command(name = "recipes", description = "List recipes")
 public class ListRecipesCommand implements ICommand {
 
-    /**
-     * Logger
-     */
-    private static final Logger LOG = LoggerFactory.getLogger(ValidateCommand.class);
-
     @CommandLine.Mixin
     private GlobalOptions options;
 
     @Override
+    public Config setup(Config.Builder builder) {
+        options.config(builder);
+        return builder.build();
+    }
+
+    @Override
     public Integer call() throws Exception {
-        Settings.AVAILABLE_RECIPES.forEach(recipe -> LOG.info(
-                "{} - {}",
-                recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", ""),
-                recipe.getDescription()));
+        PluginModernizer modernizer = getModernizer();
+        modernizer.listRecipes();
         return 0;
     }
 }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
@@ -1,15 +1,14 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
-import com.google.inject.Guice;
 import io.jenkins.tools.pluginmodernizer.cli.converter.RecipeConverter;
+import io.jenkins.tools.pluginmodernizer.cli.options.EnvOptions;
+import io.jenkins.tools.pluginmodernizer.cli.options.GitHubOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.PluginOptions;
-import io.jenkins.tools.pluginmodernizer.core.GuiceModule;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
 import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
-import java.util.ArrayList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -41,25 +40,52 @@ public class RunCommand implements ICommand {
             converter = RecipeConverter.class)
     private Recipe recipe;
 
+    @CommandLine.Option(
+            names = {"--draft"},
+            description = "Open a draft pull request.")
+    public boolean draft;
+
+    @CommandLine.Option(
+            names = {"--clean-forks"},
+            description =
+                    "Remove forked repositories before and after the modernization process. Might cause data loss if you have other changes pushed on those forks. Forks with open pull request targeting original repo are not removed to prevent closing unmerged pull requests.")
+    public boolean removeForks;
+
+    /**
+     * Environment options
+     */
+    @CommandLine.Mixin
+    private EnvOptions envOptions;
+
     /**
      * Global options for all commands
      */
     @CommandLine.Mixin
     private GlobalOptions options;
 
+    /**
+     * GitHub options
+     */
+    @CommandLine.Mixin
+    private GitHubOptions githubOptions;
+
     @Override
     public Config setup(Config.Builder builder) {
-        return builder.withPlugins(pluginOptions != null ? pluginOptions.getEffectivePlugins() : new ArrayList<>())
-                .withDryRun(false)
+        options.config(builder);
+        envOptions.config(builder);
+        pluginOptions.config(builder);
+        githubOptions.config(builder);
+        return builder.withDryRun(false)
                 .withRecipe(recipe)
+                .withDraft(draft)
+                .withRemoveForks(removeForks)
                 .build();
     }
 
     @Override
     public Integer call() throws Exception {
         LOG.info("Run Plugin Modernizer");
-        PluginModernizer modernizer = Guice.createInjector(new GuiceModule(setup(options.getBuilderForOptions())))
-                .getInstance(PluginModernizer.class);
+        PluginModernizer modernizer = getModernizer();
         try {
             modernizer.validate();
         } catch (ModernizerException e) {

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/EnvOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/EnvOptions.java
@@ -1,0 +1,56 @@
+package io.jenkins.tools.pluginmodernizer.cli.options;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import java.net.URL;
+import picocli.CommandLine;
+
+/**
+ * Option for the tool environment configuration (like URLS, paths, etc)
+ */
+@CommandLine.Command(
+        synopsisHeading = "%nUsage:%n",
+        descriptionHeading = "%nDescription:%n",
+        parameterListHeading = "%nParameters:%n",
+        optionListHeading = "%nOptions:%n",
+        commandListHeading = "%nCommands:%n")
+public class EnvOptions implements IOption {
+
+    @CommandLine.Option(
+            names = "--jenkins-update-center",
+            description =
+                    "Sets main update center; will override JENKINS_UC environment variable. If not set via CLI option or environment variable, will use default update center url.")
+    public URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
+
+    @CommandLine.Option(
+            names = "--jenkins-plugin-info",
+            description =
+                    "Sets jenkins plugin version; will override JENKINS_PLUGIN_INFO environment variable. If not set via CLI option or environment variable, will use default plugin info")
+    public URL jenkinsPluginVersions = Settings.DEFAULT_PLUGIN_VERSIONS;
+
+    @CommandLine.Option(
+            names = "--plugin-health-score",
+            description =
+                    "Sets the plugin health score URL; will override JENKINS_PHS environment variable. If not set via CLI option or environment variable, will use default health score url.")
+    public URL pluginHealthScore = Settings.DEFAULT_HEALTH_SCORE_URL;
+
+    @CommandLine.Option(
+            names = "--jenkins-plugins-stats-installations-url",
+            description =
+                    "Sets the Jenkins stats top plugins URL; will override JENKINS_PLUGINS_STATS_INSTALLATIONS_URL environment variable. If not set via CLI option or environment variable, will use default Jenkins stats top plugins url.")
+    public URL jenkinsPluginsStatsInstallationsUrl = Settings.DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL;
+
+    @CommandLine.Option(
+            names = {"--github-api-url"},
+            description = "GitHub API URL. Default to https://api.github.com")
+    public URL githubApiUrl = Settings.GITHUB_API_URL;
+
+    @Override
+    public void config(Config.Builder builder) {
+        builder.withJenkinsUpdateCenter(jenkinsUpdateCenter)
+                .withJenkinsPluginVersions(jenkinsPluginVersions)
+                .withPluginHealthScore(pluginHealthScore)
+                .withPluginStatsInstallations(jenkinsPluginsStatsInstallationsUrl)
+                .withGithubApiUrl(githubApiUrl);
+    }
+}

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GitHubOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GitHubOptions.java
@@ -1,0 +1,51 @@
+package io.jenkins.tools.pluginmodernizer.cli.options;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import picocli.CommandLine;
+
+/**
+ * Option for GitHub integration
+ */
+@CommandLine.Command(
+        synopsisHeading = "%nUsage:%n",
+        descriptionHeading = "%nDescription:%n",
+        parameterListHeading = "%nParameters:%n",
+        optionListHeading = "%nOptions:%n",
+        commandListHeading = "%nCommands:%n")
+public class GitHubOptions implements IOption {
+
+    @CommandLine.Option(
+            names = {"-g", "--github-owner"},
+            description = "GitHub owner for forked repositories.")
+    private String githubOwner = Settings.GITHUB_OWNER;
+
+    @CommandLine.Option(
+            names = {"--github-app-id"},
+            description =
+                    "GitHub App ID. If set you will need to set GH_APP_CLIENT_ID, GH_APP_CLIENT_SECRET, GH_APP_PRIVATE_KEY_FILE as environment variables to use JWT authentication. The app installation must be done on the given github owner (personal or organization).")
+    public Long githubAppId;
+
+    @CommandLine.Option(
+            names = {"--github-app-source-installation-id"},
+            description =
+                    "GitHub App Installation ID for the source repositories. If set, the app installation must be done on the given github owner (personal or organization).")
+    public Long githubAppSourceInstallationId;
+
+    @CommandLine.Option(
+            names = {"--github-app-target-installation-id"},
+            description =
+                    "GitHub App Installation ID for the target repositories. If set, the app installation must be done on the given github owner (personal or organization).")
+    public Long githubAppTargetInstallationId;
+
+    /**
+     * Create a new config build for the global options
+     */
+    @Override
+    public void config(Config.Builder builder) {
+        builder.withGitHubOwner(githubOwner)
+                .withGitHubAppId(githubAppId)
+                .withGitHubAppSourceInstallationId(githubAppSourceInstallationId)
+                .withGitHubAppTargetInstallationId(githubAppTargetInstallationId);
+    }
+}

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
@@ -3,10 +3,8 @@ package io.jenkins.tools.pluginmodernizer.cli.options;
 import io.jenkins.tools.pluginmodernizer.cli.VersionProvider;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
-import java.net.URL;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import java.nio.file.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 /**
@@ -19,105 +17,12 @@ import picocli.CommandLine;
         parameterListHeading = "%nParameters:%n",
         optionListHeading = "%nOptions:%n",
         commandListHeading = "%nCommands:%n")
-public class GlobalOptions {
-
-    /**
-     * Logger
-     */
-    private static Logger LOG = LoggerFactory.getLogger(GlobalOptions.class);
+public class GlobalOptions implements IOption {
 
     @CommandLine.Option(
             names = {"-d", "--debug"},
             description = "Enable debug logging.")
     public boolean debug;
-
-    @CommandLine.Option(
-            names = {"-g", "--github-owner"},
-            description = "GitHub owner for forked repositories.")
-    private String githubOwner = Settings.GITHUB_OWNER;
-
-    @CommandLine.Option(
-            names = {"--github-app-id"},
-            description =
-                    "GitHub App ID. If set you will need to set GH_APP_CLIENT_ID, GH_APP_CLIENT_SECRET, GH_APP_PRIVATE_KEY_FILE as environment variables to use JWT authentication. The app installation must be done on the given github owner (personal or organization).")
-    public Long githubAppId;
-
-    @CommandLine.Option(
-            names = {"--github-app-source-installation-id"},
-            description =
-                    "GitHub App Installation ID for the source repositories. If set, the app installation must be done on the given github owner (personal or organization).")
-    public Long githubAppSourceInstallationId;
-
-    @CommandLine.Option(
-            names = {"--github-app-target-installation-id"},
-            description =
-                    "GitHub App Installation ID for the target repositories. If set, the app installation must be done on the given github owner (personal or organization).")
-    public Long githubAppTargetInstallationId;
-
-    @CommandLine.Option(
-            names = {"--draft"},
-            description = "Open a draft pull request.")
-    public boolean draft;
-
-    @CommandLine.Option(
-            names = {"--skip-push"},
-            description = "Skip pushing changes to the forked repositories. Always true if --dry-run is set.")
-    public boolean skipPush;
-
-    @CommandLine.Option(
-            names = {"--skip-build"},
-            description = "Skip building the plugins before and after modernization.")
-    public boolean skipBuild;
-
-    @CommandLine.Option(
-            names = {"--skip-pull-request"},
-            description = "Skip creating pull requests but pull changes to the fork. Always true if --dry-run is set.")
-    public boolean skipPullRequest;
-
-    @CommandLine.Option(
-            names = {"--clean-local-data"},
-            description = "Remove local plugin data before and after the modernization process.")
-    public boolean removeLocalData;
-
-    @CommandLine.Option(
-            names = {"--clean-forks"},
-            description =
-                    "Remove forked repositories before and after the modernization process. Might cause data loss if you have other changes pushed on those forks. Forks with open pull request targeting original repo are not removed to prevent closing unmerged pull requests.")
-    public boolean removeForks;
-
-    @CommandLine.Option(
-            names = {"-e", "--export-datatables"},
-            description = "Creates a report or summary of the changes made through OpenRewrite.")
-    public boolean exportDatatables;
-
-    @CommandLine.Option(
-            names = "--jenkins-update-center",
-            description =
-                    "Sets main update center; will override JENKINS_UC environment variable. If not set via CLI option or environment variable, will use default update center url.")
-    public URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
-
-    @CommandLine.Option(
-            names = "--jenkins-plugin-info",
-            description =
-                    "Sets jenkins plugin version; will override JENKINS_PLUGIN_INFO environment variable. If not set via CLI option or environment variable, will use default plugin info")
-    public URL jenkinsPluginVersions = Settings.DEFAULT_PLUGIN_VERSIONS;
-
-    @CommandLine.Option(
-            names = "--plugin-health-score",
-            description =
-                    "Sets the plugin health score URL; will override JENKINS_PHS environment variable. If not set via CLI option or environment variable, will use default health score url.")
-    public URL pluginHealthScore = Settings.DEFAULT_HEALTH_SCORE_URL;
-
-    @CommandLine.Option(
-            names = "--jenkins-plugins-stats-installations-url",
-            description =
-                    "Sets the Jenkins stats top plugins URL; will override JENKINS_PLUGINS_STATS_INSTALLATIONS_URL environment variable. If not set via CLI option or environment variable, will use default Jenkins stats top plugins url.")
-    public URL jenkinsPluginsStatsInstallationsUrl = Settings.DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL;
-
-    @CommandLine.Option(
-            names = {"--github-api-url"},
-            description = "GitHub API URL. Default to https://api.github.com")
-    public URL githubApiUrl = Settings.GITHUB_API_URL;
 
     @CommandLine.Option(
             names = {"-c", "--cache-path"},
@@ -131,28 +36,11 @@ public class GlobalOptions {
 
     /**
      * Create a new config build for the global options
-     * @return Config.Builder for global options
      */
-    public Config.Builder getBuilderForOptions() {
+    @Override
+    public void config(Config.Builder builder) {
         Config.DEBUG = debug;
-        return Config.builder()
-                .withVersion(getVersion())
-                .withGitHubOwner(githubOwner)
-                .withGitHubAppId(githubAppId)
-                .withGitHubAppSourceInstallationId(githubAppSourceInstallationId)
-                .withGitHubAppTargetInstallationId(githubAppTargetInstallationId)
-                .withSkipPush(skipPush)
-                .withSkipBuild(skipBuild)
-                .withSkipPullRequest(skipPullRequest)
-                .withDraft(draft)
-                .withRemoveLocalData(removeLocalData)
-                .withRemoveForks(removeForks)
-                .withExportDatatables(exportDatatables)
-                .withJenkinsUpdateCenter(jenkinsUpdateCenter)
-                .withJenkinsPluginVersions(jenkinsPluginVersions)
-                .withPluginHealthScore(pluginHealthScore)
-                .withPluginStatsInstallations(jenkinsPluginsStatsInstallationsUrl)
-                .withGithubApiUrl(githubApiUrl)
+        builder.withVersion(getVersion())
                 .withCachePath(
                         !cachePath.endsWith(Settings.CACHE_SUBDIR)
                                 ? cachePath.resolve(Settings.CACHE_SUBDIR)
@@ -168,8 +56,7 @@ public class GlobalOptions {
         try {
             return new VersionProvider().getMavenVersion();
         } catch (Exception e) {
-            LOG.error("Error getting version from pom.properties", e);
-            return "unknown";
+            throw new ModernizerException("Failed to get version from pom.properties", e);
         }
     }
 }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/IOption.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/IOption.java
@@ -1,0 +1,15 @@
+package io.jenkins.tools.pluginmodernizer.cli.options;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+
+/**
+ * Interface for all options
+ */
+public interface IOption {
+
+    /**
+     * Enrich the configuration build with specific options
+     * @param builder the configuration builder
+     */
+    default void config(Config.Builder builder) {}
+}

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/PluginOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/PluginOptions.java
@@ -2,6 +2,7 @@ package io.jenkins.tools.pluginmodernizer.cli.options;
 
 import io.jenkins.tools.pluginmodernizer.cli.converter.PluginConverter;
 import io.jenkins.tools.pluginmodernizer.cli.converter.PluginFileConverter;
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,7 +12,7 @@ import picocli.CommandLine;
 /**
  * Plugin option that are mutually exclusive.
  */
-public final class PluginOptions {
+public final class PluginOptions implements IOption {
 
     /**
      * List of plugins from CLI
@@ -32,11 +33,16 @@ public final class PluginOptions {
             converter = PluginFileConverter.class)
     private List<Plugin> pluginsFromFile;
 
+    @Override
+    public void config(Config.Builder builder) {
+        builder.withPlugins(getEffectivePlugins());
+    }
+
     /**
      * Get effective plugins
      * @return List of plugins from CLI and/or file
      */
-    public List<Plugin> getEffectivePlugins() {
+    private List<Plugin> getEffectivePlugins() {
         if (plugins == null) {
             plugins = List.of();
         }

--- a/plugin-modernizer-cli/src/main/resources/logback.xml
+++ b/plugin-modernizer-cli/src/main/resources/logback.xml
@@ -42,6 +42,7 @@
     <logger name="jdk.event.security" level="INFO" />
     <logger name="java.lang.ProcessBuilder" level="WARN" />
     <logger name="java.lang.Shutdown" level="WARN" />
+    <logger name="java.lang.Runtime" level="WARN" />
     <logger name="org.eclipse.jgit.internal.storage.file" level="INFO" />
     <logger name="org.eclipse.jgit.internal.util" level="INFO" />
     <logger name="org.eclipse.jgit.transport" level="INFO" />

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -23,13 +23,8 @@ public class Config {
     private final Path cachePath;
     private final Path mavenHome;
     private final boolean dryRun;
-    private final boolean skipPush;
-    private final boolean skipBuild;
     private final boolean draft;
-    private final boolean skipPullRequest;
-    private final boolean removeLocalData;
     private final boolean removeForks;
-    private final boolean exportDatatables;
     private final String githubOwner;
     private final Long githubAppId;
     private final Long githubAppSourceInstallationId;
@@ -51,13 +46,8 @@ public class Config {
             Path cachePath,
             Path mavenHome,
             boolean dryRun,
-            boolean skipPush,
-            boolean skipBuild,
             boolean draft,
-            boolean skipPullRequest,
-            boolean removeLocalData,
-            boolean removeForks,
-            boolean exportDatatables) {
+            boolean removeForks) {
         this.version = version;
         this.githubOwner = githubOwner;
         this.githubAppId = githubAppId;
@@ -73,13 +63,8 @@ public class Config {
         this.cachePath = cachePath;
         this.mavenHome = mavenHome;
         this.dryRun = dryRun;
-        this.skipPush = skipPush;
-        this.skipBuild = skipBuild;
         this.draft = draft;
-        this.skipPullRequest = skipPullRequest;
-        this.removeLocalData = removeLocalData;
         this.removeForks = removeForks;
-        this.exportDatatables = exportDatatables;
     }
 
     public String getVersion() {
@@ -154,32 +139,12 @@ public class Config {
         return DEBUG;
     }
 
-    public boolean isSkipPullRequest() {
-        return skipPullRequest;
-    }
-
     public boolean isDraft() {
         return draft;
     }
 
-    public boolean isSkipPush() {
-        return skipPush;
-    }
-
-    public boolean isSkipBuild() {
-        return skipBuild;
-    }
-
-    public boolean isRemoveLocalData() {
-        return removeLocalData;
-    }
-
     public boolean isRemoveForks() {
         return removeForks;
-    }
-
-    public boolean isExportDatatables() {
-        return exportDatatables;
     }
 
     public static Builder builder() {
@@ -203,11 +168,6 @@ public class Config {
         private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
         private boolean dryRun = false;
         private boolean draft = false;
-        private boolean skipPush = false;
-        private boolean skipBuild = false;
-        private boolean skipPullRequest = false;
-        private boolean exportDatatables = false;
-        public boolean removeLocalData = false;
         public boolean removeForks = false;
 
         public Builder withVersion(String version) {
@@ -304,33 +264,8 @@ public class Config {
             return this;
         }
 
-        public Builder withSkipPush(boolean skipPush) {
-            this.skipPush = skipPush;
-            return this;
-        }
-
-        public Builder withSkipBuild(boolean skipBuild) {
-            this.skipBuild = skipBuild;
-            return this;
-        }
-
-        public Builder withSkipPullRequest(boolean skipPullRequest) {
-            this.skipPullRequest = skipPullRequest;
-            return this;
-        }
-
-        public Builder withRemoveLocalData(boolean removeLocalData) {
-            this.removeLocalData = removeLocalData;
-            return this;
-        }
-
         public Builder withRemoveForks(boolean removeForks) {
             this.removeForks = removeForks;
-            return this;
-        }
-
-        public Builder withExportDatatables(boolean exportDatatables) {
-            this.exportDatatables = exportDatatables;
             return this;
         }
 
@@ -351,13 +286,8 @@ public class Config {
                     cachePath,
                     mavenHome,
                     dryRun,
-                    skipPush,
-                    skipBuild,
                     draft,
-                    skipPullRequest,
-                    removeLocalData,
-                    removeForks,
-                    exportDatatables);
+                    removeForks);
         }
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -185,7 +185,7 @@ public class Settings {
         if (host == null) {
             host = "api.github.com";
         }
-        return new URL("http://%s".formatted(host));
+        return new URL("https://%s".formatted(host));
     }
 
     private static @NotNull String getRemediationJenkinsMinimumVersion() {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -114,7 +114,6 @@ public class MavenInvoker {
     private String[] getSingleRecipeArgs(Recipe recipe) {
         List<String> goals = new ArrayList<>();
         goals.add("org.openrewrite.maven:rewrite-maven-plugin:" + Settings.MAVEN_REWRITE_PLUGIN_VERSION + ":run");
-        goals.add("-Drewrite.exportDatatables=" + config.isExportDatatables());
         goals.add("-Drewrite.activeRecipes=" + recipe.getName());
         goals.add("-Drewrite.recipeArtifactCoordinates=io.jenkins.plugin-modernizer:plugin-modernizer-core:"
                 + config.getVersion());

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
@@ -40,11 +40,7 @@ public class ConfigTest {
                 .withCachePath(cachePath)
                 .withMavenHome(mavenHome)
                 .withDryRun(dryRun)
-                .withSkipPullRequest(true)
-                .withSkipPush(true)
-                .withExportDatatables(true)
                 .withRemoveForks(true)
-                .withRemoveLocalData(true)
                 .build();
 
         assertEquals(version, config.getVersion());
@@ -55,12 +51,9 @@ public class ConfigTest {
         assertEquals(cachePath, config.getCachePath());
         assertEquals(mavenHome, config.getMavenHome());
         assertTrue(config.isRemoveForks());
-        assertTrue(config.isSkipPush());
-        assertTrue(config.isSkipPullRequest());
         assertTrue(config.isRemoveForks());
-        assertTrue(config.isRemoveLocalData());
-        assertTrue(config.isExportDatatables());
         assertTrue(config.isDryRun());
+        assertEquals("https://api.github.com", config.getGithubApiUrl().toString());
     }
 
     @Test
@@ -74,11 +67,7 @@ public class ConfigTest {
         assertEquals(Settings.DEFAULT_CACHE_PATH, config.getCachePath());
         assertEquals(Settings.DEFAULT_MAVEN_HOME, config.getMavenHome());
         assertFalse(config.isRemoveForks());
-        assertFalse(config.isSkipPush());
-        assertFalse(config.isSkipPullRequest());
         assertFalse(config.isRemoveForks());
-        assertFalse(config.isRemoveLocalData());
-        assertFalse(config.isExportDatatables());
         assertFalse(config.isDryRun());
     }
 


### PR DESCRIPTION
Fix: https://github.com/jenkins-infra/plugin-modernizer-tool/issues/420

- Replace --clean-data by subcommand
- Removed some unused options

I also added a negative integration test that skip metadata when a plugin is deprecated

To have a positive test we should use https://testcontainers.com/modules/git/ to perform the clone of a fake plugin