### PR TITLE
Allow openrewrite outdated plugins

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/MavenInvoker.java
@@ -73,14 +73,14 @@ public class MavenInvoker {
     /**
      * Invoke a goal on a plugin
      * @param plugin The plugin to run the goal on
-     * @param goal The goal to run. For example, "clean"
+     * @param goals The goals to run. For example, "clean"
      */
-    public void invokeGoal(Plugin plugin, String goal) {
-        LOG.debug("Running {} phase for plugin {}", goal, plugin.getName());
+    public void invokeGoal(Plugin plugin, String... goals) {
+        LOG.debug("Running {} phase for plugin {}", goals, plugin.getName());
         LOG.debug(
                 "Running maven on directory {}",
                 plugin.getLocalRepository().toAbsolutePath().toFile());
-        invokeGoals(plugin, goal);
+        invokeGoals(plugin, goals);
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -6,6 +6,7 @@ import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
 import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.model.JDK;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.PluginProcessingException;
 import io.jenkins.tools.pluginmodernizer.core.utils.PluginService;
@@ -228,7 +229,7 @@ public class PluginModernizer {
 
             // Collect metadata and move metadata from the target directory of the plugin to the common cache
             if (!plugin.hasMetadata() || config.isFetchMetadataOnly()) {
-                collectMetadata(plugin);
+                collectMetadata(plugin, true);
 
             } else {
                 LOG.debug("Metadata already computed for plugin {}. Using cached metadata.", plugin.getName());
@@ -253,7 +254,7 @@ public class PluginModernizer {
 
                 // Retry to collect metadata after remediation to get up-to-date results
                 if (!config.isFetchMetadataOnly()) {
-                    collectMetadata(plugin);
+                    collectMetadata(plugin, true);
                 }
             }
 
@@ -292,7 +293,7 @@ public class PluginModernizer {
             if (!config.isFetchMetadataOnly()) {
                 plugin.withJDK(JDK.JAVA_17);
                 plugin.clean(mavenInvoker);
-                collectMetadata(plugin);
+                collectMetadata(plugin, false);
                 LOG.debug(
                         "Plugin {} metadata after modernization: {}",
                         plugin.getName(),
@@ -325,8 +326,34 @@ public class PluginModernizer {
      * Collect metadata for a plugin
      * @param plugin The plugin
      */
-    private void collectMetadata(Plugin plugin) {
-        plugin.collectMetadata(mavenInvoker);
+    private void collectMetadata(Plugin plugin, boolean retryAfterFirstCompile) {
+        LOG.debug("Collecting metadata for plugin {}... Please be patient", plugin.getName());
+        plugin.withJDK(JDK.JAVA_17);
+        try {
+            plugin.collectMetadata(mavenInvoker);
+            if (plugin.hasErrors()) {
+                plugin.raiseLastError();
+            }
+        } catch (ModernizerException e) {
+            if (retryAfterFirstCompile) {
+                plugin.removeErrors();
+                LOG.warn(
+                        "Failed to collect metadata for plugin {}. Will retry after a first compile using lowest JDK",
+                        plugin.getName());
+                plugin.verifyWithoutTests(mavenInvoker, JDK.JAVA_8);
+                if (plugin.hasErrors()) {
+                    LOG.debug(
+                            "Plugin {} failed to compile with JDK 8. Skipping metadata collection after retry",
+                            plugin.getName());
+                    plugin.raiseLastError();
+                }
+                plugin.withJDK(JDK.JAVA_17);
+                plugin.collectMetadata(mavenInvoker);
+            } else {
+                LOG.info("Failed to collect metadata for plugin {}. Not retrying.", plugin.getName());
+                throw e;
+            }
+        }
         plugin.copyMetadata(cacheManager);
         plugin.loadMetadata(cacheManager);
         plugin.enrichMetadata(pluginService);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -268,6 +268,12 @@ public class PluginModernizer {
             }
 
             // Run OpenRewrite
+            if (plugin.getMetadata().getJdks().stream().allMatch(jdk -> jdk.equals(JDK.JAVA_8))) {
+                LOG.info("Plugin support only Java 8. Need a first compile to general classes");
+                plugin.verifyWithoutTests(mavenInvoker, JDK.JAVA_8);
+            } else {
+                plugin.withJDK(JDK.min(plugin.getMetadata().getJdks()));
+            }
             plugin.runOpenRewrite(mavenInvoker);
             if (plugin.hasErrors()) {
                 LOG.warn(

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -620,6 +620,7 @@ public class Plugin {
      * @param maven The maven invoker instance
      */
     public void runOpenRewrite(MavenInvoker maven) {
+        withJDK(JDK.JAVA_17);
         if (config.isFetchMetadataOnly()) {
             LOG.info("Skipping OpenRewrite recipe application for plugin {} as only metadata is required", name);
             return;

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -414,6 +414,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
+  - org.openrewrite.java.RemoveUnusedImports
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.SetupDependabot


### PR DESCRIPTION
One trick I found is to compile the plugin using JDK 8 and run OpenRewrite

This work for pyenv-pipeline for example

Then fail for other reason 

- Using plugin that were detached (like command launcher)
- Use deleted constructor like

```diff
-                new SSHLauncher(ipBound(22), port(22), "test", "test", "", ""),
+                new SSHLauncher(ipBound(22), port(22), "test"),
``` 

Could use refaster template to replace the constructor

docker-fixture need to be updated to

```xml
    <dependency>
      <groupId>org.jenkins-ci.test</groupId>
      <artifactId>docker-fixtures</artifactId>
      <version>170.v2339def98d76</version>
      <scope>test</scope>
    </dependency>
```

```xml
<jenkins-test-harness.version>2.1</jenkins-test-harness.version>
```

Need to be removed

```xml
    <dependency>
      <groupId>org.jenkins-ci.main</groupId>
      <artifactId>jenkins-test-harness</artifactId>
      <version>2.24</version>
      <scope>test</scope>
    </dependency>
```

Need to be removed

### Testing done


### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
