### PR TITLE
Remove rewrite jenkins override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,6 @@
     <!-- Version -->
     <openrewrite.bom.version>2.23.1</openrewrite.bom.version>
     <openrewrite.maven.plugin.version>5.46.3</openrewrite.maven.plugin.version>
-    <openrewrite.jenkins.version>0.18.1</openrewrite.jenkins.version>
     <micrometer.version>1.14.2</micrometer.version>
     <slf4j.version>2.0.16</slf4j.version>
     <logback.version>1.5.12</logback.version>
@@ -220,11 +219,6 @@
         <groupId>org.kohsuke</groupId>
         <artifactId>github-api</artifactId>
         <version>${github-api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.openrewrite.recipe</groupId>
-        <artifactId>rewrite-jenkins</artifactId>
-        <version>${openrewrite.jenkins.version}</version>
       </dependency>
       <dependency>
         <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Use bom version to avoid dependency issue.

And we will most likely remove it from packaging due to license changes.

One temporary option could be to add it from `recipeArtifactCoordinates` to avoid packinging a non-OSS dependency into our jar