### PR TITLE
Fix some regression for outdated plugin and add tests for fetch metadata

### DIFF
--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -83,6 +83,20 @@ public class CommandLineITCase {
                         setPluginName("replace-by-api-plugins");
                         setJenkinsVersion("2.452.4");
                     }
+                }),
+                // Similar to vagrant plugin bom
+                Arguments.of(new PluginMetadata() {
+                    {
+                        setPluginName("jenkins-1.5");
+                        setJenkinsVersion("1.532.3");
+                    }
+                }),
+                // Based on pyenv-pipeline plugin bom
+                Arguments.of(new PluginMetadata() {
+                    {
+                        setPluginName("jenkins-1.6");
+                        setJenkinsVersion("1.651.2");
+                    }
                 }));
     }
 

--- a/plugin-modernizer-cli/src/test/resources/jenkins-1.5/.gitignore
+++ b/plugin-modernizer-cli/src/test/resources/jenkins-1.5/.gitignore
@@ -1,0 +1,15 @@
+target
+
+# mvn hpi:run
+work
+
+# IntelliJ IDEA project files
+*.iml
+*.iws
+*.ipr
+.idea
+
+# Eclipse project files
+.settings
+.classpath
+.project

--- a/plugin-modernizer-cli/src/test/resources/jenkins-1.5/pom.xml
+++ b/plugin-modernizer-cli/src/test/resources/jenkins-1.5/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>1.554.1</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins</groupId>
+  <artifactId>jenkins-1.5</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <properties>
+    <jenkins.version>1.532.3</jenkins.version>
+    <java.level>7</java.level>
+    <jenkins-test-harness.version>1.532.3</jenkins-test-harness.version>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/plugin-modernizer-cli/src/test/resources/jenkins-1.5/src/main/resources/index.jelly
+++ b/plugin-modernizer-cli/src/test/resources/jenkins-1.5/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Empty
+</div>

--- a/plugin-modernizer-cli/src/test/resources/jenkins-1.6/.gitignore
+++ b/plugin-modernizer-cli/src/test/resources/jenkins-1.6/.gitignore
@@ -1,0 +1,15 @@
+target
+
+# mvn hpi:run
+work
+
+# IntelliJ IDEA project files
+*.iml
+*.iws
+*.ipr
+.idea
+
+# Eclipse project files
+.settings
+.classpath
+.project

--- a/plugin-modernizer-cli/src/test/resources/jenkins-1.6/pom.xml
+++ b/plugin-modernizer-cli/src/test/resources/jenkins-1.6/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>2.21</version>
+    <relativePath />
+  </parent>
+  <groupId>org.jenkins-ci.plugins</groupId>
+  <artifactId>jenkins-1.5</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <properties>
+    <jenkins.version>1.651.2</jenkins.version>
+    <jenkins-test-harness.version>2.1</jenkins-test-harness.version>
+  </properties>
+  <repositories>
+    <repository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>repo.jenkins-ci.org</id>
+      <url>https://repo.jenkins-ci.org/public/</url>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/plugin-modernizer-cli/src/test/resources/jenkins-1.6/src/main/resources/index.jelly
+++ b/plugin-modernizer-cli/src/test/resources/jenkins-1.6/src/main/resources/index.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<div>
+    Empty
+</div>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -515,15 +515,15 @@ public class Plugin {
     }
 
     /**
-     * Verify the plugin without tests using the given maven invoker and JDK.
+     * Verify the plugin without tests and quick build using the given maven invoker and JDK.
      * This is useful to run recipes on very outdated plugin
      * @param maven The maven invoker instance
      * @param jdk The JDK to use
      */
-    public void verifyWithoutTests(MavenInvoker maven, JDK jdk) {
+    public void verifyQuickBuild(MavenInvoker maven, JDK jdk) {
         LOG.info("Verifying plugin without tests {} using with JDK {} ... Please be patient", name, jdk.getMajor());
         this.withJDK(jdk);
-        maven.invokeGoal(this, "verify", "-DskipTests");
+        maven.invokeGoal(this, "verify", "-DskipTests", "-Pquick-build");
         if (!hasErrors()) {
             LOG.info("Done");
         }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PomModifier.java
@@ -87,6 +87,20 @@ public class PomModifier {
     }
 
     /**
+     * Return the Jenkins version of the POM file.
+     * @return the Jenkins version or null if not found
+     */
+    public String getJenkinsVersion() {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        try {
+            return xPath.compile("/project/properties/jenkins.version").evaluate(document);
+        } catch (Exception e) {
+            LOG.warn("Error getting jenkins.version: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Return the groupId of the POM file.
      * @return the groupId or null if not found
      */


### PR DESCRIPTION
Fix some regression for outdated plugin and add tests for fetch metadata

Added some tests for vagrant like and pyenv-pipeline outdated plugin

Still fail for some (like adaptive-disconnector) but I will investigate and add a test

### Testing done

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
