### PR TITLE
fix(gitpod): Removal of the `export-datatables` deprecated option.

### DIFF
--- a/.gitpod/init.sh
+++ b/.gitpod/init.sh
@@ -45,7 +45,7 @@ echo -e "If you want to use another GitHub handle, please set the ${color_green}
 echo -e "\nWe propose you to work with two Jenkins plugin repositories: ${color_cyan}badge-plugin${color_reset} and ${color_cyan}build-timestamp-plugin${color_reset}."
 echo -e "You could, though, use other plugin repositories as well (like ${color_cyan}plot-plugin${color_reset}) by entering their name in the following ${color_cyan}java${color_reset} command."
 echo -e "\nYou can now proceed with the modernizer tool thanks to the following commands:"
-echo -e "${color_cyan}java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar dry-run --plugins badge,build-timestamp --recipe AddCodeOwner --export-datatables${color_reset}"
+echo -e "${color_cyan}java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar dry-run --plugins badge,build-timestamp --recipe AddCodeOwner${color_reset}"
 
 echo -e "\nBy the way, you can copy/paste from/to the terminal to execute the commands (⇧+^+C or ⇧+⌘+C and then ⇧+^+V, ⇧+Ins, or ⇧+⌘+V). Enjoy! 🚀"
 echo -e "See ${color_blue}https://www.gitpod.io/docs/configure/user-settings/browser-settings#browser-settings${color_reset} to know more.\n"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ Learn more at [this project page](https://www.jenkins.io/projects/gsoc/2024/proj
 - [Examples](#examples)
     - [without dry-run](#without-dry-run)
     - [with dry-run](#with-dry-run)
-    - [with export-datatables](#with-export-datatables)
 
 ## Getting Started
 
@@ -217,20 +216,6 @@ The above command generates patch files instead of applying changes directly. Th
 
 > [!Note]
 > Enable dry-run to avoid opening pull requests in the remote repositories.
-
-### with export-datatables
-
-```shell
-plugin-modernizer dry-run --plugins git,git-client,jobcacher --recipe AddPluginsBom --export-datatables
-```
-
-The above command creates a report of the changes made through OpenRewrite in csv format. The report will be generated in `target/rewrite/datatables` inside the plugin directory.
-
-See example generated files:
-- [RecipeRunStats.csv](docs/example-rewrite-datatable/org.openrewrite.table.RecipeRunStats.csv)
-- [SourcesFileResults.csv](docs/example-rewrite-datatable/org.openrewrite.table.SourcesFileResults.csv)
-
-More about [Openrewrite Data Tables](https://docs.openrewrite.org/running-recipes/data-tables)
 
 ## Running with Docker
 


### PR DESCRIPTION
[Removal of the export-datatables deprecated option.](https://github.com/jenkins-infra/plugin-modernizer-tool/pull/557/commits/63af966badb9df1f5d7be15d69f8c994feb81c01) in the `README.md` and in the GitPod configuration file.

Should fix #556.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
