### PR TITLE
Support for scoop distribution

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -99,9 +99,9 @@ jobs:
           JRELEASER_PROJECT_VERSION: ${{ steps.extract-version.outputs.version }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Generate Homebrew token
+      - name: Generate token
         uses: tibdex/github-app-token@v2
-        id: generate_homebrew_token
+        id: generate_token
         with:
           app_id: ${{ secrets.GORELEASER_APP_ID }}
           private_key: ${{ secrets.GORELEASER_APP_PRIVKEY }}
@@ -114,7 +114,8 @@ jobs:
         env:
           JRELEASER_PROJECT_VERSION: ${{ steps.extract-version.outputs.version }}
           JRELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          JRELEASER_HOMEBREW_GITHUB_TOKEN: ${{ steps.generate_homebrew_token.outputs.token }}
+          JRELEASER_HOMEBREW_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          JRELEASER_SCOOP_GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
 
       - name: Archive output
         if: always()

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -54,3 +54,18 @@ packagers:
     skipTemplates:
       - cask.rb.tpl
       - README.md.tpl
+
+  scoop:
+    active: RELEASE
+    repository:
+      active: RELEASE
+      owner: jenkins-infra
+      name: scoop-bucket  
+      tagName: '{{distributionName}}-{{projectVersion}}'
+    commitAuthor:
+      name: jenkins-infra
+      email: jenkins-infra-team@googlegroups.com
+    extraProperties:
+      skipLicenseFile: true
+    skipTemplates:
+      - scoop-bucket/README.md.tpl


### PR DESCRIPTION
### Description
This PR adds support for distributing the plugin-modernizer plugin via Scoop on Windows. This integration leverages JReleaser to package and distribute the plugin, making it easy for Windows users to install and use the tool through Scoop.

Changes made:
- Added a Scoop bucket for distributing the plugin-modernizer plugin on Windows.
- Created an app manifest for the plugin and updated the JReleaser configuration to support Scoop as a distribution method.
- The link for the bucket where the app manifest is located is https://github.com/CodexRaunak/plugin-modernizer-bucket

Fix https://github.com/jenkins-infra/plugin-modernizer-tool/issues/505

### Testing done
This change was tested by successfully installing and running the plugin-modernizer on a Windows machine using Scoop. The installation process went through without errors.

To verify the installation:
I ran scoop install plugin-modernizer and confirmed that the installation completed successfully.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
