### PR TITLE
fix(gitpod): Creates the missing Maven local repository

### DIFF
--- a/.gitpod/init.sh
+++ b/.gitpod/init.sh
@@ -5,9 +5,9 @@
 
 # Install dependencies and perform initial setup
 
-# Run Maven clean install to ensure all project dependencies are correctly installed
+# Run Maven install to ensure all project dependencies are correctly installed
 # and the project is built successfully.
-mvn clean install -DskipTests
+mkdir -p /home/gitpod/.m2/repository && mvn install -DskipTests
 
 # Create a directory for the test plugins and move into it. This directory will serve
 # as a workspace for cloning and building Jenkins plugin repositories.


### PR DESCRIPTION
Fixes #561.

### Testing done
Used GitPod on this PR, and launched this command :
`java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar dry-run --plugins vsphere-cloud --recipe UpgradeToRecommendCoreVersion `

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
