### PR TITLE
Switch to SSH transport 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,14 +3,13 @@ target/
 !**/src/main/**/target/
 !**/src/test/**/target/
 
-### Plugins Directory ###
-test-plugins
-
 ### Log file ###
 logs/
 
 ### IntelliJ IDEA ###
 .idea/
+!.idea/runConfigurations/
+!.idea/.gitignore/
 *.iws
 *.iml
 *.ipr
@@ -33,6 +32,8 @@ logs/
 build/
 !**/src/main/**/build/
 !**/src/test/**/build/
+
+!**/test/resources/**/.git
 
 ### VS Code ###
 .vscode/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,11 @@
+@Library('pipeline-library@pull/893/head') _
+
 // While this isn't a plugin, it is much simpler to reuse the pipeline code for CI
 // allowing easy windows / linux testing and producing incrementals
 // the only feature that buildPlugin has that relates to plugins is allowing you to test against multiple jenkins versions
 buildPlugin(
     useContainerAgent: false,
+    useArtifactCachingProxy: false,
     configurations: [
         [platform: 'linux', jdk: 21],
         [platform: 'windows', jdk: 21],

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ From there you need to save both ID of installation (found on URL)
 
 ## Global option
 
-- `--debug` or `-d`: (optional) Enables debug mode. Defaults to false.
+- `--debug`: (optional) Enables debug mode. Defaults to false.
 
 
-- `--cache-path` or `-c`: (optional) Custom path to the cache directory. Defaults to `${user.home}/.cache/jenkins-plugin-modernizer-cli`.
+- `--cache-path`: (optional) Custom path to the cache directory. Defaults to `${user.home}/.cache/jenkins-plugin-modernizer-cli`.
 
 
-- `--maven-home` or `-m`: (optional) Path to the Maven home directory. Required if both `MAVEN_HOME` and `M2_HOME` environment variables are not set. The minimum required version is 3.9.7.
+- `--maven-home`: (optional) Path to the Maven home directory. Required if both `MAVEN_HOME` and `M2_HOME` environment variables are not set. The minimum required version is 3.9.7.
 
 
 - `--clean-local-data` (optional) Deletes the local plugin directory before running the tool.

--- a/plugin-modernizer-cli/pom.xml
+++ b/plugin-modernizer-cli/pom.xml
@@ -122,6 +122,7 @@
                 <include>**/*ITCase.java</include>
               </includes>
               <environmentVariables>
+                <MAVEN_LOCAL_REPO>${maven.repo.local}</MAVEN_LOCAL_REPO>
                 <MAVEN_HOME>${project.build.directory}/apache-maven-${maven.version}</MAVEN_HOME>
                 <GH_TOKEN>fake-token</GH_TOKEN>
                 <GH_OWNER>fake-owner</GH_OWNER>

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
@@ -6,6 +6,8 @@ import io.jenkins.tools.pluginmodernizer.cli.options.PluginOptions;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -28,6 +30,14 @@ public class BuildMetadataCommand implements ICommand {
     private PluginOptions pluginOptions;
 
     /**
+     * Path to the authentication key in case of private repo
+     */
+    @CommandLine.Option(
+            names = {"--ssh-private-key"},
+            description = "Path to the authentication key for GitHub. Default to ~/.ssh/id_rsa")
+    private Path sshPrivateKey = Settings.SSH_PRIVATE_KEY;
+
+    /**
      * Global options for all commands
      */
     @CommandLine.Mixin
@@ -44,12 +54,21 @@ public class BuildMetadataCommand implements ICommand {
         options.config(builder);
         envOptions.config(builder);
         pluginOptions.config(builder);
-        return builder.withRecipe(Settings.FETCH_METADATA_RECIPE).build();
+        return builder.withSshPrivateKey(sshPrivateKey)
+                .withRecipe(Settings.FETCH_METADATA_RECIPE)
+                .build();
     }
 
     @Override
-    public Integer call() throws Exception {
+    public Integer call() {
         PluginModernizer modernizer = getModernizer();
+        try {
+            modernizer.validate();
+        } catch (ModernizerException e) {
+            LOG.error("Validation error");
+            LOG.error(e.getMessage());
+            return 1;
+        }
         modernizer.start();
         return 0;
     }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ValidateCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ValidateCommand.java
@@ -6,6 +6,8 @@ import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
 import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -53,7 +55,13 @@ public class ValidateCommand implements ICommand {
         try {
             modernizer.validate();
             LOG.info("GitHub owner: {}", modernizer.getGithubOwner());
+            if (Files.isRegularFile(Path.of(modernizer.getSshPrivateKeyPath()))) {
+                LOG.info("SSH key path: {}", modernizer.getSshPrivateKeyPath());
+            } else {
+                LOG.info("SSH key not set. Will use GitHub token for Git operation");
+            }
             LOG.info("Maven home: {}", modernizer.getMavenHome());
+            LOG.info("Maven local repository: {}", modernizer.getMavenLocalRepo());
             LOG.info("Maven version: {}", modernizer.getMavenVersion());
             LOG.info("Java version: {}", modernizer.getJavaVersion());
             LOG.info("Cache path: {}", modernizer.getCachePath());

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GitHubOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GitHubOptions.java
@@ -2,6 +2,7 @@ package io.jenkins.tools.pluginmodernizer.cli.options;
 
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import java.nio.file.Path;
 import picocli.CommandLine;
 
 /**
@@ -14,6 +15,14 @@ import picocli.CommandLine;
         optionListHeading = "%nOptions:%n",
         commandListHeading = "%nCommands:%n")
 public class GitHubOptions implements IOption {
+
+    /**
+     * Path to the authentication key
+     */
+    @CommandLine.Option(
+            names = {"--ssh-private-key"},
+            description = "Path to the authentication key for GitHub. Default to ~/.ssh/id_rsa")
+    private Path sshPrivateKey = Settings.SSH_PRIVATE_KEY;
 
     @CommandLine.Option(
             names = {"-g", "--github-owner"},
@@ -46,6 +55,7 @@ public class GitHubOptions implements IOption {
         builder.withGitHubOwner(githubOwner)
                 .withGitHubAppId(githubAppId)
                 .withGitHubAppSourceInstallationId(githubAppSourceInstallationId)
-                .withGitHubAppTargetInstallationId(githubAppTargetInstallationId);
+                .withGitHubAppTargetInstallationId(githubAppTargetInstallationId)
+                .withSshPrivateKey(sshPrivateKey);
     }
 }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
@@ -20,19 +20,24 @@ import picocli.CommandLine;
 public class GlobalOptions implements IOption {
 
     @CommandLine.Option(
-            names = {"-d", "--debug"},
+            names = {"--debug"},
             description = "Enable debug logging.")
     public boolean debug;
 
     @CommandLine.Option(
-            names = {"-c", "--cache-path"},
+            names = {"--cache-path"},
             description = "Path to the cache directory.")
     public Path cachePath = Settings.DEFAULT_CACHE_PATH;
 
     @CommandLine.Option(
-            names = {"-m", "--maven-home"},
+            names = {"--maven-home"},
             description = "Path to the Maven Home directory.")
     public Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
+
+    @CommandLine.Option(
+            names = {"--maven-local-repo"},
+            description = "Path to the Maven local repository.")
+    public Path mavenLocalRepo = Settings.DEFAULT_MAVEN_LOCAL_REPO;
 
     /**
      * Create a new config build for the global options
@@ -45,7 +50,8 @@ public class GlobalOptions implements IOption {
                         !cachePath.endsWith(Settings.CACHE_SUBDIR)
                                 ? cachePath.resolve(Settings.CACHE_SUBDIR)
                                 : cachePath)
-                .withMavenHome(mavenHome);
+                .withMavenHome(mavenHome)
+                .withMavenLocalRepo(mavenLocalRepo);
     }
 
     /**

--- a/plugin-modernizer-cli/src/main/resources/logback.xml
+++ b/plugin-modernizer-cli/src/main/resources/logback.xml
@@ -43,8 +43,12 @@
     <logger name="java.lang.ProcessBuilder" level="WARN" />
     <logger name="java.lang.Shutdown" level="WARN" />
     <logger name="java.lang.Runtime" level="WARN" />
-    <logger name="org.eclipse.jgit.internal.storage.file" level="INFO" />
-    <logger name="org.eclipse.jgit.internal.util" level="INFO" />
+    <logger name="org.apache.mina.core" level="WARN" />
+    <logger name="org.apache.sshd.client" level="WARN" />
+    <logger name="org.apache.sshd.client.keyverifier" level="ERROR" />
+    <logger name="org.apache.sshd.common" level="WARN" />
+    <logger name="org.apache.sshd.git.transport" level="WARN" />
+    <logger name="org.eclipse.jgit.internal" level="WARN" />
     <logger name="org.eclipse.jgit.transport" level="INFO" />
     <logger name="org.eclipse.jgit.util" level="INFO" />
     <logger name="sun.net.www.protocol.http" level="INFO" />

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/utils/GitHubServerContainer.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/utils/GitHubServerContainer.java
@@ -1,0 +1,221 @@
+package io.jenkins.tools.pluginmodernizer.cli.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.sparsick.testcontainers.gitserver.GitServerVersions;
+import com.github.sparsick.testcontainers.gitserver.plain.GitServerContainer;
+import com.github.sparsick.testcontainers.gitserver.plain.SshIdentity;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import io.jenkins.tools.pluginmodernizer.core.model.HealthScoreData;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import io.jenkins.tools.pluginmodernizer.core.model.PluginVersionData;
+import io.jenkins.tools.pluginmodernizer.core.model.UpdateCenterData;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
+import org.testcontainers.containers.ExecConfig;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * The GitHub server container accessible by SSH
+ */
+public class GitHubServerContainer extends GitServerContainer {
+
+    /**
+     * The logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(GitHubServerContainer.class);
+
+    /**
+     * The plugin name
+     */
+    private final String plugin;
+
+    /**
+     * The WireMock runtime info
+     */
+    private final WireMockRuntimeInfo wmRuntimeInfo;
+
+    /**
+     * The branch
+     */
+    private final String branch;
+
+    /**
+     * The path containers the SSH
+     */
+    private final Path keysPath;
+
+    /**
+     * Create a GitHub server container
+     */
+    public GitHubServerContainer(WireMockRuntimeInfo wmRuntimeInfo, Path keysPath, String plugin, String branch) {
+        super(GitServerVersions.V2_45.getDockerImageName());
+        this.plugin = plugin;
+        this.wmRuntimeInfo = wmRuntimeInfo;
+        this.branch = branch;
+        this.keysPath = keysPath;
+        withSshKeyAuth();
+        withGitRepo(plugin);
+    }
+
+    @Override
+    public void start() {
+        super.start();
+        setupGitContainer();
+        setupMock();
+    }
+
+    /**
+     * Setup mocks for integration tests with WireMock and Testcontainer git
+     */
+    private void setupMock() {
+
+        // Setup responses
+        PluginStatsApiResponse pluginStatsApiResponse = new PluginStatsApiResponse(Map.of(plugin, 1));
+        UpdateCenterApiResponse updateCenterApiResponse = new UpdateCenterApiResponse(
+                Map.of(
+                        plugin,
+                        new UpdateCenterData.UpdateCenterPlugin(
+                                plugin,
+                                "1",
+                                this.getGitRepoURIAsSSH().toString(),
+                                branch,
+                                "io.jenkins.plugins:%s".formatted(plugin),
+                                null)),
+                Map.of());
+        PluginVersionsApiResponse pluginVersionsApiResponse = new PluginVersionsApiResponse(
+                Map.of(plugin, Map.of("1", new PluginVersionData.PluginVersionPlugin(plugin, "1"))));
+        HealthScoreApiResponse pluginHealthScoreApiResponse =
+                new HealthScoreApiResponse(Map.of(plugin, new HealthScoreData.HealthScorePlugin(100d)));
+
+        // Setup mocks
+        WireMock wireMock = wmRuntimeInfo.getWireMock();
+        wireMock.register(WireMock.get(WireMock.urlEqualTo("/api/user"))
+                .willReturn(WireMock.jsonResponse(new UserApiResponse("fake-owner", "User"), 200)));
+        wireMock.register(WireMock.get(WireMock.urlEqualTo("/api/repos/jenkinsci/%s".formatted(plugin)))
+                .willReturn(WireMock.jsonResponse(
+                        new RepoApiResponse(
+                                "main",
+                                "%s/%s/%s".formatted(wmRuntimeInfo.getHttpBaseUrl(), "fake-owner", plugin),
+                                this.getGitRepoURIAsSSH().toString()),
+                        200)));
+        wireMock.register(WireMock.get(WireMock.urlEqualTo("/update-center.json"))
+                .willReturn(WireMock.jsonResponse(updateCenterApiResponse, 200)));
+        wireMock.register(WireMock.get(WireMock.urlEqualTo("/plugin-versions.json"))
+                .willReturn(WireMock.jsonResponse(pluginVersionsApiResponse, 200)));
+        wireMock.register(WireMock.get(WireMock.urlEqualTo("/scores"))
+                .willReturn(WireMock.jsonResponse(pluginHealthScoreApiResponse, 200)));
+        wireMock.register(WireMock.get(WireMock.urlEqualTo("/jenkins-stats/svg/202406-plugins.csv"))
+                .willReturn(WireMock.jsonResponse(pluginStatsApiResponse, 200)));
+
+        // Setup SSH key to access the container
+        SshIdentity sshIdentity = this.getSshClientIdentity();
+        byte[] privateKey = sshIdentity.getPrivateKey();
+        try {
+            Files.write(keysPath.resolve(plugin), privateKey);
+            LOG.info("Private key: {}", keysPath.resolve(plugin));
+        } catch (IOException e) {
+            throw new ModernizerException("Error writing private key", e);
+        }
+    }
+
+    /**
+     * Run a command on the git container
+     * @param command The command
+     */
+    private void runContainerGitCommand(String user, String command) {
+        try {
+            Container.ExecResult containerResult = this.execInContainer(ExecConfig.builder()
+                    .user(user)
+                    .command(command.split(" ")) // We assume no command contains space
+                    .build());
+            LOG.debug("Running command on container: {}", command);
+            LOG.debug("Stdout: {}", containerResult.getStdout());
+            LOG.debug("Stderr: {}", containerResult.getStderr());
+
+            assertEquals(
+                    0,
+                    containerResult.getExitCode(),
+                    "Command '%s' failed with status code '%s' and output '%s' and error '%s'"
+                            .formatted(
+                                    command,
+                                    containerResult.getExitCode(),
+                                    containerResult.getStdout(),
+                                    containerResult.getStderr()));
+        } catch (IOException | InterruptedException e) {
+            throw new ModernizerException("Error running command: %s".formatted(command), e);
+        }
+    }
+
+    /**
+     * Setup the git container
+     */
+    private void setupGitContainer() {
+        String gitRepoPath = String.format("/srv/git/%s.git", plugin);
+        String sourceDirectory = "src/test/resources/%s".formatted(plugin);
+        assertTrue(
+                Files.exists(Path.of(sourceDirectory)),
+                "Source directory %s does not exist".formatted(sourceDirectory));
+        runContainerGitCommand("root", "rm -Rf %s".formatted(gitRepoPath));
+        LOG.debug("Copying %s to %s".formatted(sourceDirectory, gitRepoPath));
+        this.copyFileToContainer(MountableFile.forHostPath(sourceDirectory.formatted(plugin)), gitRepoPath);
+        LOG.debug("Copied %s to %s".formatted(sourceDirectory, gitRepoPath));
+        runContainerGitCommand("root", "chown -R git:git %s".formatted(gitRepoPath));
+        runContainerGitCommand("git", "ls -la %s".formatted(gitRepoPath));
+        runContainerGitCommand("git", "git config --global init.defaultBranch main");
+        runContainerGitCommand("git", "git config --global --add safe.directory %s".formatted(gitRepoPath));
+        runContainerGitCommand("git", "git config --global user.name Fake");
+        runContainerGitCommand("git", "git config --global user.email fake-email@example.com");
+        runContainerGitCommand("git", "git init %s".formatted(gitRepoPath));
+        runContainerGitCommand("git", "git -C %s status".formatted(gitRepoPath));
+        runContainerGitCommand("git", "git -C %s add .".formatted(gitRepoPath));
+        runContainerGitCommand("git", "git -C %s status".formatted(gitRepoPath));
+        runContainerGitCommand("git", "git -C %s commit -m init".formatted(gitRepoPath));
+        runContainerGitCommand("git", "git -C %s status".formatted(gitRepoPath));
+    }
+
+    /**
+     * Login API response
+     */
+    public record UserApiResponse(String login, String type) {}
+
+    /**
+     * Setup the mock
+     * @param ssh_url the SSH URL
+     */
+    public record RepoApiResponse(String default_branch, String clone_url, String ssh_url) {}
+
+    /**
+     * Setup the mock
+     * @param plugins
+     */
+    public record PluginStatsApiResponse(Map<String, Integer> plugins) {}
+
+    /**
+     * Update center API response
+     * @param plugins the plugins
+     * @param deprecations the deprecations
+     */
+    public record UpdateCenterApiResponse(
+            Map<String, UpdateCenterData.UpdateCenterPlugin> plugins,
+            Map<String, UpdateCenterData.DeprecatedPlugin> deprecations) {}
+
+    /**
+     * Plugin versions API response
+     * @param plugins the plugins
+     */
+    public record PluginVersionsApiResponse(Map<String, Map<String, PluginVersionData.PluginVersionPlugin>> plugins) {}
+
+    /**
+     * Health score API response
+     * @param plugins the plugins
+     */
+    public record HealthScoreApiResponse(Map<String, HealthScoreData.HealthScorePlugin> plugins) {}
+}

--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -55,7 +55,14 @@
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-invoker</artifactId>
-      <version>3.3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sshd</groupId>
+      <artifactId>sshd-git</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -68,6 +75,10 @@
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jgit</groupId>
+      <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kohsuke</groupId>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -22,6 +22,7 @@ public class Config {
     private final URL githubApiUrl;
     private final Path cachePath;
     private final Path mavenHome;
+    private final Path mavenLocalRepo;
     private final boolean dryRun;
     private final boolean draft;
     private final boolean removeForks;
@@ -29,6 +30,7 @@ public class Config {
     private final Long githubAppId;
     private final Long githubAppSourceInstallationId;
     private final Long githubAppTargetInstallationId;
+    private final Path sshPrivateKey;
 
     private Config(
             String version,
@@ -36,6 +38,7 @@ public class Config {
             Long githubAppId,
             Long githubAppSourceInstallationId,
             Long githubAppTargetInstallationId,
+            Path sshPrivateKey,
             List<Plugin> plugins,
             Recipe recipe,
             URL jenkinsUpdateCenter,
@@ -45,6 +48,7 @@ public class Config {
             URL githubApiUrl,
             Path cachePath,
             Path mavenHome,
+            Path mavenLocalRepo,
             boolean dryRun,
             boolean draft,
             boolean removeForks) {
@@ -53,6 +57,7 @@ public class Config {
         this.githubAppId = githubAppId;
         this.githubAppSourceInstallationId = githubAppSourceInstallationId;
         this.githubAppTargetInstallationId = githubAppTargetInstallationId;
+        this.sshPrivateKey = sshPrivateKey;
         this.plugins = plugins;
         this.recipe = recipe;
         this.jenkinsUpdateCenter = jenkinsUpdateCenter;
@@ -62,6 +67,7 @@ public class Config {
         this.githubApiUrl = githubApiUrl;
         this.cachePath = cachePath;
         this.mavenHome = mavenHome;
+        this.mavenLocalRepo = mavenLocalRepo;
         this.dryRun = dryRun;
         this.draft = draft;
         this.removeForks = removeForks;
@@ -85,6 +91,10 @@ public class Config {
 
     public Long getGithubAppTargetInstallationId() {
         return githubAppTargetInstallationId;
+    }
+
+    public Path getSshPrivateKey() {
+        return sshPrivateKey;
     }
 
     public List<Plugin> getPlugins() {
@@ -124,11 +134,21 @@ public class Config {
     }
 
     public Path getCachePath() {
-        return cachePath;
+        return cachePath.toAbsolutePath();
     }
 
     public Path getMavenHome() {
-        return mavenHome;
+        if (mavenHome == null) {
+            return null;
+        }
+        return mavenHome.toAbsolutePath();
+    }
+
+    public Path getMavenLocalRepo() {
+        if (mavenLocalRepo == null) {
+            return Settings.DEFAULT_MAVEN_LOCAL_REPO;
+        }
+        return mavenLocalRepo.toAbsolutePath();
     }
 
     public boolean isDryRun() {
@@ -157,6 +177,7 @@ public class Config {
         private Long githubAppId;
         private Long githubAppSourceInstallationId;
         private Long githubAppTargetInstallationId;
+        private Path sshPrivateKey = Settings.SSH_PRIVATE_KEY;
         private List<Plugin> plugins;
         private Recipe recipe;
         private URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
@@ -166,6 +187,7 @@ public class Config {
         private URL githubApiUrl = Settings.GITHUB_API_URL;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
         private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
+        private Path mavenLocalRepo = Settings.DEFAULT_MAVEN_LOCAL_REPO;
         private boolean dryRun = false;
         private boolean draft = false;
         public boolean removeForks = false;
@@ -192,6 +214,11 @@ public class Config {
 
         public Builder withGitHubAppTargetInstallationId(Long githubAppInstallationId) {
             this.githubAppTargetInstallationId = githubAppInstallationId;
+            return this;
+        }
+
+        public Builder withSshPrivateKey(Path sshPrivateKey) {
+            this.sshPrivateKey = sshPrivateKey;
             return this;
         }
 
@@ -254,6 +281,13 @@ public class Config {
             return this;
         }
 
+        public Builder withMavenLocalRepo(Path mavenLocalRepo) {
+            if (mavenLocalRepo != null) {
+                this.mavenLocalRepo = mavenLocalRepo;
+            }
+            return this;
+        }
+
         public Builder withDryRun(boolean dryRun) {
             this.dryRun = dryRun;
             return this;
@@ -276,6 +310,7 @@ public class Config {
                     githubAppId,
                     githubAppSourceInstallationId,
                     githubAppTargetInstallationId,
+                    sshPrivateKey,
                     plugins,
                     recipe,
                     jenkinsUpdateCenter,
@@ -285,6 +320,7 @@ public class Config {
                     githubApiUrl,
                     cachePath,
                     mavenHome,
+                    mavenLocalRepo,
                     dryRun,
                     draft,
                     removeForks);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -114,6 +114,7 @@ public class MavenInvoker {
     private String[] getSingleRecipeArgs(Recipe recipe) {
         List<String> goals = new ArrayList<>();
         goals.add("org.openrewrite.maven:rewrite-maven-plugin:" + Settings.MAVEN_REWRITE_PLUGIN_VERSION + ":run");
+        goals.add("-Dmaven.repo.local=%s".formatted(config.getMavenLocalRepo()));
         goals.add("-Drewrite.activeRecipes=" + recipe.getName());
         goals.add("-Drewrite.recipeArtifactCoordinates=io.jenkins.plugin-modernizer:plugin-modernizer-core:"
                 + config.getVersion());
@@ -163,10 +164,10 @@ public class MavenInvoker {
     }
 
     /**
-     * Validate the Maven home directory.
+     * Validate the Maven home and local repo directory.
      * @throws IllegalArgumentException if the Maven home directory is not set or invalid.
      */
-    public void validateMavenHome() {
+    public void validateMaven() {
         Path mavenHome = config.getMavenHome();
         if (mavenHome == null) {
             throw new ModernizerException(
@@ -175,6 +176,14 @@ public class MavenInvoker {
 
         if (!Files.isDirectory(mavenHome) || !Files.isExecutable(mavenHome.resolve("bin/mvn"))) {
             throw new ModernizerException("Invalid Maven home directory at '%s'.".formatted(mavenHome));
+        }
+
+        Path mavenLocalRepo = config.getMavenLocalRepo();
+        if (mavenLocalRepo == null) {
+            throw new ModernizerException("Maven local repository is not set.");
+        }
+        if (!Files.isDirectory(mavenLocalRepo)) {
+            throw new ModernizerException("Invalid Maven local repository at '%s'.".formatted(mavenLocalRepo));
         }
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -38,7 +38,7 @@ public class PluginModernizer {
      * Validate the configuration
      */
     public void validate() {
-        mavenInvoker.validateMavenHome();
+        mavenInvoker.validateMaven();
         mavenInvoker.validateMavenVersion();
         if (!ghService.isConnected()) {
             ghService.connect();
@@ -73,6 +73,14 @@ public class PluginModernizer {
     }
 
     /**
+     * Expose the effective SSH private key path
+     * @return The SSH private key path
+     */
+    public String getSshPrivateKeyPath() {
+        return config.getSshPrivateKey().toString();
+    }
+
+    /**
      * Expose the effective Maven version
      * @return The Maven version
      */
@@ -88,6 +96,14 @@ public class PluginModernizer {
      */
     public String getMavenHome() {
         return config.getMavenHome().toString();
+    }
+
+    /**
+     * Expose the effective Maven local repository
+     * @return The Maven local repository
+     */
+    public String getMavenLocalRepo() {
+        return config.getMavenLocalRepo().toString();
     }
 
     /**
@@ -125,11 +141,18 @@ public class PluginModernizer {
         LOG.debug("Plugins: {}", config.getPlugins());
         LOG.debug("Recipe: {}", config.getRecipe().getName());
         LOG.debug("GitHub owner: {}", config.getGithubOwner());
+        if (ghService.isSshKeyAuth()) {
+            LOG.debug("SSH private key: {}", config.getSshPrivateKey());
+        } else {
+            LOG.debug("Using GitHub token for git authentication");
+        }
         LOG.debug("Update Center Url: {}", config.getJenkinsUpdateCenter());
         LOG.debug("Plugin versions Url: {}", config.getJenkinsPluginVersions());
         LOG.debug("Plugin Health Score Url: {}", config.getPluginHealthScore());
         LOG.debug("Installation Stats Url: {}", config.getPluginStatsInstallations());
         LOG.debug("Cache Path: {}", config.getCachePath());
+        LOG.debug("Maven Home: {}", config.getMavenHome());
+        LOG.debug("Maven Local Repository: {}", config.getMavenLocalRepo());
         LOG.debug("Dry Run: {}", config.isDryRun());
         LOG.debug("Maven rewrite plugin version: {}", Settings.MAVEN_REWRITE_PLUGIN_VERSION);
 
@@ -374,6 +397,7 @@ public class PluginModernizer {
                         LOG.error("Stacktrace: ", error);
                     }
                 }
+
             }
             // Display what's done
             else {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginService.java
@@ -38,7 +38,7 @@ public class PluginService {
         String scmUrl = updateCenterPlugin.scm();
         int lastSlashIndex = scmUrl.lastIndexOf('/');
         if (lastSlashIndex != -1 && lastSlashIndex < scmUrl.length() - 1) {
-            return scmUrl.substring(lastSlashIndex + 1);
+            return scmUrl.substring(lastSlashIndex + 1).replaceAll(".git$", "");
         } else {
             plugin.addError("Invalid SCM URL format");
             plugin.raiseLastError();

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
@@ -27,8 +27,8 @@ public class ConfigTest {
         Recipe recipe = Mockito.mock(Recipe.class);
         Mockito.doReturn("recipe1").when(recipe).getName();
         URL jenkinsUpdateCenter = new URL("https://updates.jenkins.io/current/update-center.actual.json");
-        Path cachePath = Paths.get("/path/to/cache");
-        Path mavenHome = Paths.get("/path/to/maven");
+        Path cachePath = Paths.get("path/to/cache");
+        Path mavenHome = Paths.get("path/to/maven");
         boolean dryRun = true;
 
         Config config = Config.builder()
@@ -48,8 +48,8 @@ public class ConfigTest {
         assertEquals(plugins, config.getPlugins());
         assertEquals(recipe, config.getRecipe());
         assertEquals(jenkinsUpdateCenter, config.getJenkinsUpdateCenter());
-        assertEquals(cachePath, config.getCachePath());
-        assertEquals(mavenHome, config.getMavenHome());
+        assertEquals(cachePath.toAbsolutePath(), config.getCachePath());
+        assertEquals(mavenHome.toAbsolutePath(), config.getMavenHome());
         assertTrue(config.isRemoveForks());
         assertTrue(config.isRemoveForks());
         assertTrue(config.isDryRun());

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
@@ -14,6 +14,7 @@ import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.impl.MavenInvoker;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -50,11 +51,30 @@ public class PluginTest {
     }
 
     @Test
-    public void testLocalRepository() {
-        Plugin plugin = Plugin.build("example");
+    public void testDefaultLocalRepository() {
+        Plugin plugin = mock(Plugin.class);
+        doReturn("example").when(plugin).getName();
+        Config config = mock(Config.class);
+        doReturn(Settings.DEFAULT_CACHE_PATH).when(config).getCachePath();
+        doReturn(config).when(plugin).getConfig();
         assertEquals(
                 Settings.getPluginsDirectory(plugin).resolve("sources").toString(),
-                plugin.getLocalRepository().toString());
+                Settings.DEFAULT_CACHE_PATH
+                        .resolve("example")
+                        .resolve("sources")
+                        .toString());
+    }
+
+    @Test
+    public void testCustomLocalRepository() {
+        Plugin plugin = mock(Plugin.class);
+        doReturn("example").when(plugin).getName();
+        Config config = mock(Config.class);
+        doReturn(Path.of("my-cache")).when(config).getCachePath();
+        doReturn(config).when(plugin).getConfig();
+        assertEquals(
+                Settings.getPluginsDirectory(plugin).resolve("sources").toString(),
+                Path.of("my-cache").resolve("example").resolve("sources").toString());
     }
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
@@ -63,6 +63,10 @@ class PluginServiceTest {
                 new UpdateCenterData.UpdateCenterPlugin(
                         "valid-plugin", "1.0", "https://github.com/jenkinsci/valid-url", "main", "gav", null));
         updateCenterPlugins.put(
+                "valid-plugin-2",
+                new UpdateCenterData.UpdateCenterPlugin(
+                        "valid-plugin", "1.0", "git@github.com/jenkinsci/valid-git-repo.git", "main", "gav", null));
+        updateCenterPlugins.put(
                 "invalid-plugin",
                 new UpdateCenterData.UpdateCenterPlugin(
                         "invalid-plugin", "1.0", "invalid-scm-url", "main", "gav", null));
@@ -114,6 +118,14 @@ class PluginServiceTest {
         PluginService service = getService();
         String result = service.extractRepoName(Plugin.build("valid-plugin").withConfig(config));
         assertEquals("valid-url", result);
+    }
+
+    @Test
+    public void shouldExtractRepoNameWithGitSuffix() throws Exception {
+        setupUpdateCenterMocks();
+        PluginService service = getService();
+        String result = service.extractRepoName(Plugin.build("valid-plugin-2").withConfig(config));
+        assertEquals("valid-git-repo", result);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
     <maven.failsafe.version>3.5.2</maven.failsafe.version>
     <testcontainers.version>1.20.4</testcontainers.version>
     <testcontainers.git.version>0.10.0</testcontainers.git.version>
+    <apache.mina.version>2.14.0</apache.mina.version>
+    <maven.invoker.version>3.3.0</maven.invoker.version>
   </properties>
 
   <dependencyManagement>
@@ -198,6 +200,21 @@
         <version>${maven.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.maven.shared</groupId>
+        <artifactId>maven-invoker</artifactId>
+        <version>${maven.invoker.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-core</artifactId>
+        <version>${apache.mina.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.sshd</groupId>
+        <artifactId>sshd-git</artifactId>
+        <version>${apache.mina.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk18on</artifactId>
         <version>${bouncycastle.version}</version>
@@ -208,6 +225,11 @@
         <version>${bouncycastle.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcutil-jdk18on</artifactId>
+        <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.checkerframework</groupId>
         <artifactId>checker-qual</artifactId>
         <version>${checker.qual.version}</version>
@@ -215,6 +237,11 @@
       <dependency>
         <groupId>org.eclipse.jgit</groupId>
         <artifactId>org.eclipse.jgit</artifactId>
+        <version>${jgit.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jgit</groupId>
+        <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
         <version>${jgit.version}</version>
       </dependency>
       <dependency>
@@ -281,6 +308,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The goal for this PR is to allow support for SSH transport on JGit. In order to clone and perform Git operation via SSH

This require to pass the `--ssh-private-key`

This is also some preparation for https://github.com/jenkins-infra/plugin-modernizer-tool/issues/460

This also add better support for https://github.com/jenkins-infra/plugin-modernizer-tool/issues/318 because the authentication is passed also during fetch command

The PR also add and integration test for the `build-metadata` subcommand and a Git testcontainer

The PR also fixes various bug during testing.

One example is the support of `--maven-local-repo` which was not cutomizable. For example on ci.jenkins.io is different and was breaking the resolution of the core module (which was installed on different location `m2repo` of the workspace

The option is also useful in order to run the tool were the /home/ folder is not writable (typically on container or kubernetes distribution

One improvement is that we miss https://github.com/hub4j/github-api/pull/1996 in order to validate the target GH SSH keys