### PR TITLE
chore(updatecli): Update the compress-api plugin version

### DIFF
--- a/updatecli/updatecli.d/compress-api.yaml
+++ b/updatecli/updatecli.d/compress-api.yaml
@@ -1,0 +1,48 @@
+name: Update compress-api plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestCompressApiVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "commons-compress-api-plugin"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+    transformers:
+      - trimprefix: "commons-compress-api-"
+
+targets:
+  updateRecipesYaml:
+    name: "Update compress-api plugin version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+      matchPattern: "(pluginArtifactId: commons-compress-api\\n)(.*\\n)(.*pluginVersion:) .*"
+      replacePattern: '$1$2$3 {{ source "latestCompressApiVersion" }}'
+    sourceid: latestCompressApiVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update compress-api plugin version to {{ source "latestCompressApiVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli


### PR DESCRIPTION
This is a follow-up to #471.
A new Updatecli configuration file `compress-api.yaml` has been introduced to automate version updates for the `commons-compress-api-plugin`. The configuration defines a process to fetch the latest plugin version from GitHub releases, automatically update the version in the `recipes.yml` file, and create a pull request with the new version details.

## Changes

| File | Change Summary |
|------|----------------|
| `updatecli/updatecli.d/compress-api.yaml` | New configuration file for managing version updates of commons-compress-api-plugin |

### Testing done

`updatecli diff --debug --config ./updatecli/updatecli.d/compress-api.yaml --values ./updatecli/values.github-action.yaml 2>&1`

which produced:

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/compress-api.yaml"
DEBUG: pipelineid undefined, we'll try to generate one
DEBUG: using pipeline name to generate the pipelineid

SCM repository retrieved: 1
DEBUG: cloning git repository: https://github.com/jenkins-infra/plugin-modernizer-tool.git in /tmp/updatecli/github/jenkins-infra/plugin-modernizer-tool
DEBUG: repository already exists, trying to pull changes
DEBUG: Fetching remote branches for resetting local ones


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



######################################
# UPDATE COMPRESS-API PLUGIN VERSION #
######################################

source: source#latestCompressApiVersion
-------------------------------
DEBUG: GitHub Api credit used 1, remaining 4986 (reset at 2024-12-18T09:41:18Z)
DEBUG: 3 releases found
Searching for version matching pattern "latest"
✔ GitHub release version "commons-compress-api-1.27.1-1" found matching pattern "latest" of kind "latest"
[transformers]
✔ Result correctly transformed from "commons-compress-api-1.27.1-1" to "1.27.1-1"


CHANGELOG:
----------

Release published on the 2024-12-13 07:58:03 +0000 UTC at the url https://github.com/jenkinsci/commons-compress-api-plugin/releases/tag/commons-compress-api-1.27.1-1

<!-- Optional: add a release summary here -->
## 📦 Dependency updates

* Update zstd (#23) @basil
* Bump org.tukaani:xz from 1.9 to 1.10 (#8) @dependabot
* Bump org.apache.commons:commons-compress from 1.26.1 to 1.27.1 (#12) @dependabot
* Bump io.jenkins.plugins:commons-lang3-api from 3.14.0-76.vda_5591261cfe to 3.17.0-84.vb_b_938040b_078 (#14) @dependabot
* Bump org.jenkins-ci.plugins:plugin from 4.86 to 4.88 (#16) @dependabot
* Bump org.jenkins-ci.plugins:plugin from 4.85 to 4.86 (#9) @dependabot
* Bump org.jenkins-ci.plugins:plugin from 4.84 to 4.85 (#6) @dependabot
* Bump io.jenkins.plugins:commons-lang3-api from 3.13.0-62.v7d18e55f51e2 to 3.14.0-76.vda_5591261cfe (#4) @dependabot
* Bump org.jenkins-ci.plugins:plugin from 4.83 to 4.84 (#5) @dependabot


target: target#updateRecipesYaml
------------------------

**Dry Run enabled**

DEBUG: checkout git branch "updatecli_main_c58adbdc2f6bec5bb62800917367afdca3ab88f50f330ce20b41685cea186805", based on "main"
DEBUG: Checking if branch "updatecli_main_c58adbdc2f6bec5bb62800917367afdca3ab88f50f330ce20b41685cea186805" diverged from "main":
DEBUG:  all good,branch "updatecli_main_c58adbdc2f6bec5bb62800917367afdca3ab88f50f330ce20b41685cea186805" is ahead of "main"
DEBUG: Relative path detected: changing from "./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml" to absolute path from SCM: "/tmp/updatecli/github/jenkins-infra/plugin-modernizer-tool/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml"
DEBUG: Match found for pattern "(pluginArtifactId: commons-compress-api\\n)(.*\\n)(.*pluginVersion:) .*" in file "./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml"
"./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml" updated with [dry run] content "$1$2$3 1.27.1-1"

```
--- ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -142,7 +142,7 @@
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: commons-compress-api
       # TODO: version from bom and filtered here ? or managed by renovate ?
-      pluginVersion: 1.26.1-2
+      pluginVersion: 1.27.1-1
       replaces:
         - groupId: org.apache.commons
           artifactId: commons-compress

```

⚠ - 1 file(s) updated with "$1$2$3 1.27.1-1":
        * ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
DEBUG: Checking if local changes have been done that should be published
DEBUG: no changes detected between branches "main" and "updatecli_main_c58adbdc2f6bec5bb62800917367afdca3ab88f50f330ce20b41685cea186805"


ACTIONS
========


Update compress-api plugin version
  => Update compress-api plugin version to 1.27.1-1

DEBUG: No CI pipeline detected (Unknown CI Engine.)
[Dry Run] An action of kind "github/pullrequest" is expected.
DEBUG: The expected action would have the following information:
        |
        |       ##Title:
        |       Update compress-api plugin version to 1.27.1-1
        |       ##Report:
        |
        |       <Action id="c58adbdc2f6bec5bb62800917367afdca3ab88f50f330ce20b41685cea186805">
        |           <h3>Update compress-api plugin version</h3>
        |           <details id="18b771348c288fa118fcb781107011692cd04ad380ccd0231f148c224dccfbf4">
        |               <summary>Update compress-api plugin version in recipes.yml</summary>
        |               <p>1 file(s) updated with &#34;$1$2$3 1.27.1-1&#34;:&#xA;&#x9;* ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml&#xA;</p>
        |               <details>
        |                   <summary>1.27.1-1</summary>
        |                   <pre>&#xA;Release published on the 2024-12-13 07:58:03 +0000 UTC at the url https://github.com/jenkinsci/commons-compress-api-plugin/releases/tag/commons-compress-api-1.27.1-1&#xA;&#xA;&lt;!-- Optional: add a release summary here --&gt;&#xD;&#xA;## 📦 Dependency updates&#xD;&#xA;&#xD;&#xA;* Update zstd (#23) @basil&#xD;&#xA;* Bump org.tukaani:xz from 1.9 to 1.10 (#8) @dependabot&#xD;&#xA;* Bump org.apache.commons:commons-compress from 1.26.1 to 1.27.1 (#12) @dependabot&#xD;&#xA;* Bump io.jenkins.plugins:commons-lang3-api from 3.14.0-76.vda_5591261cfe to 3.17.0-84.vb_b_938040b_078 (#14) @dependabot&#xD;&#xA;* Bump org.jenkins-ci.plugins:plugin from 4.86 to 4.88 (#16) @dependabot&#xD;&#xA;* Bump org.jenkins-ci.plugins:plugin from 4.85 to 4.86 (#9) @dependabot&#xD;&#xA;* Bump org.jenkins-ci.plugins:plugin from 4.84 to 4.85 (#6) @dependabot&#xD;&#xA;* Bump io.jenkins.plugins:commons-lang3-api from 3.13.0-62.v7d18e55f51e2 to 3.14.0-76.vda_5591261cfe (#4) @dependabot&#xD;&#xA;* Bump org.jenkins-ci.plugins:plugin from 4.83 to 4.84 (#5) @dependabot&#xD;&#xA;</pre>
        |               </details>
        |           </details>
        |       </Action>
        |
        |       =====
        |
DEBUG: The expected action would have the following information:
        |
        |       ##Title:
        |       Update compress-api plugin version to 1.27.1-1
        |
        |
        |       ##Report:
        |
        |       <Action id="c58adbdc2f6bec5bb62800917367afdca3ab88f50f330ce20b41685cea186805">
        |           <h3>Update compress-api plugin version</h3>
        |           <details id="18b771348c288fa118fcb781107011692cd04ad380ccd0231f148c224dccfbf4">
        |               <summary>Update compress-api plugin version in recipes.yml</summary>
        |               <p>1 file(s) updated with &#34;$1$2$3 1.27.1-1&#34;:&#xA;&#x9;* ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml&#xA;</p>
        |               <details>
        |                   <summary>1.27.1-1</summary>
        |                   <pre>&#xA;Release published on the 2024-12-13 07:58:03 +0000 UTC at the url https://github.com/jenkinsci/commons-compress-api-plugin/releases/tag/commons-compress-api-1.27.1-1&#xA;&#xA;&lt;!-- Optional: add a release summary here --&gt;&#xD;&#xA;## 📦 Dependency updates&#xD;&#xA;&#xD;&#xA;* Update zstd (#23) @basil&#xD;&#xA;* Bump org.tukaani:xz from 1.9 to 1.10 (#8) @dependabot&#xD;&#xA;* Bump org.apache.commons:commons-compress from 1.26.1 to 1.27.1 (#12) @dependabot&#xD;&#xA;* Bump io.jenkins.plugins:commons-lang3-api from 3.14.0-76.vda_5591261cfe to 3.17.0-84.vb_b_938040b_078 (#14) @dependabot&#xD;&#xA;* Bump org.jenkins-ci.plugins:plugin from 4.86 to 4.88 (#16) @dependabot&#xD;&#xA;* Bump org.jenkins-ci.plugins:plugin from 4.85 to 4.86 (#9) @dependabot&#xD;&#xA;* Bump org.jenkins-ci.plugins:plugin from 4.84 to 4.85 (#6) @dependabot&#xD;&#xA;* Bump io.jenkins.plugins:commons-lang3-api from 3.13.0-62.v7d18e55f51e2 to 3.14.0-76.vda_5591261cfe (#4) @dependabot&#xD;&#xA;* Bump org.jenkins-ci.plugins:plugin from 4.83 to 4.84 (#5) @dependabot&#xD;&#xA;</pre>
        |               </details>
        |           </details>
        |       </Action>
        |
        |       =====
        |

=============================

SUMMARY:



⚠ Update compress-api plugin version:
        Source:
                ✔ [latestCompressApiVersion]
        Target:
                ⚠ [updateRecipesYaml] Update compress-api plugin version in recipes.yml


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
