### PR TITLE
Extract for info from Jenkinsfile and support different layout

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/JenkinsfileVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/JenkinsfileVisitor.java
@@ -1,7 +1,11 @@
 package io.jenkins.tools.pluginmodernizer.core.extractor;
 
 import io.jenkins.tools.pluginmodernizer.core.model.JDK;
+import io.jenkins.tools.pluginmodernizer.core.model.Platform;
+import io.jenkins.tools.pluginmodernizer.core.model.PlatformConfig;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -13,7 +17,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Visitor for a Jenkinsfile
+ * Visitor for a Jenkinsfile to accumulate @see PluginMetadata.
  */
 public class JenkinsfileVisitor extends GroovyIsoVisitor<PluginMetadata> {
 
@@ -22,6 +26,9 @@ public class JenkinsfileVisitor extends GroovyIsoVisitor<PluginMetadata> {
      */
     public static final Logger LOG = LoggerFactory.getLogger(JenkinsfileVisitor.class);
 
+    /**
+     * Keep track of variables if there are defined on top level and not directly on the method invocation.
+     */
     private final Map<String, Object> variableMap = new HashMap<>();
 
     @Override
@@ -37,65 +44,196 @@ public class JenkinsfileVisitor extends GroovyIsoVisitor<PluginMetadata> {
     }
 
     @Override
+    public J visitMapEntry(G.MapEntry mapEntry, PluginMetadata pluginMetadata) {
+        super.visitMapEntry(mapEntry, pluginMetadata);
+        J.MethodInvocation method = getCursor().firstEnclosing(J.MethodInvocation.class);
+        if (method == null) {
+            return mapEntry;
+        }
+        if (method.getSimpleName().equals("buildPlugin")) {
+            if ("useContainerAgent".equals(mapEntry.getKey().toString())) {
+                if (mapEntry.getValue() instanceof J.Literal literal) {
+                    pluginMetadata.setUseContainerAgent(Boolean.valueOf(literal.getValueSource()));
+                } else if (mapEntry.getValue() instanceof J.Identifier) {
+                    Expression resolvedArg = resolveVariable(mapEntry.getValue());
+                    if (resolvedArg instanceof J.Literal literal) {
+                        pluginMetadata.setUseContainerAgent(Boolean.valueOf(literal.getValueSource()));
+                    }
+                }
+            }
+            if ("forkCount".equals(mapEntry.getKey().toString())) {
+                if (mapEntry.getValue() instanceof J.Literal literal) {
+                    pluginMetadata.setForkCount(literal.getValue().toString());
+                } else if (mapEntry.getValue() instanceof J.Identifier) {
+                    Expression resolvedArg = resolveVariable(mapEntry.getValue());
+                    if (resolvedArg instanceof J.Literal literal) {
+                        pluginMetadata.setForkCount(literal.getValue().toString());
+                    }
+                }
+            }
+        }
+        return mapEntry;
+    }
+
+    @Override
     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, PluginMetadata pluginMetadata) {
         LOG.debug("Visiting method invocation {}", method);
         method = super.visitMethodInvocation(method, pluginMetadata);
         if ("buildPlugin".equals(method.getSimpleName())) {
             List<Expression> args = method.getArguments();
 
-            List<Integer> jdkVersions =
-                    args.stream().flatMap(this::extractJdkVersions).distinct().toList();
+            // Empty args means Java 8 in Windows and Linux
+            if (args.size() == 1 && args.get(0) instanceof J.Empty) {
+                pluginMetadata.addPlatform(new PlatformConfig(Platform.LINUX, JDK.JAVA_8, null, true));
+                pluginMetadata.addPlatform(new PlatformConfig(Platform.WINDOWS, JDK.JAVA_8, null, true));
+                return method;
+            }
 
-            LOG.info("JDK versions found: {}", jdkVersions);
+            List<PlatformConfig> platforms = new LinkedList<>();
+            for (Expression expression : args) {
+                platforms.addAll(extractPlatforms(expression));
+            }
+            // Filter platforms (Remove implicit if there is at least one explicit)
+            if (platforms.stream().anyMatch(pc -> !pc.implicit())) {
+                platforms.removeIf(PlatformConfig::implicit);
+            }
+            // If all platform are unknown ensure each platform on the list is present with LINUX and WINDOWS
+            if (platforms.stream().allMatch(pc -> pc.name() == Platform.UNKNOWN)) {
+                List<PlatformConfig> newPlatforms = new LinkedList<>();
+                for (PlatformConfig pc : platforms) {
+                    newPlatforms.add(new PlatformConfig(Platform.LINUX, pc.jdk(), null, false));
+                    newPlatforms.add(new PlatformConfig(Platform.WINDOWS, pc.jdk(), null, false));
+                }
+                platforms = newPlatforms;
+            }
+            // If there is a platform without JDK ensure all all JDK are using the same platform
+            if (platforms.stream().anyMatch(pc -> pc.jdk() == null)) {
+                List<PlatformConfig> newPlatforms = new LinkedList<>();
+                for (PlatformConfig pc : platforms) {
+                    if (!pc.name().equals(Platform.UNKNOWN)) {
+                        if (platforms.stream().allMatch(p -> p.jdk() == null)) {
+                            newPlatforms.add(new PlatformConfig(pc.name(), JDK.JAVA_8, null, false));
+                            continue;
+                        }
+                        for (PlatformConfig pc2 : platforms) {
+                            if (pc2.jdk() != null) {
+                                newPlatforms.add(new PlatformConfig(pc.name(), pc2.jdk(), null, false));
+                            }
+                        }
+                    }
+                }
+                platforms = newPlatforms;
+            }
 
-            jdkVersions.forEach(jdkVersion -> pluginMetadata.addJdk(JDK.get(jdkVersion)));
+            LOG.info("Platform: {}", platforms);
+            pluginMetadata.setPlatforms(platforms);
         }
 
         return method;
     }
 
-    private Stream<Integer> extractJdkVersions(Expression arg) {
+    private List<PlatformConfig> extractPlatforms(Expression arg) {
         if (arg instanceof G.MapEntry) {
-            return Stream.of(arg)
+
+            // Get 'configurations' stream
+            Stream<G.MapEntry> configurations = Stream.of(arg)
                     .map(G.MapEntry.class::cast)
-                    .filter(entry -> "configurations".equals(((J.Literal) entry.getKey()).getValue()))
+                    .filter(entry -> "configurations".equals(((J.Literal) entry.getKey()).getValue()));
+
+            // List of platform config from 'configurations' parameter
+            List<PlatformConfig> platformFromConfigs = configurations
                     .map(entry -> resolveConfigurations(entry.getValue()))
                     .filter(value -> value instanceof G.ListLiteral)
                     .flatMap(value -> ((G.ListLiteral) value).getElements().stream())
                     .filter(expression -> expression instanceof G.MapLiteral)
-                    .flatMap(expression -> ((G.MapLiteral) expression).getElements().stream())
-                    .filter(mapExpr -> mapExpr instanceof G.MapEntry)
+                    .map(expression -> (G.MapLiteral) expression)
+                    .map(JenkinsfileVisitor::toPlatformEntry)
+                    .toList();
+
+            // Cannot be combinated
+            if (!platformFromConfigs.isEmpty()) {
+                return platformFromConfigs;
+            }
+
+            // List of JDK versions from 'jdkVersions' parameter
+            List<Integer> jdkVersions = Stream.of(arg)
                     .map(G.MapEntry.class::cast)
-                    .filter(mapEntry -> "jdk".equals(((J.Literal) mapEntry.getKey()).getValue()))
-                    .map(mapEntry -> Integer.parseInt(
-                            ((J.Literal) mapEntry.getValue()).getValue().toString()));
-        } else {
+                    .filter(entry -> "jdkVersions".equals(((J.Literal) entry.getKey()).getValue()))
+                    .map(entry -> resolveConfigurations(entry.getValue()))
+                    .filter(value -> value instanceof G.ListLiteral)
+                    .map(value -> (G.ListLiteral) value)
+                    .flatMap(value -> value.getElements().stream())
+                    .map(expression ->
+                            Integer.parseInt(((J.Literal) expression).getValue().toString()))
+                    .toList();
+
+            // List of platforms from 'platforms' parameter
+            List<String> platforms = Stream.of(arg)
+                    .map(G.MapEntry.class::cast)
+                    .filter(entry -> "platforms".equals(((J.Literal) entry.getKey()).getValue()))
+                    .map(entry -> resolveConfigurations(entry.getValue()))
+                    .filter(value -> value instanceof G.ListLiteral)
+                    .map(value -> (G.ListLiteral) value)
+                    .flatMap(value -> value.getElements().stream())
+                    .map(expression -> expression instanceof J.Literal ? expression.toString() : null)
+                    .toList();
+
+            // Combine all JDK versions with all platforms
+            List<PlatformConfig> platformFromJdkVersions = new LinkedList<>();
+            for (Integer jdk : jdkVersions) {
+                platformFromJdkVersions.add(new PlatformConfig(Platform.UNKNOWN, JDK.get(jdk), null, true));
+            }
+            for (String platform : platforms) {
+                platformFromJdkVersions.add(new PlatformConfig(Platform.fromPlatform(platform), null, null, true));
+            }
+
+            return platformFromJdkVersions;
+
+        } else if (arg instanceof J.Identifier) {
             Expression resolvedArg = resolveVariable(arg);
             return Stream.of(resolvedArg)
                     .filter(resolved -> resolved instanceof G.MapLiteral)
                     .flatMap(resolved -> ((G.MapLiteral) resolved).getElements().stream())
-                    .filter(entry -> entry instanceof G.MapEntry)
-                    .map(G.MapEntry.class::cast)
                     .filter(entry -> "configurations".equals(((J.Literal) entry.getKey()).getValue()))
                     .map(entry -> resolveConfigurations(entry.getValue()))
                     .filter(value -> value instanceof G.ListLiteral)
                     .flatMap(value -> ((G.ListLiteral) value).getElements().stream())
                     .filter(expression -> expression instanceof G.MapLiteral)
-                    .flatMap(expression -> ((G.MapLiteral) expression).getElements().stream())
-                    .filter(mapExpr -> mapExpr instanceof G.MapEntry)
-                    .map(G.MapEntry.class::cast)
-                    .filter(mapEntry -> "jdk".equals(((J.Literal) mapEntry.getKey()).getValue()))
-                    .map(mapEntry -> Integer.parseInt(
-                            ((J.Literal) mapEntry.getValue()).getValue().toString()));
+                    .map(expression -> (G.MapLiteral) expression)
+                    .map(JenkinsfileVisitor::toPlatformEntry)
+                    .toList();
         }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Return if the map entry is a platform entry.
+     * @param mapLiteral The map entry
+     * @return The platform config
+     */
+    private static PlatformConfig toPlatformEntry(G.MapLiteral mapLiteral) {
+        Stream<G.MapEntry> entries = mapLiteral.getElements().stream();
+        List<G.MapEntry> list = entries.toList();
+        Integer jdk = null;
+        String platform = null;
+        for (G.MapEntry entry : list) {
+            if (entry.getKey() instanceof J.Literal key) {
+                if ("jdk".equals(key.getValue())) {
+                    jdk = Integer.parseInt(entry.getValue().toString());
+                }
+                if ("platform".equals(key.getValue())) {
+                    platform = entry.getValue().toString();
+                }
+            }
+        }
+
+        return new PlatformConfig(Platform.fromPlatform(platform), JDK.get(jdk), null, false);
     }
 
     private Expression resolveVariable(Expression expression) {
-        if (expression instanceof J.Identifier) {
-            String variableName = ((J.Identifier) expression).getSimpleName();
-            if (variableMap.containsKey(variableName)) {
-                return (Expression) variableMap.get(variableName);
-            }
+        String variableName = ((J.Identifier) expression).getSimpleName();
+        if (variableMap.containsKey(variableName)) {
+            return (Expression) variableMap.get(variableName);
         }
         return expression;
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/CacheEntry.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/CacheEntry.java
@@ -2,12 +2,11 @@ package io.jenkins.tools.pluginmodernizer.core.model;
 
 import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
 import io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils;
-import java.io.Serializable;
 import java.nio.file.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class CacheEntry<T extends CacheEntry<T>> implements Serializable {
+public abstract class CacheEntry<T extends CacheEntry<T>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(CacheEntry.class);
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/HealthScoreData.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/HealthScoreData.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * We are storing only the data we are interested in (like plugins).
  * Further implementation can consider ignoring plugin with deprecation
  */
-public class HealthScoreData extends CacheEntry<HealthScoreData> implements Serializable {
+public class HealthScoreData extends CacheEntry<HealthScoreData> {
 
     /**
      * Plugins in the health score mapped by their name

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Platform.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Platform.java
@@ -1,0 +1,23 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+/**
+ * Platform from Jenkinsfile
+ */
+public enum Platform {
+    LINUX,
+    WINDOWS,
+    UNKNOWN;
+
+    /**
+     * Return a platform from a string.
+     * @param platform The platform
+     * @return The platform
+     */
+    public static Platform fromPlatform(String platform) {
+        return switch (platform) {
+            case "linux" -> LINUX;
+            case "windows" -> WINDOWS;
+            default -> UNKNOWN;
+        };
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PlatformConfig.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PlatformConfig.java
@@ -1,0 +1,7 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+/**
+ * Extracted platform from Jenkinsfile
+ */
+public record PlatformConfig(Platform name, JDK jdk, String jenkins, boolean implicit) {}
+;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PluginInstallationStatsData.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PluginInstallationStatsData.java
@@ -1,11 +1,10 @@
 package io.jenkins.tools.pluginmodernizer.core.model;
 
 import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
-import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.Map;
 
-public class PluginInstallationStatsData extends CacheEntry<PluginInstallationStatsData> implements Serializable {
+public class PluginInstallationStatsData extends CacheEntry<PluginInstallationStatsData> {
 
     /**
      * Plugins in the installation stats mapped by their name

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PluginVersionData.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PluginVersionData.java
@@ -10,7 +10,7 @@ import java.util.Map;
  * We are storing only the data we are interested in (like plugins).
  * Further implementation can consider ignoring plugin with deprecation
  */
-public class PluginVersionData extends CacheEntry<PluginVersionData> implements Serializable {
+public class PluginVersionData extends CacheEntry<PluginVersionData> {
 
     /**
      * Plugins in the update center mapped by their name

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/UpdateCenterData.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/UpdateCenterData.java
@@ -11,7 +11,7 @@ import java.util.Map;
  * We are storing only the data we are interested in (like plugins).
  * Further implementation can consider ignoring plugin with deprecation
  */
-public class UpdateCenterData extends CacheEntry<UpdateCenterData> implements Serializable {
+public class UpdateCenterData extends CacheEntry<UpdateCenterData> {
 
     /**
      * Plugins in the update center mapped by their name

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/FetchMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/FetchMetadata.java
@@ -6,8 +6,6 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.RecipeList;
 import org.openrewrite.TreeVisitor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Recipe to fetch metadata from source files and store it in the target directory.
@@ -16,11 +14,6 @@ import org.slf4j.LoggerFactory;
  * See {@link PluginMetadata} for the metadata structure.
  */
 public class FetchMetadata extends Recipe {
-
-    /**
-     * LOGGER.
-     */
-    private static final Logger LOG = LoggerFactory.getLogger(FetchMetadata.class);
 
     @Override
     public String getDisplayName() {

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/FetchMetadataTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/FetchMetadataTest.java
@@ -8,8 +8,8 @@ import static org.openrewrite.test.SourceSpecs.text;
 import static org.openrewrite.yaml.Assertions.yaml;
 
 import io.jenkins.tools.pluginmodernizer.core.model.JDK;
+import io.jenkins.tools.pluginmodernizer.core.model.Platform;
 import io.jenkins.tools.pluginmodernizer.core.recipes.FetchMetadata;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.LinkedList;
@@ -30,15 +30,17 @@ public class FetchMetadataTest implements RewriteTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(FetchMetadataTest.class);
 
-    private static final PluginMetadata EXPECTED_POM_METADATA;
+    private static final PluginMetadata EXPECTED_METADATA;
 
     static {
-        EXPECTED_POM_METADATA = new PluginMetadata();
-        EXPECTED_POM_METADATA.setPluginName("GitLab Plugin");
-        EXPECTED_POM_METADATA.setParentVersion("4.80");
-        EXPECTED_POM_METADATA.setJenkinsVersion("2.426.3");
-        EXPECTED_POM_METADATA.setBomArtifactId("bom-2.414.x");
-        EXPECTED_POM_METADATA.setBomVersion("2950.va_633b_f42f759");
+        EXPECTED_METADATA = new PluginMetadata();
+        EXPECTED_METADATA.setPluginName("GitLab Plugin");
+        EXPECTED_METADATA.setParentVersion("4.80");
+        EXPECTED_METADATA.setJenkinsVersion("2.426.3");
+        EXPECTED_METADATA.setBomArtifactId("bom-2.414.x");
+        EXPECTED_METADATA.setBomVersion("2950.va_633b_f42f759");
+        EXPECTED_METADATA.setUseContainerAgent(null);
+        EXPECTED_METADATA.setForkCount(null);
         Map<String, String> properties = new LinkedHashMap<>();
         properties.put("revision", "1.8.1");
         properties.put("java.level", "8");
@@ -50,17 +52,17 @@ public class FetchMetadataTest implements RewriteTest {
         properties.put("hpi.compatibleSinceVersion", "1.4.0");
         properties.put("mockserver.version", "5.15.0");
         properties.put("spotless.check.skip", "false");
-        EXPECTED_POM_METADATA.setProperties(properties);
+        EXPECTED_METADATA.setProperties(properties);
         List<ArchetypeCommonFile> commonFiles = new LinkedList<>();
         commonFiles.add(ArchetypeCommonFile.JENKINSFILE);
         commonFiles.add(ArchetypeCommonFile.POM);
-        EXPECTED_POM_METADATA.setCommonFiles(commonFiles);
+        EXPECTED_METADATA.setCommonFiles(commonFiles);
         Set<MetadataFlag> flags = new LinkedHashSet<>();
         flags.add(MetadataFlag.DEVELOPER_SET);
         flags.add(MetadataFlag.LICENSE_SET);
         flags.add(MetadataFlag.SCM_HTTPS);
         flags.add(MetadataFlag.MAVEN_REPOSITORIES_HTTPS);
-        EXPECTED_POM_METADATA.setFlags(flags);
+        EXPECTED_METADATA.setFlags(flags);
     }
 
     @Language("xml")
@@ -192,12 +194,12 @@ public class FetchMetadataTest implements RewriteTest {
         assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM));
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(0, jdkVersion.size());
-        assertEquals(EXPECTED_POM_METADATA.getParentVersion(), pluginMetadata.getParentVersion());
-        assertEquals(EXPECTED_POM_METADATA.getPluginName(), pluginMetadata.getPluginName());
-        assertEquals(EXPECTED_POM_METADATA.getJenkinsVersion(), pluginMetadata.getJenkinsVersion());
-        assertEquals(EXPECTED_POM_METADATA.getBomVersion(), pluginMetadata.getBomVersion());
-        assertEquals(EXPECTED_POM_METADATA.getProperties(), pluginMetadata.getProperties());
-        assertEquals(EXPECTED_POM_METADATA.getFlags(), pluginMetadata.getFlags());
+        assertEquals(EXPECTED_METADATA.getParentVersion(), pluginMetadata.getParentVersion());
+        assertEquals(EXPECTED_METADATA.getPluginName(), pluginMetadata.getPluginName());
+        assertEquals(EXPECTED_METADATA.getJenkinsVersion(), pluginMetadata.getJenkinsVersion());
+        assertEquals(EXPECTED_METADATA.getBomVersion(), pluginMetadata.getBomVersion());
+        assertEquals(EXPECTED_METADATA.getProperties(), pluginMetadata.getProperties());
+        assertEquals(EXPECTED_METADATA.getFlags(), pluginMetadata.getFlags());
 
         // Only pom here
         assertEquals(List.of(ArchetypeCommonFile.POM), pluginMetadata.getCommonFiles());
@@ -281,12 +283,12 @@ public class FetchMetadataTest implements RewriteTest {
         assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM));
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(0, jdkVersion.size());
-        assertEquals(EXPECTED_POM_METADATA.getParentVersion(), pluginMetadata.getParentVersion());
-        assertEquals(EXPECTED_POM_METADATA.getPluginName(), pluginMetadata.getPluginName());
-        assertEquals(EXPECTED_POM_METADATA.getJenkinsVersion(), pluginMetadata.getJenkinsVersion());
-        assertEquals(EXPECTED_POM_METADATA.getBomVersion(), pluginMetadata.getBomVersion());
-        assertEquals(EXPECTED_POM_METADATA.getProperties(), pluginMetadata.getProperties());
-        assertEquals(EXPECTED_POM_METADATA.getFlags(), pluginMetadata.getFlags());
+        assertEquals(EXPECTED_METADATA.getParentVersion(), pluginMetadata.getParentVersion());
+        assertEquals(EXPECTED_METADATA.getPluginName(), pluginMetadata.getPluginName());
+        assertEquals(EXPECTED_METADATA.getJenkinsVersion(), pluginMetadata.getJenkinsVersion());
+        assertEquals(EXPECTED_METADATA.getBomVersion(), pluginMetadata.getBomVersion());
+        assertEquals(EXPECTED_METADATA.getProperties(), pluginMetadata.getProperties());
+        assertEquals(EXPECTED_METADATA.getFlags(), pluginMetadata.getFlags());
 
         // Only pom here
         assertEquals(List.of(ArchetypeCommonFile.POM), pluginMetadata.getCommonFiles());
@@ -354,12 +356,13 @@ public class FetchMetadataTest implements RewriteTest {
         // Check rest
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(2, jdkVersion.size());
-        assertEquals(EXPECTED_POM_METADATA.getParentVersion(), pluginMetadata.getParentVersion());
-        assertEquals(EXPECTED_POM_METADATA.getPluginName(), pluginMetadata.getPluginName());
-        assertEquals(EXPECTED_POM_METADATA.getJenkinsVersion(), pluginMetadata.getJenkinsVersion());
-        assertEquals(EXPECTED_POM_METADATA.getBomVersion(), pluginMetadata.getBomVersion());
-        assertEquals(EXPECTED_POM_METADATA.getProperties(), pluginMetadata.getProperties());
-        assertEquals(EXPECTED_POM_METADATA.getFlags(), pluginMetadata.getFlags());
+        assertTrue(pluginMetadata.isUseContainerAgent());
+        assertEquals(EXPECTED_METADATA.getParentVersion(), pluginMetadata.getParentVersion());
+        assertEquals(EXPECTED_METADATA.getPluginName(), pluginMetadata.getPluginName());
+        assertEquals(EXPECTED_METADATA.getJenkinsVersion(), pluginMetadata.getJenkinsVersion());
+        assertEquals(EXPECTED_METADATA.getBomVersion(), pluginMetadata.getBomVersion());
+        assertEquals(EXPECTED_METADATA.getProperties(), pluginMetadata.getProperties());
+        assertEquals(EXPECTED_METADATA.getFlags(), pluginMetadata.getFlags());
     }
 
     @Test
@@ -370,7 +373,8 @@ public class FetchMetadataTest implements RewriteTest {
                 groovy(
                         """
                          buildPlugin(
-                         useContainerAgent: true,
+                         useContainerAgent: false,
+                         forkCount: '1C',
                          configurations: [
                                 [platform: 'linux', jdk: 21],
                                 [platform: 'windows', jdk: 17],
@@ -382,45 +386,22 @@ public class FetchMetadataTest implements RewriteTest {
         assertNotNull(pluginMetadata, "Plugin metadata was not written by the recipe");
         // Only Jenkinsfile here
         assertEquals(List.of(ArchetypeCommonFile.JENKINSFILE), pluginMetadata.getCommonFiles());
+
+        // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(2, jdkVersion.size());
+        assertFalse(pluginMetadata.isUseContainerAgent());
+        assertEquals("1C", pluginMetadata.getForkCount());
+
+        // Assert platform
+        Set<Platform> platforms = pluginMetadata.getPlatforms();
+        assertEquals(2, platforms.size());
+        assertTrue(platforms.contains(Platform.WINDOWS));
+        assertTrue(platforms.contains(Platform.LINUX));
     }
 
     @Test
-    void testPluginWithJenkinsfileWithoutJdkInfo() throws Exception {
-        EXPECTED_POM_METADATA.setJdks(Set.of());
-        EXPECTED_POM_METADATA.setJdks(Collections.emptySet());
-        rewriteRun(
-                recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
-                // language=groovy
-                groovy(
-                        """
-                          buildPlugin()
-                          """,
-                        spec -> spec.path("Jenkinsfile")),
-                pomXml(POM_XML));
-
-        PluginMetadata pluginMetadata = new PluginMetadata().refresh();
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM));
-        Set<JDK> jdkVersion = pluginMetadata.getJdks();
-        assertEquals(0, jdkVersion.size());
-        assertEquals(EXPECTED_POM_METADATA.getParentVersion(), pluginMetadata.getParentVersion());
-        assertEquals(EXPECTED_POM_METADATA.getPluginName(), pluginMetadata.getPluginName());
-        assertEquals(EXPECTED_POM_METADATA.getJenkinsVersion(), pluginMetadata.getJenkinsVersion());
-
-        assertEquals(EXPECTED_POM_METADATA.getBomVersion(), pluginMetadata.getBomVersion());
-        assertEquals(EXPECTED_POM_METADATA.getProperties(), pluginMetadata.getProperties());
-        assertEquals(EXPECTED_POM_METADATA.getFlags(), pluginMetadata.getFlags());
-        assertEquals(EXPECTED_POM_METADATA.getCommonFiles(), pluginMetadata.getCommonFiles());
-    }
-
-    @Test
-    void testPluginWithJenkinsfileWithJdkInfo() {
-        Set<JDK> jdks = new LinkedHashSet<>();
-        jdks.add(JDK.JAVA_21);
-        jdks.add(JDK.JAVA_17);
-        EXPECTED_POM_METADATA.setJdks(jdks);
+    void testPluginWithJenkinsfileWithJdkInfoConfiguration() {
         rewriteRun(
                 recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
                 // language=groovy
@@ -441,6 +422,127 @@ public class FetchMetadataTest implements RewriteTest {
         assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
         assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM));
 
+        // Assert JDK
+        Set<JDK> jdkVersion = pluginMetadata.getJdks();
+        assertEquals(2, jdkVersion.size());
+        assertTrue(jdkVersion.contains(JDK.JAVA_21));
+        assertTrue(jdkVersion.contains(JDK.JAVA_17));
+        assertTrue(pluginMetadata.isUseContainerAgent());
+
+        // Assert platform
+        Set<Platform> platforms = pluginMetadata.getPlatforms();
+        assertEquals(2, platforms.size());
+        assertTrue(platforms.contains(Platform.WINDOWS));
+        assertTrue(platforms.contains(Platform.LINUX));
+    }
+
+    @Test
+    void testPluginWithJenkinsfileWithJdkInfoVersion() {
+        rewriteRun(
+                recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
+                // language=groovy
+                groovy(
+                        """
+                         buildPlugin(
+                             jdkVersions: [21, 17]
+                         )
+                         """,
+                        spec -> spec.path("Jenkinsfile")));
+
+        PluginMetadata pluginMetadata = new PluginMetadata().refresh();
+        // Files are present
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+
+        // Assert JDK
+        Set<JDK> jdkVersion = pluginMetadata.getJdks();
+        assertEquals(2, jdkVersion.size());
+        assertTrue(jdkVersion.contains(JDK.JAVA_21));
+        assertTrue(jdkVersion.contains(JDK.JAVA_17));
+
+        // Assert platform
+        Set<Platform> platforms = pluginMetadata.getPlatforms();
+        assertEquals(2, platforms.size());
+        assertTrue(platforms.contains(Platform.WINDOWS));
+        assertTrue(platforms.contains(Platform.LINUX));
+    }
+
+    @Test
+    void testPluginWithJenkinsfileWithPlatformsOnly() {
+        rewriteRun(
+                recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
+                // language=groovy
+                groovy(
+                        """
+                         buildPlugin(
+                             platforms: ["linux", "windows"]
+                         )
+                         """,
+                        spec -> spec.path("Jenkinsfile")));
+
+        PluginMetadata pluginMetadata = new PluginMetadata().refresh();
+        // Files are present
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+
+        // Assert JDK
+        Set<JDK> jdkVersion = pluginMetadata.getJdks();
+        assertEquals(1, jdkVersion.size());
+        assertTrue(jdkVersion.contains(JDK.JAVA_8));
+
+        // Assert platform
+        Set<Platform> platforms = pluginMetadata.getPlatforms();
+        assertEquals(2, platforms.size());
+        assertTrue(platforms.contains(Platform.WINDOWS));
+        assertTrue(platforms.contains(Platform.LINUX));
+    }
+
+    @Test
+    void testPluginWithJenkinsfileWithJdkInfoVersionAndPlatform() {
+        rewriteRun(
+                recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
+                // language=groovy
+                groovy(
+                        """
+                         buildPlugin(
+                             platforms: ['linux'],
+                             jdkVersions: [21, 17]
+                         )
+                         """,
+                        spec -> spec.path("Jenkinsfile")));
+
+        PluginMetadata pluginMetadata = new PluginMetadata().refresh();
+        // Files are present
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+
+        // Assert JDK
+        Set<JDK> jdkVersion = pluginMetadata.getJdks();
+        assertEquals(2, jdkVersion.size());
+        assertTrue(jdkVersion.contains(JDK.JAVA_21));
+        assertTrue(jdkVersion.contains(JDK.JAVA_17));
+
+        // Assert platform
+        Set<Platform> platforms = pluginMetadata.getPlatforms();
+        assertEquals(1, platforms.size());
+        assertTrue(platforms.contains(Platform.LINUX));
+    }
+
+    @Test
+    void testPluginWithJenkinsfileWithJdkInfoVersionVar() {
+        rewriteRun(
+                recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
+                // language=groovy
+                groovy(
+                        """
+                         def versions = [21, 17]
+                         buildPlugin(
+                             jdkVersions: versions
+                         )
+                         """,
+                        spec -> spec.path("Jenkinsfile")));
+
+        PluginMetadata pluginMetadata = new PluginMetadata().refresh();
+        // Files are present
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(2, jdkVersion.size());
         assertTrue(jdkVersion.contains(JDK.JAVA_21));
@@ -448,11 +550,46 @@ public class FetchMetadataTest implements RewriteTest {
     }
 
     @Test
+    // Keep in sync with https://github.com/jenkins-infra/pipeline-library with default JDK
+    void testPluginWithJenkinsfileDefault() {
+
+        // Keep in sync with https://github.com/jenkins-infra/pipeline-library with default JDK and 2 platforms
+        EXPECTED_METADATA.addPlatform(Platform.LINUX, JDK.JAVA_8, null);
+        EXPECTED_METADATA.addPlatform(Platform.WINDOWS, JDK.JAVA_8, null);
+
+        rewriteRun(
+                recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
+                // language=groovy
+                groovy(
+                        """
+                         buildPlugin()
+                         """,
+                        spec -> spec.path("Jenkinsfile")));
+
+        PluginMetadata pluginMetadata = new PluginMetadata().refresh();
+        // Files are present
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+
+        // Assert JDK
+        Set<JDK> jdkVersion = pluginMetadata.getJdks();
+        assertEquals(1, jdkVersion.size());
+        assertNull(pluginMetadata.isUseContainerAgent());
+        assertTrue(jdkVersion.contains(JDK.JAVA_8));
+
+        // Assert platform
+        Set<Platform> platforms = pluginMetadata.getPlatforms();
+        assertEquals(2, platforms.size());
+        assertTrue(platforms.contains(Platform.WINDOWS));
+        assertTrue(platforms.contains(Platform.LINUX));
+    }
+
+    @Test
     void testJenkinsfileWithConfigurationsAsParameter() {
         Set<JDK> jdks = new LinkedHashSet<>();
         jdks.add(JDK.JAVA_11);
         jdks.add(JDK.JAVA_17);
-        EXPECTED_POM_METADATA.setJdks(jdks);
+        EXPECTED_METADATA.addPlatform(Platform.LINUX, JDK.JAVA_11, null);
+        EXPECTED_METADATA.addPlatform(Platform.WINDOWS, JDK.JAVA_17, null);
         rewriteRun(
                 recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
                 // language=groovy
@@ -477,8 +614,16 @@ public class FetchMetadataTest implements RewriteTest {
                 pomXml(POM_XML));
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+
+        // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(2, jdkVersion.size());
+
+        // Assert platform
+        Set<Platform> platforms = pluginMetadata.getPlatforms();
+        assertEquals(2, platforms.size());
+        assertTrue(platforms.contains(Platform.WINDOWS));
+        assertTrue(platforms.contains(Platform.LINUX));
     }
 
     @Test
@@ -486,18 +631,23 @@ public class FetchMetadataTest implements RewriteTest {
         Set<JDK> jdks = new LinkedHashSet<>();
         jdks.add(JDK.JAVA_11);
         jdks.add(JDK.JAVA_17);
-        EXPECTED_POM_METADATA.setJdks(jdks);
+        EXPECTED_METADATA.addPlatform(Platform.LINUX, JDK.JAVA_11, null);
+        EXPECTED_METADATA.addPlatform(Platform.WINDOWS, JDK.JAVA_17, null);
         rewriteRun(
                 recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
                 // language=groovy
                 groovy(
                         """
+                            def forkCount = '1C'
+                            def useContainerAgent = true
                             def configurations = [
                               [ platform: "linux", jdk: "11" ],
                               [ platform: "windows", jdk: "17" ]
                             ]
 
                             buildPlugin(
+                                forkCount: forkCount,
+                                useContainerAgent: useContainerAgent,
                                 failFast: false,
                                 configurations: configurations,
                                 checkstyle: [qualityGates: [[threshold: 1, type: 'NEW', unstable: true]]],
@@ -508,7 +658,19 @@ public class FetchMetadataTest implements RewriteTest {
                 pomXml(POM_XML));
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+
+        // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(2, jdkVersion.size());
+
+        // Assert platform
+        Set<Platform> platforms = pluginMetadata.getPlatforms();
+        assertEquals(2, platforms.size());
+        assertTrue(platforms.contains(Platform.WINDOWS));
+        assertTrue(platforms.contains(Platform.LINUX));
+
+        assertNotNull(pluginMetadata.isUseContainerAgent());
+        assertTrue(pluginMetadata.isUseContainerAgent());
+        assertEquals("1C", pluginMetadata.getForkCount());
     }
 }


### PR DESCRIPTION
Extract full platform information from Jenkinsfile and detect default values according to https://github.com/jenkins-infra/pipeline-library (including useContainerAgent or forkCount)

The only missing is the 'jenkinsVersion' that some plugin decide to override instead of using the default from the pom. I will add it on an other PR

This is also some preparation for https://github.com/jenkins-infra/plugin-modernizer-tool/issues/531 in order to keep the current config but migrate to new format. Or adding, removing JDK. Or removing extra jenkinsVersion or limit matrix size (for example 2 or 3 if necessary) to save compute resource

For example

```groovy
buildPlugin()
```

will have JDK8 on Linux and Windows

Or 

```groovy
buildPlugin(
   jdkVersions: [21, 17]
)
```

Will have Java 17 and 21 on Linux and Windows

This is some preparation to convert to the "new" format 

```groovy
buildPlugin(
  configurations: [
        [platform: 'linux', jdk: 21],
        [platform: 'windows', jdk: 17],
  ]
)
```

### Testing done

Mainly automated tests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
