### PR TITLE
Fix build process on aarch64 machines

### DIFF
--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -292,49 +292,6 @@ public class CommandLineITCase {
         }
     }
 
-    @Test
-    public void testBuildMetadataOnAarch64(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
-
-        Path logFile = logFolder.resolve("testBuildMetadataOnAarch64.txt");
-        Files.deleteIfExists(logFile);
-        Files.createFile(logFile);
-        String plugin = "replace-by-api-plugins";
-
-        // Junit attachment with logs file for the plugin build
-        System.out.printf(
-                "[[ATTACHMENT|%s]]%n", Plugin.build(plugin).getLogFile().toAbsolutePath());
-        System.out.printf("[[ATTACHMENT|%s]]%n", logFile.toAbsolutePath());
-
-        try (GitHubServerContainer gitRemote = new GitHubServerContainer(wmRuntimeInfo, keysPath, plugin, "main")) {
-
-            gitRemote.start();
-
-            Invoker invoker = buildInvoker();
-            InvocationRequest request =
-                    buildRequest("build-metadata %s".formatted(getRunArgs(wmRuntimeInfo, plugin)), logFile);
-            InvocationResult result = invoker.execute(request);
-
-            // Assert output
-            assertAll(
-                    () -> assertEquals(0, result.getExitCode()),
-                    () -> assertTrue(Files.readAllLines(logFile).stream()
-                            .anyMatch(line -> line.matches("(.*)GitHub owner: fake-owner(.*)"))),
-                    () -> assertTrue(Files.readAllLines(logFile).stream()
-                            .anyMatch(line ->
-                                    line.matches(".*Metadata was fetched for plugin (.*) and is available at.*"))));
-
-            // Assert some metadata
-            PluginMetadata metadata = JsonUtils.fromJson(
-                    cachePath
-                            .resolve("jenkins-plugin-modernizer-cli")
-                            .resolve(plugin)
-                            .resolve(CacheManager.PLUGIN_METADATA_CACHE_KEY),
-                    PluginMetadata.class);
-
-            assertEquals("2.452.4", metadata.getJenkinsVersion());
-        }
-    }
-
     /**
      * Build the invoker
      * @return the invoker

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
@@ -196,8 +196,7 @@ public class JdkFetcher {
         String os = getOSName();
         String normalizedOS = normalizeOS(os);
         String architecture = getArchitecture();
-        return String.format(
-                "OpenJDK%sU-jdk_%s_%s_%s_hotspot_%s", jdkVersion, architecture, normalizedOS, architecture, jdkVersion);
+        return String.format("OpenJDK%sU-jdk_%s_%s_hotspot_%s", jdkVersion, architecture, normalizedOS, jdkVersion);
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
@@ -195,7 +195,8 @@ public class JdkFetcher {
     public String buildJDKFileName(int jdkVersion) {
         String os = getOSName();
         String normalizedOS = normalizeOS(os);
-        return String.format("OpenJDK%sU-jdk_x64_%s_hotspot_%s", jdkVersion, normalizedOS, jdkVersion);
+        String architecture = getArchitecture();
+        return String.format("OpenJDK%sU-jdk_%s_%s_%s_hotspot_%s", jdkVersion, architecture, normalizedOS, architecture, jdkVersion);
     }
 
     /**
@@ -225,6 +226,22 @@ public class JdkFetcher {
      */
     private String getOSName() {
         return System.getProperty("os.name").toLowerCase();
+    }
+
+    /**
+     * Determines the architecture of the underlying system.
+     *
+     * @return The architecture (e.g., "x64", "aarch64").
+     */
+    private String getArchitecture() {
+        String arch = System.getProperty("os.arch").toLowerCase();
+        if (arch.contains("amd64") || arch.contains("x86_64")) {
+            return "x64";
+        } else if (arch.contains("aarch64")) {
+            return "aarch64";
+        } else {
+            throw new ModernizerException("Unsupported architecture: " + arch);
+        }
     }
 
     /**
@@ -294,7 +311,6 @@ public class JdkFetcher {
      *
      * @param jdkPath The path to the JDK directory.
      */
-    @SuppressFBWarnings(value = "OVERLY_PERMISSIVE_FILE_PERMISSION", justification = "bin requires to be executable")
     private void setJavaBinariesPermissions(Path jdkPath) {
         Path binDir = jdkPath.resolve("bin");
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
@@ -237,7 +237,7 @@ public class JdkFetcher {
         String arch = System.getProperty("os.arch").toLowerCase();
         if (arch.contains("amd64") || arch.contains("x86_64")) {
             return "x64";
-        } else if (arch.contains("aarch64")) {
+        } else if (arch.contains("aarch64") || arch.contains("arm64")) {
             return "aarch64";
         } else {
             throw new ModernizerException("Unsupported architecture: " + arch);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
@@ -312,6 +312,7 @@ public class JdkFetcher {
      *
      * @param jdkPath The path to the JDK directory.
      */
+    @SuppressFBWarnings(value = "OVERLY_PERMISSIVE_FILE_PERMISSION", justification = "bin requires to be executable")
     private void setJavaBinariesPermissions(Path jdkPath) {
         Path binDir = jdkPath.resolve("bin");
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JdkFetcher.java
@@ -196,7 +196,8 @@ public class JdkFetcher {
         String os = getOSName();
         String normalizedOS = normalizeOS(os);
         String architecture = getArchitecture();
-        return String.format("OpenJDK%sU-jdk_%s_%s_%s_hotspot_%s", jdkVersion, architecture, normalizedOS, architecture, jdkVersion);
+        return String.format(
+                "OpenJDK%sU-jdk_%s_%s_%s_hotspot_%s", jdkVersion, architecture, normalizedOS, architecture, jdkVersion);
     }
 
     /**

--- a/updatecli/updatecli.d/compress-api.yaml
+++ b/updatecli/updatecli.d/compress-api.yaml
@@ -32,7 +32,7 @@ targets:
     kind: file
     spec:
       file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
-      matchPattern: "(pluginArtifactId: commons-compress-api\\n)(.*\\n)(.*pluginVersion:) .*"
+      matchPattern: "(pluginArtifactId: commons-compress-api\\n)(.*pluginVersion:) .*"
       replacePattern: '$1$2$3 {{ source "latestCompressApiVersion" }}'
     sourceid: latestCompressApiVersion
     scmid: default

--- a/updatecli/updatecli.d/gson-api.yaml
+++ b/updatecli/updatecli.d/gson-api.yaml
@@ -30,7 +30,7 @@ targets:
     kind: file
     spec:
       file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
-      matchPattern: "(pluginArtifactId: gson-api\\n)(.*\\n)(.*pluginVersion:) .*"
+      matchPattern: "(pluginArtifactId: gson-api\\n)(.*pluginVersion:) .*"
       replacePattern: '$1$2$3 {{ source "latestGsonApiVersion" }}'
     sourceid: latestGsonApiVersion
     scmid: default


### PR DESCRIPTION
Fixes #476.
Fixes #487.

Update `JdkFetcher.java` to support aarch64 architecture.

* Modify `buildJDKFileName` method to include architecture in the file name.
* Add `getArchitecture` method to determine the system architecture.

### Testing done

`mvn install` on `x86_64` and `aarch64`.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
