### PR TITLE
Add updatecli manifest to keep parent plugin pom update to date

### DIFF
--- a/updatecli/updatecli.d/plugin-pom.yaml
+++ b/updatecli/updatecli.d/plugin-pom.yaml
@@ -1,0 +1,48 @@
+name: Update plugin pom version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestPluginPomVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "plugin-pom"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+    transformers:
+      - trimprefix: "plugin-"
+
+targets:
+  updateVersionsProperties:
+    name: "Update plugin-pom version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/versions.properties
+      matchPattern: "(jenkins.parent.version =) (.*)"
+      replacePattern: '$1 {{ source "latestPluginPomVersion" }}'
+    sourceid: latestPluginPomVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update plugin-pom version to {{ source "latestPluginPomVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli


### PR DESCRIPTION
Add updatecli manifest to keep parent plugin pom update to date

### Testing done

updatecli diff --config updatecli/updatecli.d/plugin-pom.yaml  --values updatecli/values.github-action.yaml

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
