### PR TITLE
Several improvements and fixes on recipes

### DIFF
--- a/plugin-modernizer-cli/pom.xml
+++ b/plugin-modernizer-cli/pom.xml
@@ -65,6 +65,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.18.0</version>
+      <scope>test</scope>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>io.github.sparsick.testcontainers.gitserver</groupId>

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -25,6 +25,7 @@ import java.security.PrivateKey;
 import java.security.Security;
 import java.util.Properties;
 import java.util.stream.Stream;
+import org.apache.commons.io.FileUtils;
 import org.apache.maven.shared.invoker.DefaultInvocationRequest;
 import org.apache.maven.shared.invoker.DefaultInvoker;
 import org.apache.maven.shared.invoker.InvocationRequest;
@@ -119,7 +120,6 @@ public class CommandLineITCase {
                 () -> assertEquals(0, result2.getExitCode()),
                 () -> assertTrue(Files.readAllLines(logFile).stream()
                         .anyMatch(line -> line.matches("plugin modernizer ([a-zA-Z0-9.\\-_]+) (.*)"))));
-
         InvocationResult result3 = invoker.execute(buildRequest("version --short", logFile));
         assertAll(
                 () -> assertEquals(0, result3.getExitCode()),
@@ -312,6 +312,21 @@ public class CommandLineITCase {
                     () -> assertEquals(0, result.getExitCode()),
                     () -> assertTrue(Files.readAllLines(logFile1).stream()
                             .anyMatch(line -> line.matches("(.*)Dry run mode. Changes were commited on (.*)"))));
+
+            // Delete target folder to use data from cache
+            File targetDirectory = cachePath
+                    .resolve("jenkins-plugin-modernizer-cli")
+                    .resolve(plugin)
+                    .resolve("sources")
+                    .resolve("target")
+                    .toFile();
+            FileUtils.deleteDirectory(targetDirectory);
+
+            // Ensure metadata is still present on cache
+            assertTrue(Files.exists(cachePath
+                    .resolve("jenkins-plugin-modernizer-cli")
+                    .resolve(plugin)
+                    .resolve(CacheManager.PLUGIN_METADATA_CACHE_KEY)));
 
             // Ensure it still works after running again (with caching)
             InvocationRequest request2 = buildRequest(

--- a/plugin-modernizer-cli/src/test/resources/replace-by-api-plugins/Jenkinsfile
+++ b/plugin-modernizer-cli/src/test/resources/replace-by-api-plugins/Jenkinsfile
@@ -1,0 +1,11 @@
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -165,6 +165,27 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>4.0.1</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Recipes test dependencies -->
+    <dependency>
+      <groupId>org.kohsuke.stapler</groupId>
+      <artifactId>stapler</artifactId>
+      <version>1928.v9115fe47607f</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.openrewrite</groupId>
@@ -177,6 +198,7 @@
       <version>2.1.7</version>
       <scope>test</scope>
     </dependency>
+
   </dependencies>
 
   <build>
@@ -206,6 +228,27 @@
       </resource>
     </resources>
     <plugins>
+
+      <!-- Used to copy openrewrite test dependencies to a separate directory for running java recipes -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.8.1</version>
+        <executions>
+          <execution>
+            <id>copy-dependencies</id>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <outputDirectory>${project.build.directory}/openrewrite-classpath</outputDirectory>
+              <!-- Adapt when testing java transformation -->
+              <includeGroupIds>javax.servlet,jakarta.servlet,org.kohsuke.stapler</includeGroupIds>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>gg.jte</groupId>
         <artifactId>jte-maven-plugin</artifactId>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -192,6 +192,10 @@ public class Settings {
         return readProperty("jenkins.parent.version", "versions.properties");
     }
 
+    public static @Nullable String getBomVersion() {
+        return readProperty("bom.version", "versions.properties");
+    }
+
     private static @Nullable URL getUpdateCenterUrl() throws MalformedURLException {
         String url = System.getenv("JENKINS_UC");
         if (url != null) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataVisitor.java
@@ -66,7 +66,7 @@ public class MetadataVisitor extends TreeVisitor<Tree, ExecutionContext> {
         // Extract metadata from POM
         else if (PathUtils.matchesGlob(sourceFile.getSourcePath(), "**/pom.xml")) {
             LOG.debug("Visiting POM {}", sourceFile.getSourcePath());
-            PluginMetadata pomMetadata = new PomVisitor().reduce(tree, pluginMetadata);
+            PluginMetadata pomMetadata = new PomResolutionVisitor().reduce(tree, pluginMetadata);
             LOG.debug("POM metadata: {}", JsonUtils.toJson(pomMetadata));
             executionContext.putMessage("pomMetadata", pomMetadata); // Is there better than context messaging ?
             return tree;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PomResolutionVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PomResolutionVisitor.java
@@ -12,12 +12,23 @@ import org.openrewrite.xml.tree.Xml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class PomVisitor extends MavenIsoVisitor<PluginMetadata> {
+/**
+ * A pom visitor that accumulate PluginMetadata using maven resolution result.
+ * Maven resolution might not get updated if the tree is modified by other visitor
+ * So it's best used in preconditons recipes to avoid side effect
+ * An other implementation of this visitor could be extraction from the tree instead of maven resolution result
+ */
+public class PomResolutionVisitor extends MavenIsoVisitor<PluginMetadata> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(PomVisitor.class);
+    /**
+     * LOGGER.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(PomResolutionVisitor.class);
 
     @Override
     public Xml.Document visitDocument(Xml.Document document, PluginMetadata pluginMetadata) {
+
+        document = super.visitDocument(document, pluginMetadata);
 
         Markers markers = getCursor().firstEnclosingOrThrow(Xml.Document.class).getMarkers();
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsMissingBom.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsMissingBom.java
@@ -1,7 +1,7 @@
 package io.jenkins.tools.pluginmodernizer.core.recipes;
 
 import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
-import io.jenkins.tools.pluginmodernizer.core.extractor.PomVisitor;
+import io.jenkins.tools.pluginmodernizer.core.extractor.PomResolutionVisitor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -37,7 +37,7 @@ public class IsMissingBom extends Recipe {
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
 
-                PluginMetadata pluginMetadata = new PomVisitor().reduce(document, new PluginMetadata());
+                PluginMetadata pluginMetadata = new PomResolutionVisitor().reduce(document, new PluginMetadata());
 
                 if (pluginMetadata.getBomVersion() == null) {
                     LOG.info("Project is missing Jenkins BOM");

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsMissingJenkinsBaselineProperty.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsMissingJenkinsBaselineProperty.java
@@ -1,7 +1,7 @@
 package io.jenkins.tools.pluginmodernizer.core.recipes;
 
 import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
-import io.jenkins.tools.pluginmodernizer.core.extractor.PomVisitor;
+import io.jenkins.tools.pluginmodernizer.core.extractor.PomResolutionVisitor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -37,7 +37,7 @@ public class IsMissingJenkinsBaselineProperty extends Recipe {
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
 
-                PluginMetadata pluginMetadata = new PomVisitor().reduce(document, new PluginMetadata());
+                PluginMetadata pluginMetadata = new PomResolutionVisitor().reduce(document, new PluginMetadata());
 
                 if (!pluginMetadata.getProperties().containsKey("jenkins.baseline")) {
                     LOG.info("Project is missing jenkins.baseline property");

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingBom.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingBom.java
@@ -1,7 +1,7 @@
 package io.jenkins.tools.pluginmodernizer.core.recipes;
 
 import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
-import io.jenkins.tools.pluginmodernizer.core.extractor.PomVisitor;
+import io.jenkins.tools.pluginmodernizer.core.extractor.PomResolutionVisitor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -37,7 +37,7 @@ public class IsUsingBom extends Recipe {
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
 
-                PluginMetadata pluginMetadata = new PomVisitor().reduce(document, new PluginMetadata());
+                PluginMetadata pluginMetadata = new PomResolutionVisitor().reduce(document, new PluginMetadata());
 
                 if (pluginMetadata.getBomVersion() != null) {
                     LOG.info("Project is using Jenkins bom at version {}", pluginMetadata.getBomVersion());

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateToJenkinsBaseLineProperty.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateToJenkinsBaseLineProperty.java
@@ -1,31 +1,40 @@
 package io.jenkins.tools.pluginmodernizer.core.recipes;
 
 import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
-import io.jenkins.tools.pluginmodernizer.core.extractor.PomVisitor;
+import io.jenkins.tools.pluginmodernizer.core.extractor.PomResolutionVisitor;
 import io.jenkins.tools.pluginmodernizer.core.visitors.AddBeforePropertyVisitor;
 import io.jenkins.tools.pluginmodernizer.core.visitors.AddPropertyCommentVisitor;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.Cursor;
 import org.openrewrite.maven.AddPropertyVisitor;
+import org.openrewrite.maven.ChangeManagedDependencyGroupIdAndArtifactId;
 import org.openrewrite.maven.MavenIsoVisitor;
-import org.openrewrite.xml.ChangeTagValueVisitor;
 import org.openrewrite.xml.tree.Xml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A recipe to migrate the pom.xml to use the jenkins.baseLine property.
+ * Doesn't upgrade the jenkins version or bom version.
+ * If the plugin is not using the bom or using the weekly baseline, it will skip the update.
+ * This will also fix the bom version if it doesn't match the jenkins.version.
+ */
 public class MigrateToJenkinsBaseLineProperty extends Recipe {
 
+    /**
+     * Logger for the class.
+     */
     public static final Logger LOG = LoggerFactory.getLogger(MigrateToJenkinsBaseLineProperty.class);
 
     @Override
     public String getDisplayName() {
-        return "Migrate to Jenkins baseline property";
+        return "Update the pom.xml to use newly introduced jenkins.baseline property";
     }
 
     @Override
     public String getDescription() {
-        return "Migrate to Jenkins baseline property.";
+        return "Update the pom.xml to use newly introduced jenkins.baseline property.";
     }
 
     @Override
@@ -47,8 +56,8 @@ public class MigrateToJenkinsBaseLineProperty extends Recipe {
         public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
             Xml.Document d = super.visitDocument(document, ctx);
 
-            // Skip if not bom or weekly bom
-            PluginMetadata pluginMetadata = new PomVisitor().reduce(document, new PluginMetadata());
+            // Skip if not using bom or using weekly baseline
+            PluginMetadata pluginMetadata = new PomResolutionVisitor().reduce(document, new PluginMetadata());
             if (pluginMetadata.getBomArtifactId() == null || "bom-weekly".equals(pluginMetadata.getBomArtifactId())) {
                 LOG.debug("Project is using Jenkins weekly bom or not bom, skipping");
                 return d;
@@ -58,6 +67,10 @@ public class MigrateToJenkinsBaseLineProperty extends Recipe {
             return document;
         }
 
+        /**
+         * Perform the update.
+         * @param document The document to update.
+         */
         private void performUpdate(Xml.Document document) {
 
             Xml.Tag jenkinsVersionTag = document.getRoot()
@@ -71,7 +84,7 @@ public class MigrateToJenkinsBaseLineProperty extends Recipe {
 
             // Keep only major and minor and ignore patch version
             String jenkinsVersion = jenkinsVersionTag.getValue().get();
-            String jenkinsBaseline = jenkinsVersionTag.getValue().get();
+            String jenkinsBaseline = jenkinsVersion;
             String jenkinsPatch = null;
 
             // It's a LTS, extract patch
@@ -102,20 +115,31 @@ public class MigrateToJenkinsBaseLineProperty extends Recipe {
             }
 
             // Change the bom artifact ID
-            Xml.Tag artifactIdTag = document.getRoot()
+            Xml.Tag bom = document.getRoot()
                     .getChild("dependencyManagement")
                     .flatMap(dm -> dm.getChild("dependencies"))
                     .flatMap(deps -> deps.getChild("dependency"))
                     .filter(dep -> dep.getChildValue("groupId")
                             .map("io.jenkins.tools.bom"::equals)
                             .orElse(false))
-                    .flatMap(dep -> dep.getChild("artifactId"))
                     .orElseThrow();
 
-            LOG.debug("Artifact ID is {}", artifactIdTag.getValue().get());
+            Xml.Tag artifactIdTag = bom.getChild("artifactId").orElseThrow();
+            Xml.Tag version = bom.getChild("version").orElseThrow();
 
+            LOG.debug("Artifact ID is {}", artifactIdTag.getValue().get());
+            LOG.debug("Version is {}", version.getValue().get());
+
+            // Change the artifact and perform upgrade
             if (!artifactIdTag.getValue().get().equals("bom-${jenkins.baseline}.x")) {
-                doAfterVisit(new ChangeTagValueVisitor<>(artifactIdTag, "bom-${jenkins.baseline}.x"));
+                doAfterVisit(new ChangeManagedDependencyGroupIdAndArtifactId(
+                                "io.jenkins.tools.bom",
+                                artifactIdTag.getValue().get(),
+                                "io.jenkins.tools.bom",
+                                "bom-${jenkins.baseline}.x",
+                                version.getValue().get(),
+                                "\\.v[a-f0-9_]+")
+                        .getVisitor());
             }
         }
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateBom.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateBom.java
@@ -1,0 +1,26 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import io.jenkins.tools.pluginmodernizer.core.visitors.UpdateBomVersionVisitor;
+import org.openrewrite.*;
+import org.openrewrite.maven.table.MavenMetadataFailures;
+
+/**
+ * A recipe that update the bom version to latest available.
+ */
+public class UpdateBom extends Recipe {
+
+    @Override
+    public @NlsRewrite.DisplayName String getDisplayName() {
+        return "Update bom recipe";
+    }
+
+    @Override
+    public @NlsRewrite.Description String getDescription() {
+        return "Update bom recipe.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new IsUsingBom(), new UpdateBomVersionVisitor(new MavenMetadataFailures(this)));
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsVersion.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsVersion.java
@@ -1,0 +1,61 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import org.openrewrite.*;
+import org.openrewrite.jenkins.UpgradeVersionProperty;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A recipe to upgrade the Jenkins version in the pom.xml.
+ * Take care of updating the bom or adding the bom if it's not present.
+ * Not changing anything if the version is already higher than the minimum version.
+ */
+public class UpgradeJenkinsVersion extends Recipe {
+
+    /**
+     * LOGGER.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(UpgradeJenkinsVersion.class);
+
+    /**
+     * The minimum version.
+     */
+    @Option(displayName = "Version", description = "The version.", example = "2.452.4")
+    String minimumVersion;
+
+    /**
+     * Constructor.
+     * @param minimumVersion The minimum version.
+     */
+    public UpgradeJenkinsVersion(String minimumVersion) {
+        this.minimumVersion = minimumVersion;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Upgrade Jenkins version";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Upgrade Jenkins version.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MavenIsoVisitor<>() {
+
+            @Override
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+
+                // Return another tree with jenkins version updated
+                document = (Xml.Document) new UpgradeVersionProperty("jenkins.version", minimumVersion)
+                        .getVisitor()
+                        .visitNonNull(document, ctx);
+                return (Xml.Document) new UpdateBom().getVisitor().visitNonNull(document, ctx);
+            }
+        };
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitor.java
@@ -7,10 +7,21 @@ import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.xml.tree.Content;
 import org.openrewrite.xml.tree.Xml;
 
+/**
+ * A visitor that remove a comment from a property in a maven pom file.
+ * Only a comment with exact match will be removed inside the properties block.
+ */
 public class RemovePropertyCommentVisitor extends MavenIsoVisitor<ExecutionContext> {
 
-    private String comment;
+    /**
+     * The comment to remove.
+     */
+    private final String comment;
 
+    /**
+     * Constructor of the visitor.
+     * @param comment The comment to remove.
+     */
     public RemovePropertyCommentVisitor(String comment) {
         this.comment = comment;
     }
@@ -20,7 +31,7 @@ public class RemovePropertyCommentVisitor extends MavenIsoVisitor<ExecutionConte
         tag = super.visitTag(tag, executionContext);
         if (tag.getName().equals("properties")) {
 
-            List<Content> contents = new ArrayList<>(tag.getContent());
+            List<Content> contents = new ArrayList<>(tag.getContent() != null ? tag.getContent() : List.of());
 
             // Remove the comment if needed
             boolean containsComment = contents.stream()

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/UpdateBomVersionVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/visitors/UpdateBomVersionVisitor.java
@@ -1,0 +1,109 @@
+package io.jenkins.tools.pluginmodernizer.core.visitors;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.maven.*;
+import org.openrewrite.maven.table.MavenMetadataFailures;
+import org.openrewrite.maven.trait.MavenDependency;
+import org.openrewrite.semver.LatestRelease;
+import org.openrewrite.semver.VersionComparator;
+import org.openrewrite.xml.ChangeTagValueVisitor;
+import org.openrewrite.xml.tree.Xml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A visitor that updates the BOM version in a maven pom file.
+ */
+public class UpdateBomVersionVisitor extends MavenIsoVisitor<ExecutionContext> {
+
+    /**
+     * LOGGER.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(UpdateBomVersionVisitor.class);
+
+    private transient MavenMetadataFailures metadataFailures;
+
+    /**
+     * Contructor
+     */
+    public UpdateBomVersionVisitor(MavenMetadataFailures metadataFailures) {
+        this.metadataFailures = metadataFailures;
+    }
+
+    @Override
+    public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+        document = super.visitDocument(document, ctx);
+
+        // Resolve artifact id
+        Xml.Tag bomTag = getBomTag(document);
+        Xml.Tag versionTag = bomTag.getChild("version").orElseThrow();
+        Xml.Tag getProperties = getProperties(document);
+
+        String artifactId =
+                bomTag.getChild("artifactId").orElseThrow().getValue().orElseThrow();
+        String version = bomTag.getChild("version").orElseThrow().getValue().orElseThrow();
+        LOG.debug("Updating bom version from {} to latest.release", version);
+        if (artifactId.equals("bom-${jenkins.baseline}.x")) {
+            artifactId =
+                    "bom-" + getProperties.getChildValue("jenkins.baseline").orElseThrow() + ".x";
+        }
+
+        String newBomVersionAvailable = findNewerBomVersion(artifactId, version, ctx);
+        if (newBomVersionAvailable == null) {
+            LOG.debug("No newer version available for {}", artifactId);
+            return document;
+        }
+
+        return (Xml.Document)
+                new ChangeTagValueVisitor<>(versionTag, newBomVersionAvailable).visitNonNull(document, ctx);
+    }
+
+    /**
+     * Find the newer bom version
+     * @param artifactId The artifact id
+     * @param currentVersion The current version
+     * @param ctx The execution context
+     * @return The newer bom version
+     */
+    private String findNewerBomVersion(String artifactId, String currentVersion, ExecutionContext ctx) {
+        VersionComparator latestRelease = new LatestRelease("\\.v[a-f0-9_]+");
+        try {
+            return MavenDependency.findNewerVersion(
+                    "io.jenkins.tools.bom",
+                    artifactId,
+                    currentVersion,
+                    getResolutionResult(),
+                    metadataFailures,
+                    latestRelease,
+                    ctx);
+        } catch (MavenDownloadingException e) {
+            LOG.warn("Failed to download metadata for {}", artifactId, e);
+            return null;
+        }
+    }
+
+    /**
+     * Get the bom tag from the document
+     * @param document The document
+     * @return The bom tag
+     */
+    private Xml.Tag getBomTag(Xml.Document document) {
+        return document.getRoot()
+                .getChild("dependencyManagement")
+                .flatMap(dm -> dm.getChild("dependencies"))
+                .flatMap(deps -> deps.getChild("dependency"))
+                .filter(dep -> dep.getChildValue("groupId")
+                        .map("io.jenkins.tools.bom"::equals)
+                        .orElse(false))
+                .orElseThrow();
+    }
+
+    /**
+     * Get the properties tag from the document
+     * @param document The document
+     * @return The properties tag
+     */
+    private Xml.Tag getProperties(Xml.Document document) {
+        return document.getRoot().getChild("properties").orElseThrow();
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -61,12 +61,21 @@ recipeList:
       groupId: org.jenkins-ci.plugins
       artifactId: plugin
       newVersion: 5.X
-  - org.openrewrite.jenkins.UpgradeVersionProperty:
-      key: jenkins.version
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: 2.479.1
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.kohsuke.stapler.StaplerRequest
       newFullyQualifiedTypeName: org.kohsuke.stapler.StaplerRequest2
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.kohsuke.stapler.Stapler getCurrentRequest()
+      newMethodName: getCurrentRequest2
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.kohsuke.stapler.Stapler getCurrentResponse()
+      newMethodName: getCurrentResponse2
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: javax.servlet
+      newPackageName: jakarta.servlet
+      recursive: false
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - org.openrewrite.maven.RemoveProperty: # Set by 5.x parent, ensure it's removed
       propertyName: maven.compiler.release
@@ -79,11 +88,7 @@ tags: ['dependencies']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.core.recipes.IsUsingBom
 recipeList:
-  - org.openrewrite.maven.UpgradeDependencyVersion:
-      groupId: io.jenkins.tools.bom
-      artifactId: "bom-*"
-      newVersion: latest.release
-      versionPattern: "\\.v[a-f0-9_]+"
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpdateBom
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -283,11 +288,11 @@ tags: ['developer']
 recipeList:
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
   - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
-  - org.openrewrite.jenkins.UpgradeVersionProperty:
-      key: jenkins.version
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: 2.452.4
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
+  - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion
@@ -297,11 +302,11 @@ tags: ['developer']
 recipeList:
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
   - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
-  - org.openrewrite.jenkins.UpgradeVersionProperty:
-      key: jenkins.version
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: 2.462.3
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
+  - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeToJava17

--- a/plugin-modernizer-core/src/main/resources/versions.properties
+++ b/plugin-modernizer-core/src/main/resources/versions.properties
@@ -1,5 +1,6 @@
 openrewrite.maven.plugin.version = ${openrewrite.maven.plugin.version}
 jenkins.parent.version = 5.4
+bom.version = 3850.vb_c5319efa_e29
 remediation.jenkins.minimum.version = 2.440.3
 remediation.jenkins.plugin.parent.version = 4.51
 remediation.bom.version = 3413.v0d896b_76a_30d

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsVersionTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsVersionTest.java
@@ -2,18 +2,23 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * Test for {@link MigrateToJenkinsBaseLineProperty}
+ * Test for {@link UpgradeJenkinsVersion}.
  */
-public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
+public class UpgradeJenkinsVersionTest implements RewriteTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UpgradeJenkinsVersionTest.class);
 
     @Test
-    void testNoChanges() {
+    void testPerformUpgradeWithoutBom() {
         rewriteRun(
-                spec -> spec.recipe(new MigrateToJenkinsBaseLineProperty()),
+                spec -> spec.recipe(new UpgradeJenkinsVersion("2.452.4")),
                 pomXml(
                         """
                  <?xml version="1.0" encoding="UTF-8"?>
@@ -22,7 +27,7 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                    <parent>
                      <groupId>org.jenkins-ci.plugins</groupId>
                      <artifactId>plugin</artifactId>
-                     <version>4.88</version>
+                     <version>4.87</version>
                      <relativePath />
                    </parent>
                    <groupId>io.jenkins.plugins</groupId>
@@ -31,16 +36,158 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
-                        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                        <jenkins.baseline>2.452</jenkins.baseline>
-                        <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+                     <jenkins.version>2.440.3</jenkins.version>
+                   </properties>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.87</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                     <jenkins.version>2.452.4</jenkins.version>
+                   </properties>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                 """));
+    }
+
+    @Test
+    void testPerformUpgradeWithBaselineWithoutBom() {
+        rewriteRun(
+                spec -> spec.recipe(new UpgradeJenkinsVersion("2.452.4")),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.87</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                     <jenkins.baseline>2.440</jenkins.baseline>
+                     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                   </properties>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.87</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                     <jenkins.baseline>2.452</jenkins.baseline>
+                     <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+                   </properties>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                 """));
+    }
+
+    @Test
+    void testPerformUpgradeWithoutBaselineWithBomAndUpgradeBomIfDoesntExistsForNewJenkinsVersion() {
+        rewriteRun(
+                spec -> spec.recipe(new UpgradeJenkinsVersion("2.452.4")),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.87</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                     <jenkins.version>2.440.3</jenkins.version>
                    </properties>
                    <dependencyManagement>
                      <dependencies>
                        <dependency>
                          <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                         <version>3814.v9563d972079a_</version>
+                         <artifactId>bom-2.440.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
                          <type>pom</type>
                          <scope>import</scope>
                        </dependency>
@@ -59,14 +206,7 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                      </pluginRepository>
                    </pluginRepositories>
                  </project>
-                """));
-    }
-
-    @Test
-    void testAddBaseline() {
-        rewriteRun(
-                spec -> spec.recipe(new MigrateToJenkinsBaseLineProperty()),
-                pomXml(
+                """,
                         """
                  <?xml version="1.0" encoding="UTF-8"?>
                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -74,7 +214,7 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                    <parent>
                      <groupId>org.jenkins-ci.plugins</groupId>
                      <artifactId>plugin</artifactId>
-                     <version>4.88</version>
+                     <version>4.87</version>
                      <relativePath />
                    </parent>
                    <groupId>io.jenkins.plugins</groupId>
@@ -90,7 +230,59 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                        <dependency>
                          <groupId>io.jenkins.tools.bom</groupId>
                          <artifactId>bom-2.452.x</artifactId>
-                         <version>3814.v9563d972079a_</version>
+                         <version>%s</version>
+                         <type>pom</type>
+                         <scope>import</scope>
+                       </dependency>
+                     </dependencies>
+                   </dependencyManagement>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                 """
+                                .formatted(Settings.getBomVersion())));
+    }
+
+    @Test
+    void testPerformUpgradeWithBaselineWithBomAndUpgradeBomIfDoesntExistsForNewJenkinsVersion() {
+        rewriteRun(
+                spec -> spec.recipe(new UpgradeJenkinsVersion("2.452.4")),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.87</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <properties>
+                     <jenkins.baseline>2.440</jenkins.baseline>
+                     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                   </properties>
+                   <dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>io.jenkins.tools.bom</groupId>
+                         <artifactId>bom-2.440.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
                          <type>pom</type>
                          <scope>import</scope>
                        </dependency>
@@ -117,59 +309,7 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                    <parent>
                      <groupId>org.jenkins-ci.plugins</groupId>
                      <artifactId>plugin</artifactId>
-                     <version>4.88</version>
-                     <relativePath />
-                   </parent>
-                   <groupId>io.jenkins.plugins</groupId>
-                   <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
-                   <packaging>hpi</packaging>
-                   <name>Empty Plugin</name>
-                   <properties>
-                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                     <jenkins.baseline>2.452</jenkins.baseline>
-                     <jenkins.version>${jenkins.baseline}.4</jenkins.version>
-                   </properties>
-                   <dependencyManagement>
-                     <dependencies>
-                       <dependency>
-                         <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                         <version>3814.v9563d972079a_</version>
-                         <type>pom</type>
-                         <scope>import</scope>
-                       </dependency>
-                     </dependencies>
-                   </dependencyManagement>
-                   <repositories>
-                     <repository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </repository>
-                   </repositories>
-                   <pluginRepositories>
-                     <pluginRepository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </pluginRepository>
-                   </pluginRepositories>
-                 </project>
-                """));
-    }
-
-    @Test
-    void testAddComment() {
-        rewriteRun(
-                spec -> spec.recipe(new MigrateToJenkinsBaseLineProperty()),
-                pomXml(
-                        """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                   <modelVersion>4.0.0</modelVersion>
-                   <parent>
-                     <groupId>org.jenkins-ci.plugins</groupId>
-                     <artifactId>plugin</artifactId>
-                     <version>4.88</version>
+                     <version>4.87</version>
                      <relativePath />
                    </parent>
                    <groupId>io.jenkins.plugins</groupId>
@@ -185,53 +325,8 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                      <dependencies>
                        <dependency>
                          <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>bom-2.452.x</artifactId>
-                         <version>3814.v9563d972079a_</version>
-                         <type>pom</type>
-                         <scope>import</scope>
-                       </dependency>
-                     </dependencies>
-                   </dependencyManagement>
-                   <repositories>
-                     <repository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </repository>
-                   </repositories>
-                   <pluginRepositories>
-                     <pluginRepository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </pluginRepository>
-                   </pluginRepositories>
-                 </project>
-                """,
-                        """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                   <modelVersion>4.0.0</modelVersion>
-                   <parent>
-                     <groupId>org.jenkins-ci.plugins</groupId>
-                     <artifactId>plugin</artifactId>
-                     <version>4.88</version>
-                     <relativePath />
-                   </parent>
-                   <groupId>io.jenkins.plugins</groupId>
-                   <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
-                   <packaging>hpi</packaging>
-                   <name>Empty Plugin</name>
-                   <properties>
-                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                     <jenkins.baseline>2.452</jenkins.baseline>
-                     <jenkins.version>${jenkins.baseline}.4</jenkins.version>
-                   </properties>
-                   <dependencyManagement>
-                     <dependencies>
-                       <dependency>
-                         <groupId>io.jenkins.tools.bom</groupId>
                          <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                         <version>3814.v9563d972079a_</version>
+                         <version>%s</version>
                          <type>pom</type>
                          <scope>import</scope>
                        </dependency>
@@ -250,253 +345,7 @@ public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
                      </pluginRepository>
                    </pluginRepositories>
                  </project>
-                """));
-    }
-
-    @Test
-    void testAddBaselineWithOtherProperties() {
-        rewriteRun(
-                spec -> spec.recipe(new MigrateToJenkinsBaseLineProperty()),
-                pomXml(
-                        """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                   <modelVersion>4.0.0</modelVersion>
-                   <parent>
-                     <groupId>org.jenkins-ci.plugins</groupId>
-                     <artifactId>plugin</artifactId>
-                     <version>4.88</version>
-                     <relativePath />
-                   </parent>
-                   <groupId>io.jenkins.plugins</groupId>
-                   <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
-                   <packaging>hpi</packaging>
-                   <name>Empty Plugin</name>
-                   <!-- My properties -->
-                   <properties>
-                     <!-- My property -->
-                     <foo.bar>baz</foo.bar>
-                     <jenkins.version>2.452.4</jenkins.version>
-                   </properties>
-                   <dependencyManagement>
-                     <dependencies>
-                       <dependency>
-                         <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>bom-2.452.x</artifactId>
-                         <version>3814.v9563d972079a_</version>
-                         <type>pom</type>
-                         <scope>import</scope>
-                       </dependency>
-                     </dependencies>
-                   </dependencyManagement>
-                   <repositories>
-                     <repository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </repository>
-                   </repositories>
-                   <pluginRepositories>
-                     <pluginRepository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </pluginRepository>
-                   </pluginRepositories>
-                 </project>
-                """,
-                        """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                   <modelVersion>4.0.0</modelVersion>
-                   <parent>
-                     <groupId>org.jenkins-ci.plugins</groupId>
-                     <artifactId>plugin</artifactId>
-                     <version>4.88</version>
-                     <relativePath />
-                   </parent>
-                   <groupId>io.jenkins.plugins</groupId>
-                   <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
-                   <packaging>hpi</packaging>
-                   <name>Empty Plugin</name>
-                   <!-- My properties -->
-                   <properties>
-                     <!-- My property -->
-                     <foo.bar>baz</foo.bar>
-                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                     <jenkins.baseline>2.452</jenkins.baseline>
-                     <jenkins.version>${jenkins.baseline}.4</jenkins.version>
-                   </properties>
-                   <dependencyManagement>
-                     <dependencies>
-                       <dependency>
-                         <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                         <version>3814.v9563d972079a_</version>
-                         <type>pom</type>
-                         <scope>import</scope>
-                       </dependency>
-                     </dependencies>
-                   </dependencyManagement>
-                   <repositories>
-                     <repository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </repository>
-                   </repositories>
-                   <pluginRepositories>
-                     <pluginRepository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </pluginRepository>
-                   </pluginRepositories>
-                 </project>
-                """));
-    }
-
-    @Test
-    void testFixBom() {
-        rewriteRun(
-                spec -> spec.recipe(new MigrateToJenkinsBaseLineProperty()),
-                pomXml(
-                        """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                   <modelVersion>4.0.0</modelVersion>
-                   <parent>
-                     <groupId>org.jenkins-ci.plugins</groupId>
-                     <artifactId>plugin</artifactId>
-                     <version>4.88</version>
-                     <relativePath />
-                   </parent>
-                   <groupId>io.jenkins.plugins</groupId>
-                   <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
-                   <packaging>hpi</packaging>
-                   <name>Empty Plugin</name>
-                   <properties>
-                     <jenkins.version>2.479.1</jenkins.version>
-                   </properties>
-                   <dependencyManagement>
-                     <dependencies>
-                       <dependency>
-                         <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>bom-2.452.x</artifactId>
-                         <version>3814.v9563d972079a_</version>
-                         <type>pom</type>
-                         <scope>import</scope>
-                       </dependency>
-                     </dependencies>
-                   </dependencyManagement>
-                   <repositories>
-                     <repository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </repository>
-                   </repositories>
-                   <pluginRepositories>
-                     <pluginRepository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </pluginRepository>
-                   </pluginRepositories>
-                 </project>
-                """,
-                        """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                   <modelVersion>4.0.0</modelVersion>
-                   <parent>
-                     <groupId>org.jenkins-ci.plugins</groupId>
-                     <artifactId>plugin</artifactId>
-                     <version>4.88</version>
-                     <relativePath />
-                   </parent>
-                   <groupId>io.jenkins.plugins</groupId>
-                   <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
-                   <packaging>hpi</packaging>
-                   <name>Empty Plugin</name>
-                   <properties>
-                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                     <jenkins.baseline>2.479</jenkins.baseline>
-                     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
-                   </properties>
-                   <dependencyManagement>
-                     <dependencies>
-                       <dependency>
-                         <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                         <version>3814.v9563d972079a_</version>
-                         <type>pom</type>
-                         <scope>import</scope>
-                       </dependency>
-                     </dependencies>
-                   </dependencyManagement>
-                   <repositories>
-                     <repository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </repository>
-                   </repositories>
-                   <pluginRepositories>
-                     <pluginRepository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </pluginRepository>
-                   </pluginRepositories>
-                 </project>
-                """));
-    }
-
-    @Test
-    void testNoChangesWithWeekly() {
-        rewriteRun(
-                spec -> spec.recipe(new MigrateToJenkinsBaseLineProperty()),
-                pomXml(
-                        """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                   <modelVersion>4.0.0</modelVersion>
-                   <parent>
-                     <groupId>org.jenkins-ci.plugins</groupId>
-                     <artifactId>plugin</artifactId>
-                     <version>4.88</version>
-                     <relativePath />
-                   </parent>
-                   <groupId>io.jenkins.plugins</groupId>
-                   <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
-                   <packaging>hpi</packaging>
-                   <name>Empty Plugin</name>
-                   <properties>
-                        <jenkins.baseline>2.452</jenkins.baseline>
-                        <jenkins.version>${jenkins.baseline}</jenkins.version>
-                   </properties>
-                   <dependencyManagement>
-                     <dependencies>
-                       <dependency>
-                         <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>bom-weekly</artifactId>
-                         <version>3814.v9563d972079a_</version>
-                         <type>pom</type>
-                         <scope>import</scope>
-                       </dependency>
-                     </dependencies>
-                   </dependencyManagement>
-                   <repositories>
-                     <repository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </repository>
-                   </repositories>
-                   <pluginRepositories>
-                     <pluginRepository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </pluginRepository>
-                   </pluginRepositories>
-                 </project>
-                """));
+                 """
+                                .formatted(Settings.getBomVersion())));
     }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddBeforePropertyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddBeforePropertyTest.java
@@ -10,7 +10,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.xml.tree.Xml;
 
 /**
- * A visitor that add a maven property before another property.
+ * Test for {@link AddBeforePropertyVisitor}
  */
 public class AddBeforePropertyTest implements RewriteTest {
 

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitorTest.java
@@ -10,7 +10,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.xml.tree.Xml;
 
 /**
- * A visitor that remove a property comment.
+ * Test for {@link RemovePropertyCommentVisitor}
  */
 public class RemovePropertyCommentVisitorTest implements RewriteTest {
 
@@ -60,5 +60,87 @@ public class RemovePropertyCommentVisitorTest implements RewriteTest {
                    </properties>
                  </project>
                   """));
+    }
+
+    @Test
+    void notChangesIfCommentIsNotMatching() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new RemovePropertyCommentVisitor(" Comment 1 "));
+                        doAfterVisit(new RemovePropertyCommentVisitor(" Comment 2 "));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- My properties -->
+                   <properties>
+                        <!-- My other property -->
+                        <my.other.property>value</my.other.property>
+                        <!-- Unrelated comment -->
+                        <jenkins.version>2.440</jenkins.version>
+                   </properties>
+                 </project>
+                 """));
+    }
+
+    @Test
+    void noChangesIfEmptyProperties() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new RemovePropertyCommentVisitor(" No property here "));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <!-- No property here -->
+                   <properties />
+                 </project>
+                 """));
+    }
+
+    @Test
+    void noChangesIfNoProperties() {
+        rewriteRun(
+                spec -> spec.recipe(toRecipe(() -> new MavenIsoVisitor<>() {
+                    @Override
+                    public Xml.Document visitDocument(Xml.Document x, ExecutionContext ctx) {
+                        doAfterVisit(new RemovePropertyCommentVisitor(" No property here "));
+                        return super.visitDocument(x, ctx);
+                    }
+                })),
+                pomXml(
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                 </project>
+                 """));
     }
 }


### PR DESCRIPTION
- Ensure second execution work with caching and several improvement 
- Add more tests
- One missing Jenkinsfile on test plugin
- Enhance recipe to bump Jenkins 2.479.1 due to Stapler changes 
- Add java test (this one need probably improved to create a sample mavenProject for rewrite test instead of standalone pom and java source. Future PR will follow). This would avoid to pollute test dependencies on core pom.xml

### Testing done

Automated tests and one test on `dashboard-view`

```diff
diff --git a/pom.xml b/pom.xml
index 5e76b57..1265a58 100644
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.86</version>
+    <version>5.4</version>
     <relativePath />
   </parent>
 
@@ -44,7 +44,9 @@
     <revision>2</revision>
     <changelist>999999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-    <jenkins.version>2.440.3</jenkins.version>
+    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
@@ -53,8 +55,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.440.x</artifactId>
-        <version>3435.v238d66a_043fb_</version>
+        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+        <version>3850.vb_c5319efa_e29</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
diff --git a/src/main/java/hudson/plugins/view/dashboard/Dashboard.java b/src/main/java/hudson/plugins/view/dashboard/Dashboard.java
index f256b6a..a23414e 100644
--- a/src/main/java/hudson/plugins/view/dashboard/Dashboard.java
+++ b/src/main/java/hudson/plugins/view/dashboard/Dashboard.java
@@ -10,19 +10,19 @@ import hudson.model.Job;
 import hudson.model.ListView;
 import hudson.model.TopLevelItem;
 import hudson.model.ViewDescriptor;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import javax.servlet.ServletException;
 import jenkins.security.stapler.StaplerDispatchable;
 import net.sf.json.JSONObject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * View that can be customized with portlets to show the selected jobs information in various ways.
@@ -197,7 +197,7 @@ public class Dashboard extends ListView {
     }
 
     @Override
-    protected synchronized void submit(StaplerRequest req) throws IOException, ServletException, FormException {
+    protected synchronized void submit(StaplerRequest2 req) throws IOException, ServletException, FormException {
         super.submit(req);
 
         try {
diff --git a/src/main/java/hudson/plugins/view/dashboard/DashboardPortlet.java b/src/main/java/hudson/plugins/view/dashboard/DashboardPortlet.java
index 69e296f..f865566 100644
--- a/src/main/java/hudson/plugins/view/dashboard/DashboardPortlet.java
+++ b/src/main/java/hudson/plugins/view/dashboard/DashboardPortlet.java
@@ -9,7 +9,7 @@ import hudson.model.TopLevelItem;
 import java.util.Comparator;
 import jenkins.model.Jenkins;
 import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * Report that can summarize project data across multiple projects and display the resulting data.
@@ -34,7 +34,7 @@ public abstract class DashboardPortlet implements ModelObject, Describable<Dashb
 
     public Dashboard getDashboard() {
         // TODO Can the dashboard instance be a field on this class -- parent?
-        StaplerRequest req = Stapler.getCurrentRequest();
+        StaplerRequest2 req = Stapler.getCurrentRequest2();
         return req != null ? req.findAncestorObject(Dashboard.class) : null;
     }
```


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
