### PR TITLE
Add visitor to add and remove a comment for properties and `jenkins.baseline` migration

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
@@ -254,6 +254,13 @@ public class PluginMetadata extends CacheEntry<PluginMetadata> implements Serial
         this.properties = properties;
     }
 
+    public void addProperty(String key, String value) {
+        if (properties == null) {
+            properties = new HashMap<>();
+        }
+        properties.put(key, value);
+    }
+
     @Override
     public UUID getId() {
         return id;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Recipe.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Recipe.java
@@ -19,6 +19,9 @@ public class Recipe {
     @JsonIgnore
     private Object preconditions; // Use Object to avoid mapping complex nested structures.
 
+    @JsonIgnore
+    private Boolean causesAnotherCycle;
+
     public String getName() {
         return name;
     }
@@ -69,5 +72,17 @@ public class Recipe {
 
     public Object getPreconditions() {
         return preconditions;
+    }
+
+    public void setPreconditions(Object preconditions) {
+        this.preconditions = preconditions;
+    }
+
+    public Boolean getCausesAnotherCycle() {
+        return causesAnotherCycle;
+    }
+
+    public void setCausesAnotherCycle(Boolean causesAnotherCycle) {
+        this.causesAnotherCycle = causesAnotherCycle;
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddBeforePropertyVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddBeforePropertyVisitor.java
@@ -1,0 +1,84 @@
+package io.jenkins.tools.pluginmodernizer.core.visitors;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.tree.Content;
+import org.openrewrite.xml.tree.Xml;
+
+/**
+ * A visitor that add a maven property before another property.
+ * If the property already exists, it will update its value.
+ * If the previous property does not exist, the new property will not be added.
+ */
+public class AddBeforePropertyVisitor extends MavenIsoVisitor<ExecutionContext> {
+
+    /**
+     * The previous property name to add the new property before.
+     */
+    private final String previousPropertyName;
+
+    /**
+     * The property name to add.
+     */
+    private final String propertyName;
+
+    /**
+     * The property value to add.
+     */
+    private final String propertyValue;
+
+    /**
+     * Constructor of the visitor.
+     * @param previousPropertyName The previous property name to add the new property before.
+     * @param propertyName The property name to add.
+     * @param propertyValue The property value to add.
+     */
+    public AddBeforePropertyVisitor(String previousPropertyName, String propertyName, String propertyValue) {
+        this.previousPropertyName = previousPropertyName;
+        this.propertyName = propertyName;
+        this.propertyValue = propertyValue;
+    }
+
+    @Override
+    public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext executionContext) {
+        tag = super.visitTag(tag, executionContext);
+        if (tag.getName().equals("properties")) {
+
+            // Ensure previous
+            Xml.Tag previousPropertyTag = tag.getChild(previousPropertyName).orElse(null);
+            if (previousPropertyTag == null) {
+                return tag;
+            }
+
+            // Ensure value if exists
+            Xml.Tag existingPropertyTag = tag.getChild(propertyName).orElse(null);
+            if (existingPropertyTag != null && existingPropertyTag.getValue().isPresent()) {
+                // doAfterVisit(new ChangeTagValueVisitor<>(existingPropertyTag, propertyValue));
+                return tag;
+            }
+
+            if (tag.getContent() == null || tag.getContent().isEmpty()) {
+                return tag;
+            }
+
+            List<Content> contents = new ArrayList<>(tag.getContent());
+            int propertyIndex = contents.indexOf(previousPropertyTag);
+
+            // If there are comments leave them as they are
+            while (propertyIndex > 0 && contents.get(propertyIndex - 1) instanceof Xml.Comment) {
+                propertyIndex--;
+            }
+
+            // Place the tag just before the property or on first element of the sequence
+            Xml.Tag propertyTag = Xml.Tag.build("<" + propertyName + ">" + propertyValue + "</" + propertyName + ">");
+            propertyTag = propertyTag.withPrefix(previousPropertyTag.getPrefix());
+            contents.add(propertyIndex, propertyTag);
+
+            tag = tag.withContent(contents);
+        }
+
+        return tag;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddPropertyCommentVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddPropertyCommentVisitor.java
@@ -1,0 +1,80 @@
+package io.jenkins.tools.pluginmodernizer.core.visitors;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Tree;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.tree.Content;
+import org.openrewrite.xml.tree.Xml;
+
+/**
+ * A visitor that add a comment before a maven property.
+ * If a comment already exists, it's updated.
+ */
+public class AddPropertyCommentVisitor extends MavenIsoVisitor<ExecutionContext> {
+
+    /**
+     * The property name to add the comment before.
+     */
+    private final String propertyName;
+
+    /**
+     * The comment to add.
+     */
+    private final String comment;
+
+    /**
+     * Constructor of the visitor.
+     * @param propertyName The property name to add the comment before.
+     * @param comment The comment to add.
+     */
+    public AddPropertyCommentVisitor(String propertyName, String comment) {
+        this.propertyName = propertyName;
+        this.comment = comment;
+    }
+
+    @Override
+    public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext executionContext) {
+        tag = super.visitTag(tag, executionContext);
+        if (tag.getName().equals("properties")) {
+
+            // Ensure property exists
+            Xml.Tag propertyTag = tag.getChild(propertyName).orElse(null);
+            if (propertyTag == null) {
+                return tag;
+            }
+
+            if (tag.getContent() == null) {
+                return tag;
+            }
+
+            List<Content> contents = new ArrayList<>(tag.getContent());
+            int propertyIndex = contents.indexOf(propertyTag);
+
+            // Add or update comment
+            if (propertyTag.getContent() != null) {
+                boolean containsComment = contents.stream()
+                        .anyMatch(c -> c instanceof Xml.Comment && comment.equals(((Xml.Comment) c).getText()));
+
+                // Add comment if not exists
+                if (!containsComment) {
+
+                    // If there is a comment just before, remove it
+                    if (propertyIndex > 0 && contents.get(propertyIndex - 1) instanceof Xml.Comment xmlComment) {
+                        propertyIndex--;
+                        contents.remove(propertyIndex);
+                        doAfterVisit(new RemovePropertyCommentVisitor(xmlComment.getText()));
+                    }
+
+                    Xml.Comment customComment = new Xml.Comment(
+                            Tree.randomId(), contents.get(propertyIndex).getPrefix(), Markers.EMPTY, comment);
+                    contents.add(propertyIndex, customComment);
+                    tag = tag.withContent(contents);
+                }
+            }
+        }
+        return tag;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitor.java
@@ -1,0 +1,43 @@
+package io.jenkins.tools.pluginmodernizer.core.visitors;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.tree.Content;
+import org.openrewrite.xml.tree.Xml;
+
+public class RemovePropertyCommentVisitor extends MavenIsoVisitor<ExecutionContext> {
+
+    private String comment;
+
+    public RemovePropertyCommentVisitor(String comment) {
+        this.comment = comment;
+    }
+
+    @Override
+    public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext executionContext) {
+        tag = super.visitTag(tag, executionContext);
+        if (tag.getName().equals("properties")) {
+
+            List<Content> contents = new ArrayList<>(tag.getContent());
+
+            // Remove the comment if needed
+            boolean containsComment = contents.stream()
+                    .anyMatch(c -> c instanceof Xml.Comment && comment.equals(((Xml.Comment) c).getText()));
+
+            // Add comment if not exists
+            if (containsComment) {
+                for (int i = 0; i < contents.size(); i++) {
+                    if (contents.get(i) instanceof Xml.Comment
+                            && comment.equals(((Xml.Comment) contents.get(i)).getText())) {
+                        contents.remove(i);
+                        break;
+                    }
+                }
+                tag = tag.withContent(contents);
+            }
+        }
+        return tag;
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -27,7 +27,6 @@ description: Migrate pom to using jenkins.baseline property if bom is present.
 tags: ['chore']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.core.recipes.IsUsingBom
-  - io.jenkins.tools.pluginmodernizer.core.recipes.IsMissingJenkinsBaselineProperty
 recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateToJenkinsBaseLineProperty
 ---
@@ -57,6 +56,7 @@ displayName: Upgrade to the next major parent version (5.X) requiring Jenkins 2.
 description: Upgrade to the next major parent version (5.X) requiring Jenkins 2.479 and Java 17.
 tags: ['dependencies']
 recipeList:
+  - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
   - org.openrewrite.maven.UpgradeParentVersion:
       groupId: org.jenkins-ci.plugins
       artifactId: plugin
@@ -281,6 +281,7 @@ displayName: Upgrade to latest recommended core version and ensure the bom is ma
 description: Upgrade to latest recommended core version and ensure the bom is matching the core version.
 tags: ['developer']
 recipeList:
+  - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
   - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
   - org.openrewrite.jenkins.UpgradeVersionProperty:
       key: jenkins.version
@@ -291,13 +292,14 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion
 displayName: Upgrade to latest LTS core version supporting Java 11
-description: Upgrade to latest LTS core version supporting Java 11
+description: Upgrade to latest LTS core version supporting Java 11.
 tags: ['developer']
 recipeList:
+  - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
+  - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
   - org.openrewrite.jenkins.UpgradeVersionProperty:
       key: jenkins.version
       minimumVersion: 2.462.3
-  - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
 ---

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -111,6 +111,17 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <jenkins.baseline>2.440</jenkins.baseline>
                       <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                    </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
                    <repositories>
                      <repository>
                        <id>repo.jenkins-ci.org</id>
@@ -141,9 +152,118 @@ public class DeclarativeRecipesTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
+                      <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
                       <jenkins.baseline>2.452</jenkins.baseline>
                       <jenkins.version>${jenkins.baseline}.4</jenkins.version>
                    </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                 """));
+    }
+
+    @Test
+    void upgradeToUpgradeToLatestJava11CoreVersion() {
+        rewriteRun(
+                spec -> spec.recipeFromResource(
+                        "/META-INF/rewrite/recipes.yml",
+                        "io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion"),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.55</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                      <jenkins.version>2.440.3</jenkins.version>
+                   </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-2.440.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.88</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                      <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                      <jenkins.baseline>2.462</jenkins.baseline>
+                      <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                   </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
                    <repositories>
                      <repository>
                        <id>repo.jenkins-ci.org</id>
@@ -261,6 +381,17 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <jenkins.baseline>2.462</jenkins.baseline>
                       <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                    </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
                    <repositories>
                      <repository>
                        <id>repo.jenkins-ci.org</id>
@@ -291,9 +422,21 @@ public class DeclarativeRecipesTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
+                      <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
                       <jenkins.baseline>2.479</jenkins.baseline>
                       <jenkins.version>${jenkins.baseline}.1</jenkins.version>
                    </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
                    <repositories>
                      <repository>
                        <id>repo.jenkins-ci.org</id>
@@ -372,6 +515,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
+                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
                      <jenkins.baseline>2.440</jenkins.baseline>
                      <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                    </properties>
@@ -474,6 +618,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
+                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
                      <jenkins.baseline>2.440</jenkins.baseline>
                      <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                    </properties>

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateToJenkinsBaseLinePropertyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateToJenkinsBaseLinePropertyTest.java
@@ -28,6 +28,7 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
+                        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
                         <jenkins.baseline>2.452</jenkins.baseline>
                         <jenkins.version>${jenkins.baseline}.4</jenkins.version>
                    </properties>
@@ -122,6 +123,204 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
+                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                     <jenkins.baseline>2.452</jenkins.baseline>
+                     <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+                   </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                         <version>3814.v9563d972079a_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                """));
+    }
+
+    @Test
+    void testAddComment() {
+        rewriteRun(
+                spec -> spec.recipe(new MigrateToJenkinsBaseLineProperty()),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.88</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                     <jenkins.baseline>2.452</jenkins.baseline>
+                     <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+                   </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-2.452.x</artifactId>
+                         <version>3814.v9563d972079a_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.88</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                     <jenkins.baseline>2.452</jenkins.baseline>
+                     <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+                   </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                         <version>3814.v9563d972079a_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                """));
+    }
+
+    @Test
+    void testAddBaselineWithOtherProperties() {
+        rewriteRun(
+                spec -> spec.recipe(new MigrateToJenkinsBaseLineProperty()),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.88</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- My properties -->
+                   <properties>
+                     <!-- My property -->
+                     <foo.bar>baz</foo.bar>
+                     <jenkins.version>2.452.4</jenkins.version>
+                   </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-2.452.x</artifactId>
+                         <version>3814.v9563d972079a_</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.88</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- My properties -->
+                   <properties>
+                     <!-- My property -->
+                     <foo.bar>baz</foo.bar>
+                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
                      <jenkins.baseline>2.452</jenkins.baseline>
                      <jenkins.version>${jenkins.baseline}.4</jenkins.version>
                    </properties>
@@ -216,6 +415,7 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
+                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
                      <jenkins.baseline>2.479</jenkins.baseline>
                      <jenkins.version>${jenkins.baseline}.1</jenkins.version>
                    </properties>

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddBeforePropertyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddBeforePropertyTest.java
@@ -1,0 +1,154 @@
+package io.jenkins.tools.pluginmodernizer.core.visitors;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.xml.tree.Xml;
+
+/**
+ * A visitor that add a maven property before another property.
+ */
+public class AddBeforePropertyTest implements RewriteTest {
+
+    @Test
+    void addProperty() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new AddBeforePropertyVisitor("jenkins.version", "jenkins.baseline", "2.440"));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                 """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                        <jenkins.baseline>2.440</jenkins.baseline>
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                  """));
+    }
+
+    @Test
+    void addPropertyWithOtherProperties() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new AddBeforePropertyVisitor("jenkins.version", "jenkins.baseline", "2.440"));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                        <foo.bar>baz</foo.bar>
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                 """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                        <foo.bar>baz</foo.bar>
+                        <jenkins.baseline>2.440</jenkins.baseline>
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                  """));
+    }
+
+    @Test
+    void addPropertyWithOtherPropertiesWithComment() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new AddBeforePropertyVisitor("jenkins.version", "jenkins.baseline", "2.440"));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- Properties -->
+                   <properties>
+                        <!-- Just a property -->
+                        <foo.bar>baz</foo.bar>
+                        <bar.bar>foo</bar.bar>
+                        <!-- Jenkins version -->
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                 """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- Properties -->
+                   <properties>
+                        <!-- Just a property -->
+                        <foo.bar>baz</foo.bar>
+                        <bar.bar>foo</bar.bar>
+                        <jenkins.baseline>2.440</jenkins.baseline>
+                        <!-- Jenkins version -->
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                  """));
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddPropertyCommentVisitorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddPropertyCommentVisitorTest.java
@@ -1,0 +1,153 @@
+package io.jenkins.tools.pluginmodernizer.core.visitors;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.xml.tree.Xml;
+
+/**
+ * Tests for {@link AddPropertyCommentVisitor}.
+ */
+public class AddPropertyCommentVisitorTest implements RewriteTest {
+
+    @Test
+    void addPropertyComment() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new AddPropertyCommentVisitor("jenkins.version", " This is the jenkins version "));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                        <!-- This is the jenkins version -->
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                 """));
+    }
+
+    @Test
+    void addPropertyCommentWithOtherProperties() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new AddPropertyCommentVisitor("jenkins.version", " This is the jenkins version "));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- My properties -->
+                   <properties>
+                        <my.other.property>value</my.other.property>
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- My properties -->
+                   <properties>
+                        <my.other.property>value</my.other.property>
+                        <!-- This is the jenkins version -->
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                 """));
+    }
+
+    @Test
+    void replacePropertyComment() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new AddPropertyCommentVisitor("jenkins.version", " This is the jenkins version "));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- My properties -->
+                   <properties>
+                        <!-- My other property -->
+                        <my.other.property>value</my.other.property>
+                        <!-- Unrelated comment -->
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- My properties -->
+                   <properties>
+                        <!-- My other property -->
+                        <my.other.property>value</my.other.property>
+                        <!-- This is the jenkins version -->
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                 """));
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitorTest.java
@@ -1,0 +1,64 @@
+package io.jenkins.tools.pluginmodernizer.core.visitors;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.xml.tree.Xml;
+
+/**
+ * A visitor that remove a property comment.
+ */
+public class RemovePropertyCommentVisitorTest implements RewriteTest {
+
+    @Test
+    void replacePropertyComment() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new RemovePropertyCommentVisitor(" My other property "));
+                        doAfterVisit(new RemovePropertyCommentVisitor(" Unrelated comment "));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- My properties -->
+                   <properties>
+                        <!-- My other property -->
+                        <my.other.property>value</my.other.property>
+                        <!-- Unrelated comment -->
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                 """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- My properties -->
+                   <properties>
+                        <my.other.property>value</my.other.property>
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                  """));
+    }
+}


### PR DESCRIPTION
Replace `AddPropertyVisitor` which is pure XML and doesn't care about tag position by our own visitor that ensure `jenkins.baseline` is added just before `jenkins.version`

Add some other visitor to set pom properties comment

### Testing done

Automated tests

One test is failing because of position of properties

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
