### PR TITLE
Copy metadata to cache instead of moving it

### DIFF
--- a/plugin-modernizer-cli/pom.xml
+++ b/plugin-modernizer-cli/pom.xml
@@ -50,6 +50,10 @@
       <version>3.3.0</version>
     </dependency>
     <dependency>
+      <groupId>org.openrewrite</groupId>
+      <artifactId>rewrite-core</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
@@ -61,12 +65,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <!-- Test dependencies -->
     <dependency>
       <groupId>io.github.sparsick.testcontainers.gitserver</groupId>
       <artifactId>testcontainers-gitserver</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- Test dependencies -->
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>apache-maven</artifactId>

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
@@ -15,7 +15,10 @@ import picocli.CommandLine;
 /**
  * Run command
  */
-@CommandLine.Command(name = "build-metadata", description = "Build local metadata")
+@CommandLine.Command(
+        name = "build-metadata",
+        aliases = {"fetch-metadata"},
+        description = "Build local metadata")
 public class BuildMetadataCommand implements ICommand {
 
     /**

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -263,6 +263,15 @@ public class CommandLineITCase {
                             .resolve(CacheManager.PLUGIN_METADATA_CACHE_KEY),
                     PluginMetadata.class);
 
+            // Metadata should be still present on target folder (it should be copied to be reused by recipes not aware of the
+            // cache or external storage)
+            assertTrue(Files.exists(cachePath
+                    .resolve("jenkins-plugin-modernizer-cli")
+                    .resolve(plugin)
+                    .resolve("sources")
+                    .resolve("target")
+                    .resolve(CacheManager.PLUGIN_METADATA_CACHE_KEY)));
+
             assertEquals(expectedMetadata.getJenkinsVersion(), metadata.getJenkinsVersion());
         }
     }

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -75,6 +75,12 @@ public class CommandLineITCase {
                 }),
                 Arguments.of(new PluginMetadata() {
                     {
+                        setPluginName("empty-no-bom");
+                        setJenkinsVersion("2.452.4");
+                    }
+                }),
+                Arguments.of(new PluginMetadata() {
+                    {
                         setPluginName("replace-by-api-plugins");
                         setJenkinsVersion("2.452.4");
                     }
@@ -263,7 +269,8 @@ public class CommandLineITCase {
                             .resolve(CacheManager.PLUGIN_METADATA_CACHE_KEY),
                     PluginMetadata.class);
 
-            // Metadata should be still present on target folder (it should be copied to be reused by recipes not aware of the
+            // Metadata should be still present on target folder (it should be copied to be reused by recipes not aware
+            // of the
             // cache or external storage)
             assertTrue(Files.exists(cachePath
                     .resolve("jenkins-plugin-modernizer-cli")

--- a/plugin-modernizer-cli/src/test/resources/empty-no-bom/.gitignore
+++ b/plugin-modernizer-cli/src/test/resources/empty-no-bom/.gitignore
@@ -1,0 +1,15 @@
+target
+
+# mvn hpi:run
+work
+
+# IntelliJ IDEA project files
+*.iml
+*.iws
+*.ipr
+.idea
+
+# Eclipse project files
+.settings
+.classpath
+.project

--- a/plugin-modernizer-cli/src/test/resources/empty-no-bom/Jenkinsfile
+++ b/plugin-modernizer-cli/src/test/resources/empty-no-bom/Jenkinsfile
@@ -1,0 +1,11 @@
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/plugin-modernizer-cli/src/test/resources/empty-no-bom/pom.xml
+++ b/plugin-modernizer-cli/src/test/resources/empty-no-bom/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.88</version>
+    <relativePath />
+  </parent>
+
+  <groupId>io.jenkins.plugins</groupId>
+  <artifactId>empty-no-bom</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+
+  <name>Empty No Bom Plugin</name>
+
+  <properties>
+    <jenkins.version>2.452.4</jenkins.version>
+    <spotless.check.skip>false</spotless.check.skip>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/plugin-modernizer-cli/src/test/resources/empty-no-bom/rewrite.yml
+++ b/plugin-modernizer-cli/src/test/resources/empty-no-bom/rewrite.yml
@@ -1,0 +1,7 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.Debug
+displayName: Debug recipe
+description: Debug recipe
+conditions: []
+recipeList: []

--- a/plugin-modernizer-cli/src/test/resources/empty-no-bom/src/main/resources/index.jelly
+++ b/plugin-modernizer-cli/src/test/resources/empty-no-bom/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    Replace by API plugins
+    Empty no bom
 </div>

--- a/plugin-modernizer-cli/src/test/resources/empty/src/main/resources/index.jelly
+++ b/plugin-modernizer-cli/src/test/resources/empty/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    TODO
+    Empty
 </div>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollector.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollector.java
@@ -3,28 +3,23 @@ package io.jenkins.tools.pluginmodernizer.core.extractor;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmodernizer.core.model.JDK;
 import io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.openrewrite.ExecutionContext;
-import org.openrewrite.FindSourceFiles;
-import org.openrewrite.Preconditions;
-import org.openrewrite.ScanningRecipe;
-import org.openrewrite.SourceFile;
-import org.openrewrite.Tree;
-import org.openrewrite.TreeVisitor;
+import org.openrewrite.*;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.marker.Markers;
+import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.maven.tree.Parent;
@@ -44,6 +39,27 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
      */
     private static final Logger LOG = LoggerFactory.getLogger(MetadataCollector.class);
 
+    public MetadataCollector() {}
+
+    public MetadataCollector(boolean force, boolean search) {
+        this.force = force;
+        this.search = search;
+    }
+
+    @Option(
+            displayName = "Force collection of metadata. Default to false",
+            required = false,
+            description = "Force the collection of metadata. If false will reuse the existing metadata if any.",
+            example = "true")
+    boolean force = false;
+
+    @Option(
+            displayName = "Search for metadata Default to false",
+            required = false,
+            description = "Search for metadata. If true will search for metadata.",
+            example = "true")
+    boolean search = false;
+
     @Override
     public String getDisplayName() {
         return "Plugin metadata extractor";
@@ -58,12 +74,12 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
      * Accumulator to store metadata.
      */
     public static class MetadataAccumulator {
-        private final List<ArchetypeCommonFile> commonFiles = new ArrayList<>();
-        private final Set<MetadataFlag> flags = new HashSet<>();
-        private final Set<JDK> jdkVersions = new HashSet<>();
+        private final List<ArchetypeCommonFile> commonFiles = new LinkedList<>();
+        private final Set<MetadataFlag> flags = new LinkedHashSet<>();
+        private final Set<JDK> jdkVersions = new LinkedHashSet<>();
 
         public List<ArchetypeCommonFile> getCommonFiles() {
-            return commonFiles;
+            return commonFiles.stream().sorted().collect(Collectors.toList());
         }
 
         public Set<JDK> getJdkVersions() {
@@ -82,7 +98,7 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
             return flags;
         }
 
-        public void addFlags(List<MetadataFlag> flags) {
+        public void addFlags(Set<MetadataFlag> flags) {
             this.flags.addAll(flags);
         }
     }
@@ -211,6 +227,21 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
 
+                final PluginMetadata pluginMetadata = new PluginMetadata();
+
+                if (!force) {
+                    // Check if metadata already exists
+                    if (pluginMetadata.exists()) {
+                        PluginMetadata refreshedMetadata = pluginMetadata.refresh();
+                        LOG.info("Metadata already exists, skipping metadata extraction");
+                        LOG.info("Metadata: {}", JsonUtils.toJson(refreshedMetadata));
+                        if (search) {
+                            return SearchResult.found(document, JsonUtils.toJson(refreshedMetadata));
+                        }
+                        return document.withMarkers(document.getMarkers().add(refreshedMetadata));
+                    }
+                }
+
                 // Ensure maven resolution result is present
                 Markers markers = document.getMarkers();
                 Optional<MavenResolutionResult> mavenResolutionResult = markers.findFirst(MavenResolutionResult.class);
@@ -236,7 +267,6 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
                 properties.remove("basedir");
 
                 // Construct the plugin metadata
-                PluginMetadata pluginMetadata = new PluginMetadata();
                 pluginMetadata.setPluginName(pom.getName());
                 Parent parent = pom.getParent();
                 if (parent != null) {
@@ -259,8 +289,10 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
                 pluginMetadata.save();
                 LOG.debug("Plugin metadata written to {}", pluginMetadata.getRelativePath());
                 LOG.debug(JsonUtils.toJson(pluginMetadata));
-
-                return document;
+                if (search) {
+                    return SearchResult.found(document, JsonUtils.toJson(pluginMetadata));
+                }
+                return document.withMarkers(document.getMarkers().add(pluginMetadata));
             }
         };
     }
@@ -273,7 +305,7 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
         /**
          * Detected flag
          */
-        private final List<MetadataFlag> flags = new ArrayList<>();
+        private final Set<MetadataFlag> flags = new LinkedHashSet<>();
 
         /**
          * Convert an OpenRewrite XML tag to a metadata XML tag.
@@ -311,7 +343,7 @@ public class MetadataCollector extends ScanningRecipe<MetadataCollector.Metadata
          * Get the flags for this visitor.
          * @return flags for this visitor
          */
-        public List<MetadataFlag> getFlags() {
+        public Set<MetadataFlag> getFlags() {
             return flags;
         }
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
@@ -7,16 +7,17 @@ import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.PreconditionError;
 import java.io.Serializable;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import org.openrewrite.marker.Marker;
 
 /**
  * Metadata of a plugin extracted from its POM file or code
  */
-public class PluginMetadata extends CacheEntry<PluginMetadata> implements Serializable {
+public class PluginMetadata extends CacheEntry<PluginMetadata> implements Serializable, Marker {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient UUID id;
 
     /**
      * Name of the plugin
@@ -206,5 +207,16 @@ public class PluginMetadata extends CacheEntry<PluginMetadata> implements Serial
 
     public void setProperties(Map<String, String> properties) {
         this.properties = properties;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public PluginMetadata withId(UUID id) {
+        this.id = id;
+        return this;
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -323,7 +323,7 @@ public class PluginModernizer {
      */
     private void collectMetadata(Plugin plugin) {
         plugin.collectMetadata(mavenInvoker);
-        plugin.moveMetadata(cacheManager);
+        plugin.copyMetadata(cacheManager);
         plugin.loadMetadata(cacheManager);
         plugin.enrichMetadata(pluginService);
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -727,12 +727,12 @@ public class Plugin {
     }
 
     /**
-     * Move metadata from plugin target directory to cache
+     * Copy metadata from plugin target directory to cache
      * @param cacheManager The cache manager
      */
-    public void moveMetadata(CacheManager cacheManager) {
+    public void copyMetadata(CacheManager cacheManager) {
         CacheManager pluginCacheManager = buildPluginTargetDirectoryCacheManager();
-        setMetadata(pluginCacheManager.move(
+        setMetadata(pluginCacheManager.copy(
                 cacheManager,
                 Path.of(getName()),
                 CacheManager.PLUGIN_METADATA_CACHE_KEY,
@@ -741,20 +741,6 @@ public class Plugin {
                 "Moved plugin {} metadata to cache: {}",
                 getName(),
                 getMetadata().getLocation().toAbsolutePath());
-    }
-
-    /**
-     * Read the target metadata of the plugin. Generally to use after running recipes to get the updated metadata
-     */
-    public PluginMetadata readTargetMetadata() {
-        CacheManager pluginCacheManager = buildPluginTargetDirectoryCacheManager();
-        PluginMetadata metadata = pluginCacheManager.get(
-                pluginCacheManager.root(), CacheManager.PLUGIN_METADATA_CACHE_KEY, PluginMetadata.class);
-        if (metadata == null) {
-            addError("Failed to read target metadata for plugin " + getName());
-            raiseLastError();
-        }
-        return metadata;
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -738,7 +738,7 @@ public class Plugin {
                 CacheManager.PLUGIN_METADATA_CACHE_KEY,
                 new PluginMetadata(pluginCacheManager)));
         LOG.debug(
-                "Moved plugin {} metadata to cache: {}",
+                "Copied plugin {} metadata to cache: {}",
                 getName(),
                 getMetadata().getLocation().toAbsolutePath());
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingBom.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingBom.java
@@ -1,12 +1,10 @@
 package io.jenkins.tools.pluginmodernizer.core.recipes;
 
+import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
 import java.util.Optional;
 import org.openrewrite.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
-import org.openrewrite.maven.tree.MavenResolutionResult;
-import org.openrewrite.maven.tree.Pom;
-import org.openrewrite.maven.tree.ResolvedPom;
 import org.openrewrite.xml.XmlVisitor;
 import org.openrewrite.xml.tree.Xml;
 
@@ -31,22 +29,14 @@ public class IsUsingBom extends Recipe {
             @Override
             public Xml visitDocument(Xml.Document document, ExecutionContext ctx) {
 
-                // Ensure maven resolution result is present
+                // Ensure PluginMetadata is present
                 Markers markers = document.getMarkers();
-                Optional<MavenResolutionResult> mavenResolutionResult = markers.findFirst(MavenResolutionResult.class);
-                if (mavenResolutionResult.isEmpty()) {
+                Optional<PluginMetadata> pluginMetadata = markers.findFirst(PluginMetadata.class);
+                if (pluginMetadata.isEmpty()) {
                     return document;
                 }
-                // Get the pom
-                MavenResolutionResult resolutionResult = mavenResolutionResult.get();
-                ResolvedPom resolvedPom = resolutionResult.getPom();
-                Pom pom = resolvedPom.getRequested();
 
-                // Check if the project is using Jenkins bom
-                boolean isUsingBom = pom.getDependencyManagement().stream()
-                        .anyMatch(dependency -> dependency.getGroupId().equals("io.jenkins.tools.bom"));
-
-                if (isUsingBom) {
+                if (pluginMetadata.get().getBomVersion() != null) {
                     return SearchResult.found(document, "Project is using Jenkins bom");
                 }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtils.java
@@ -45,7 +45,7 @@ public class JsonUtils {
      */
     public static void toJsonFile(Object object, Path path) {
         try {
-            LOG.trace("Writing JSON file to {}", path);
+            LOG.debug("Writing JSON file to {}", path);
             FileUtils.writeStringToFile(path.toFile(), gson.toJson(object), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new ModernizerException("Unable to write JSON file due to IO error", e);

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -5,7 +5,8 @@ displayName: Fetch metadata
 description: Extracts metadata from a Jenkins plugin
 tags: ['extractor']
 recipeList:
-  - io.jenkins.tools.pluginmodernizer.core.extractor.MetadataCollector
+  - io.jenkins.tools.pluginmodernizer.core.extractor.MetadataCollector:
+      force: true
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.AddPluginsBom
@@ -355,6 +356,16 @@ recipeList:
   - org.openrewrite.jenkins.AddJellyXmlDeclaration
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.SearchMetadata
+displayName: Search for metadata and make it available for other recipes
+description: Search for metadata and make it available for other recipes
+tags: ['condition']
+recipeList:
+  - io.jenkins.tools.pluginmodernizer.core.extractor.MetadataCollector:
+      force: false
+      search: true
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.conditions.IsUsingRecommendCoreVersion
 displayName: Check if the plugin is using the recommended core version
 description: Check if the plugin is using the recommended core version
@@ -380,3 +391,12 @@ tags: ['condition']
 recipeList:
   - org.openrewrite.jenkins.IsJenkinsPlugin:
       version: "[2.489,)" # Adapt when LTS
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.conditions.IsUsingBom
+displayName: Check if a plugin is using a BOM
+description: Check if a plugin is using a BOM
+tags: ['condition']
+recipeList:
+  - io.jenkins.tools.pluginmodernizer.SearchMetadata
+  - io.jenkins.tools.pluginmodernizer.core.recipes.IsUsingBom

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollectorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataCollectorTest.java
@@ -1,21 +1,50 @@
 package io.jenkins.tools.pluginmodernizer.core.extractor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 import io.jenkins.tools.pluginmodernizer.core.model.JDK;
-import java.util.Map;
-import java.util.Set;
+import io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils;
+import java.util.*;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 public class MetadataCollectorTest implements RewriteTest {
+
+    private static final PluginMetadata EXPECTED_POM_METADATA;
+
+    static {
+        EXPECTED_POM_METADATA = new PluginMetadata();
+        EXPECTED_POM_METADATA.setPluginName("GitLab Plugin");
+        EXPECTED_POM_METADATA.setParentVersion("4.80");
+        EXPECTED_POM_METADATA.setJenkinsVersion("2.426.3");
+        EXPECTED_POM_METADATA.setBomVersion("2950.va_633b_f42f759");
+        Map<String, String> properties = new LinkedHashMap<>();
+        properties.put("revision", "1.8.1");
+        properties.put("java.level", "8");
+        properties.put("changelist", "-SNAPSHOT");
+        properties.put("jenkins.version", "2.426.3");
+        properties.put("spotbugs.effort", "Max");
+        properties.put("spotbugs.threshold", "Low");
+        properties.put("gitHubRepo", "jenkinsci/${project.artifactId}");
+        properties.put("hpi.compatibleSinceVersion", "1.4.0");
+        properties.put("mockserver.version", "5.15.0");
+        properties.put("spotless.check.skip", "false");
+        EXPECTED_POM_METADATA.setProperties(properties);
+        List<ArchetypeCommonFile> commonFiles = new LinkedList<>();
+        commonFiles.add(ArchetypeCommonFile.JENKINSFILE);
+        commonFiles.add(ArchetypeCommonFile.POM);
+        EXPECTED_POM_METADATA.setCommonFiles(commonFiles);
+        Set<MetadataFlag> flags = new LinkedHashSet<>();
+        flags.add(MetadataFlag.DEVELOPER_SET);
+        flags.add(MetadataFlag.LICENSE_SET);
+        flags.add(MetadataFlag.SCM_HTTPS);
+        flags.add(MetadataFlag.MAVEN_REPOSITORIES_HTTPS);
+        EXPECTED_POM_METADATA.setFlags(flags);
+    }
 
     @Language("xml")
     private static final String POM_XML =
@@ -30,7 +59,7 @@ public class MetadataCollectorTest implements RewriteTest {
                             <relativePath />
                           </parent>
 
-                          <artifactId>gitx  lab-plugin</artifactId>
+                          <artifactId>gitlab-plugin</artifactId>
                           <version>${revision}${changelist}</version>
                           <packaging>hpi</packaging>
                           <name>GitLab Plugin</name>
@@ -132,51 +161,29 @@ public class MetadataCollectorTest implements RewriteTest {
                         </project>
                         """;
 
-    @Override
-    public void defaults(RecipeSpec spec) {
-        spec.recipe(new MetadataCollector());
-    }
-
     @Test
     void testPluginWithJenkinsfileWithoutJdkInfo() throws Exception {
+        EXPECTED_POM_METADATA.setJdks(Set.of());
+        EXPECTED_POM_METADATA.setJdks(Collections.emptySet());
         rewriteRun(
+                recipeSpec -> recipeSpec.recipe(new MetadataCollector(true, true)),
                 // language=groovy
                 groovy(
                         """
                           buildPlugin()
                           """,
                         spec -> spec.path("Jenkinsfile")),
-                pomXml(POM_XML));
-        PluginMetadata pluginMetadata = new PluginMetadata().refresh();
-        String pluginName = pluginMetadata.getPluginName();
-        assertEquals("GitLab Plugin", pluginName);
-        assertEquals("4.80", pluginMetadata.getParentVersion());
-        String jenkinsVersion = pluginMetadata.getJenkinsVersion();
-        assertEquals("2.426.3", jenkinsVersion);
-        assertEquals("2950.va_633b_f42f759", pluginMetadata.getBomVersion());
-        assertNotNull(pluginMetadata.getProperties().get("java.level"));
-        assertTrue(pluginMetadata.hasFlag(MetadataFlag.SCM_HTTPS));
-        assertTrue(pluginMetadata.hasFlag(MetadataFlag.MAVEN_REPOSITORIES_HTTPS));
-        assertTrue(pluginMetadata.hasFlag(MetadataFlag.LICENSE_SET));
-        assertTrue(pluginMetadata.hasFlag(MetadataFlag.DEVELOPER_SET));
-        Map<String, String> properties = pluginMetadata.getProperties();
-        assertNotNull(properties);
-        assertEquals(10, properties.size());
-
-        // Files are present
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM));
-
-        // Absent
-        assertFalse(pluginMetadata.hasFile(ArchetypeCommonFile.WORKFLOW_CD));
-
-        Set<JDK> jdkVersion = pluginMetadata.getJdks();
-        assertEquals(0, jdkVersion.size());
+                pomXml(POM_XML, "<!--~~(" + JsonUtils.toJson(EXPECTED_POM_METADATA) + ")~~>-->" + POM_XML));
     }
 
     @Test
     void testPluginWithJenkinsfileWithJdkInfo() {
+        Set<JDK> jdks = new LinkedHashSet<>();
+        jdks.add(JDK.JAVA_21);
+        jdks.add(JDK.JAVA_17);
+        EXPECTED_POM_METADATA.setJdks(jdks);
         rewriteRun(
+                recipeSpec -> recipeSpec.recipe(new MetadataCollector(true, true)),
                 // language=groovy
                 groovy(
                         """
@@ -188,7 +195,7 @@ public class MetadataCollectorTest implements RewriteTest {
                          ])
                          """,
                         spec -> spec.path("Jenkinsfile")),
-                pomXml(POM_XML));
+                pomXml(POM_XML, "<!--~~(" + JsonUtils.toJson(EXPECTED_POM_METADATA) + ")~~>-->" + POM_XML));
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         // Files are present
         assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
@@ -203,7 +210,12 @@ public class MetadataCollectorTest implements RewriteTest {
 
     @Test
     void testJenkinsfileWithConfigurationsAsParameter() {
+        Set<JDK> jdks = new LinkedHashSet<>();
+        jdks.add(JDK.JAVA_11);
+        jdks.add(JDK.JAVA_17);
+        EXPECTED_POM_METADATA.setJdks(jdks);
         rewriteRun(
+                recipeSpec -> recipeSpec.recipe(new MetadataCollector(true, true)),
                 // language=groovy
                 groovy(
                         """
@@ -223,7 +235,7 @@ public class MetadataCollectorTest implements RewriteTest {
                             buildPlugin(params)
                             """,
                         spec -> spec.path("Jenkinsfile")),
-                pomXml(POM_XML));
+                pomXml(POM_XML, "<!--~~(" + JsonUtils.toJson(EXPECTED_POM_METADATA) + ")~~>-->" + POM_XML));
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
@@ -232,7 +244,12 @@ public class MetadataCollectorTest implements RewriteTest {
 
     @Test
     void testJenkinsfileWithInlineConfigurations() {
+        Set<JDK> jdks = new LinkedHashSet<>();
+        jdks.add(JDK.JAVA_11);
+        jdks.add(JDK.JAVA_17);
+        EXPECTED_POM_METADATA.setJdks(jdks);
         rewriteRun(
+                recipeSpec -> recipeSpec.recipe(new MetadataCollector(true, true)),
                 // language=groovy
                 groovy(
                         """
@@ -249,7 +266,7 @@ public class MetadataCollectorTest implements RewriteTest {
                                 jacoco: [sourceCodeRetention: 'MODIFIED'])
                             """,
                         spec -> spec.path("Jenkinsfile")),
-                pomXml(POM_XML));
+                pomXml(POM_XML, "<!--~~(" + JsonUtils.toJson(EXPECTED_POM_METADATA) + ")~~>-->" + POM_XML));
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
         Set<JDK> jdkVersion = pluginMetadata.getJdks();

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingBomTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingBomTest.java
@@ -2,20 +2,16 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
+import io.jenkins.tools.pluginmodernizer.core.extractor.MetadataCollector;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 public class IsUsingBomTest implements RewriteTest {
 
-    @Override
-    public void defaults(RecipeSpec spec) {
-        spec.recipe(new IsUsingBom());
-    }
-
     @Test
     void testNotUsingBom() throws Exception {
         rewriteRun(
+                spec -> spec.recipe(new IsUsingBom()),
                 pomXml(
                         """
                  <?xml version="1.0" encoding="UTF-8"?>
@@ -51,6 +47,8 @@ public class IsUsingBomTest implements RewriteTest {
     @Test
     void testWithBom() throws Exception {
         rewriteRun(
+                spec -> spec.recipes(new MetadataCollector(true, false), new IsUsingBom())
+                        .expectedCyclesThatMakeChanges(2),
                 pomXml(
                         """
                  <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
- Copy metadata to cache instead of moving it
- Add attribute on recipe to force the rebuild
- Store the metadata on the pom.xml so it can be consumed

Idea is to not "manually" perform metadata collection before a recipes but add is as a first recipe.

So that later recipes applied on the trees can lookup for the marker instead of relying of ready manually the data from any storage

The build-metadata` will remains to force the rebuild on populate the local storage

### Testing done

Automated tests

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
