### PR TITLE
Add updatecli manifest to upgrade more plugins

### DIFF
--- a/updatecli/updatecli.d/asm-api.yaml
+++ b/updatecli/updatecli.d/asm-api.yaml
@@ -1,0 +1,46 @@
+name: Update asm-api plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestAsmApiVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "asm-api-plugin"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateRecipesYaml:
+    name: "Update asm-api plugin version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+      matchPattern: "(pluginArtifactId: asm-api\\n)(.*pluginVersion:) .*"
+      replacePattern: '$1$2$3 {{ source "latestAsmApiVersion" }}'
+    sourceid: latestAsmApiVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update asm-api plugin version to {{ source "latestAsmApiVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli

--- a/updatecli/updatecli.d/byte-buddy-api.yaml
+++ b/updatecli/updatecli.d/byte-buddy-api.yaml
@@ -1,0 +1,46 @@
+name: Update byte-buddy-api plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestByteBuddyApiVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "byte-buddy-api-plugin"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateRecipesYaml:
+    name: "Update byte-buddy-api plugin version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+      matchPattern: "(pluginArtifactId: byte-buddy-api\\n)(.*pluginVersion:) .*"
+      replacePattern: '$1$2$3 {{ source "latestByteBuddyApiVersion" }}'
+    sourceid: latestByteBuddyApiVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update byte-buddy-api plugin version to {{ source "latestByteBuddyApiVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli

--- a/updatecli/updatecli.d/commons-lang3-api.yaml
+++ b/updatecli/updatecli.d/commons-lang3-api.yaml
@@ -1,0 +1,46 @@
+name: Update commons-lang3-api plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestCommonsLang3ApiPlugin:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "commons-lang3-api-plugin"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateRecipesYaml:
+    name: "Update commons-lang3-api plugin version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+      matchPattern: "(pluginArtifactId: commons-lang3-api\\n)(.*pluginVersion:) .*"
+      replacePattern: '$1$2$3 {{ source "latestCommonsLang3ApiPlugin" }}'
+    sourceid: latestCommonsLang3ApiPlugin
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update commons-lang3-api plugin version to {{ source "latestCommonsLang3ApiPlugin" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli

--- a/updatecli/updatecli.d/commons-text-api.yaml
+++ b/updatecli/updatecli.d/commons-text-api.yaml
@@ -1,0 +1,46 @@
+name: Update commons-text-api plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestCommonsTextApiVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "commons-text-api"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateRecipesYaml:
+    name: "Update commons-text-api plugin version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+      matchPattern: "(pluginArtifactId: commons-text-api\\n)(.*pluginVersion:) .*"
+      replacePattern: '$1$2$3 {{ source "latestCommonsTextApiVersion" }}'
+    sourceid: latestCommonsTextApiVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update json-api plugin version to {{ source "latestCommonsTextApiVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli

--- a/updatecli/updatecli.d/joda-time-api.yaml
+++ b/updatecli/updatecli.d/joda-time-api.yaml
@@ -1,0 +1,46 @@
+name: Update joda-time-api plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestJodaTimeApiVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "joda-time-api-plugin"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateRecipesYaml:
+    name: "Update joda-time-api plugin version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+      matchPattern: "(pluginArtifactId: joda-time-api\\n)(.*pluginVersion:) .*"
+      replacePattern: '$1$2$3 {{ source "latestJodaTimeApiVersion" }}'
+    sourceid: latestJodaTimeApiVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update joda-time-api plugin version to {{ source "latestJodaTimeApiVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli

--- a/updatecli/updatecli.d/json-api.yaml
+++ b/updatecli/updatecli.d/json-api.yaml
@@ -1,0 +1,46 @@
+name: Update json-api plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestJsonApiVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "json-api-plugin"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateRecipesYaml:
+    name: "Update json-api plugin version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+      matchPattern: "(pluginArtifactId: json-api\\n)(.*pluginVersion:) .*"
+      replacePattern: '$1$2$3 {{ source "latestJsonApiVersion" }}'
+    sourceid: latestJsonApiVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update json-api plugin version to {{ source "latestJsonApiVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli

--- a/updatecli/updatecli.d/json-path-api.yaml
+++ b/updatecli/updatecli.d/json-path-api.yaml
@@ -1,0 +1,46 @@
+name: Update json-path-api plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestJsonPathApiVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "json-path-api-plugin"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateRecipesYaml:
+    name: "Update json-api plugin version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+      matchPattern: "(pluginArtifactId: json-path-api\\n)(.*pluginVersion:) .*"
+      replacePattern: '$1$2$3 {{ source "latestJsonPathApiVersion" }}'
+    sourceid: latestJsonPathApiVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update json-path-api plugin version to {{ source "latestJsonPathApiVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli


### PR DESCRIPTION
Add updatecli manifest to upgrade more plugins

- asm-api
- json-api
- json-path-api
- byte-buddy-api
- commons-text-api
- commons-lang3-api
- joda-time-api

### Testing done

`updatecli diff` on added manifests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
