### PR TITLE
Do not remove property if still referenced

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemoveProperty.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemoveProperty.java
@@ -2,18 +2,27 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.ScanningRecipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.RemoveContentVisitor;
 import org.openrewrite.xml.tree.Xml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Remove a Maven property if it's not referenced on current sources.
  * It allow to cleanup version overrides that are not used and still reference old version
  */
 public class RemoveProperty extends ScanningRecipe<Map<String, String>> {
+
+    /**
+     * Logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveProperty.class);
 
     @Option(
             displayName = "Property name",
@@ -45,8 +54,31 @@ public class RemoveProperty extends ScanningRecipe<Map<String, String>> {
         return new MavenIsoVisitor<>() {
             @Override
             public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
-                tag = super.visitTag(tag, ctx);
-                return tag;
+                Optional<String> maybeValue = tag.getValue();
+                if (maybeValue.isEmpty()) {
+                    return super.visitTag(tag, ctx);
+                }
+                String value = maybeValue.get();
+                if (value.contains("${" + propertyName + "}")) {
+                    LOG.info("Property {} is still referenced, skipping removal", propertyName);
+                    acc.put(propertyName, value);
+                    return super.visitTag(tag, ctx);
+                }
+                return super.visitTag(tag, ctx);
+            }
+        };
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Map<String, String> acc) {
+        return new MavenIsoVisitor<>() {
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                if (!acc.containsKey(propertyName) && tag.getName().equals(propertyName)) {
+                    doAfterVisit(new RemoveContentVisitor<>(tag, true, true));
+                    maybeUpdateModel();
+                }
+                return super.visitTag(tag, ctx);
             }
         };
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemoveProperty.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemoveProperty.java
@@ -1,0 +1,53 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+/**
+ * Remove a Maven property if it's not referenced on current sources.
+ * It allow to cleanup version overrides that are not used and still reference old version
+ */
+public class RemoveProperty extends ScanningRecipe<Map<String, String>> {
+
+    @Option(
+            displayName = "Property name",
+            description = "Key name of the property to remove.",
+            example = "configuration-as-code.version")
+    String propertyName;
+
+    public RemoveProperty(String propertyName) {
+        this.propertyName = propertyName;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Remove a Maven property if it's not referenced on current sources";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Remove a Maven property if it's not referenced on current sources.";
+    }
+
+    @Override
+    public Map<String, String> getInitialValue(ExecutionContext ctx) {
+        return new HashMap<>();
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Map<String, String> acc) {
+        return new MavenIsoVisitor<>() {
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                tag = super.visitTag(tag, ctx);
+                return tag;
+            }
+        };
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -161,12 +161,7 @@ recipeList:
       newPackageName: jakarta.servlet
       recursive: false
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
-  - org.openrewrite.maven.RemoveProperty: # Set by 5.x parent, ensure it's removed
-      propertyName: maven.compiler.release
-  - org.openrewrite.maven.RemoveProperty: # Set by 5.x parent, ensure it's removed
-      propertyName: maven.compiler.source
-  - org.openrewrite.maven.RemoveProperty: # Set by 5.x parent, ensure it's removed
-      propertyName: maven.compiler.target
+  - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -195,12 +190,20 @@ displayName: Remove extra maven properties
 tags: ['chore']
 description: Remove extra maven properties from the pom.
 recipeList:
-  - org.openrewrite.maven.RemoveProperty:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty:
       propertyName: configuration-as-code.version
-  - org.openrewrite.maven.RemoveProperty:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty:
+      propertyName: jenkins-test-harness.version
+  - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty:
       propertyName: java.version
-  - org.openrewrite.maven.RemoveProperty:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty:
       propertyName: java.level
+  - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty: # Set by parent, ensure it's removed
+      propertyName: maven.compiler.release
+  - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty: # Set by parent, ensure it's removed
+      propertyName: maven.compiler.source
+  - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty: # Set by parent, ensure it's removed
+      propertyName: maven.compiler.target
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.ReplaceLibrariesWithApiPlugin

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -470,6 +469,9 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <name>Empty Plugin</name>
                           <properties>
                             <jenkins.version>2.440.3</jenkins.version>
+                             <maven.compiler.source>17</maven.compiler.source>
+                             <maven.compiler.release>17</maven.compiler.release>
+                             <maven.compiler.target>17</maven.compiler.target>
                           </properties>
                           <dependencies>
                             <dependency>
@@ -1112,7 +1114,11 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
                           <properties>
+                             <java.version>17</java.version>
                              <jenkins.version>2.440.3</jenkins.version>
+                             <maven.compiler.source>17</maven.compiler.source>
+                             <maven.compiler.release>17</maven.compiler.release>
+                             <maven.compiler.target>17</maven.compiler.target>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -1389,7 +1395,6 @@ public class DeclarativeRecipesTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("See https://github.com/jenkins-infra/plugin-modernizer-tool/issues/517")
     void addPluginBomTestAndRemoveProperties() {
         rewriteRun(
                 spec -> spec.recipeFromResource(

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemovePropertyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemovePropertyTest.java
@@ -13,7 +13,7 @@ public class RemovePropertyTest implements RewriteTest {
     @Test
     void shouldRemoveProperty() {
         rewriteRun(
-                spec -> spec.recipe(new RemoveProperty("foo.bar")),
+                spec -> spec.recipe(new RemoveProperty("json-api.version")),
                 // language=xml
                 pomXml(
                         """
@@ -32,8 +32,15 @@ public class RemovePropertyTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                    <foo.bar>1.0.0</foo.bar>
+                    <json-api.version>20240303-41.v94e11e6de726</json-api.version>
                   </properties>
+                  <dependencies>
+                    <dependency>
+                       <groupId>io.jenkins.plugins</groupId>
+                       <artifactId>json-api</artifactId>
+                       <version>20240303-41.v94e11e6de726</version>
+                    </dependency>
+                  </dependencies>
                   <repositories>
                     <repository>
                       <id>repo.jenkins-ci.org</id>
@@ -49,33 +56,87 @@ public class RemovePropertyTest implements RewriteTest {
                 </project>
                 """,
                         """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                   <modelVersion>4.0.0</modelVersion>
-                   <parent>
-                     <groupId>org.jenkins-ci.plugins</groupId>
-                     <artifactId>plugin</artifactId>
-                     <version>4.88</version>
-                     <relativePath />
-                   </parent>
-                   <groupId>io.jenkins.plugins</groupId>
-                   <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
-                   <packaging>hpi</packaging>
-                   <name>Empty Plugin</name>
-                   <repositories>
-                     <repository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </repository>
-                   </repositories>
-                   <pluginRepositories>
-                     <pluginRepository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </pluginRepository>
-                   </pluginRepositories>
-                 </project>
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.88</version>
+                    <relativePath />
+                  </parent>
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>empty</artifactId>
+                  <version>1.0.0-SNAPSHOT</version>
+                  <packaging>hpi</packaging>
+                  <name>Empty Plugin</name>
+                  <dependencies>
+                    <dependency>
+                       <groupId>io.jenkins.plugins</groupId>
+                       <artifactId>json-api</artifactId>
+                       <version>20240303-41.v94e11e6de726</version>
+                    </dependency>
+                  </dependencies>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
+                """));
+    }
+
+    @Test
+    void shouldNotRemoveProperty() {
+        rewriteRun(
+                spec -> spec.recipe(new RemoveProperty("json-api.version")),
+                // language=xml
+                pomXml(
+                        """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.88</version>
+                    <relativePath />
+                  </parent>
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>empty</artifactId>
+                  <version>1.0.0-SNAPSHOT</version>
+                  <packaging>hpi</packaging>
+                  <name>Empty Plugin</name>
+                  <properties>
+                    <json-api.version>20240303-41.v94e11e6de726</json-api.version>
+                  </properties>
+                  <dependencies>
+                    <dependency>
+                       <groupId>io.jenkins.plugins</groupId>
+                       <artifactId>json-api</artifactId>
+                       <version>${json-api.version}</version>
+                    </dependency>
+                  </dependencies>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
                 """));
     }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemovePropertyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemovePropertyTest.java
@@ -1,0 +1,81 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+
+/**
+ * Test for {@link IsMissingBom}.
+ */
+public class RemovePropertyTest implements RewriteTest {
+
+    @Test
+    void shouldRemoveProperty() {
+        rewriteRun(
+                spec -> spec.recipe(new RemoveProperty("foo.bar")),
+                // language=xml
+                pomXml(
+                        """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.88</version>
+                    <relativePath />
+                  </parent>
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>empty</artifactId>
+                  <version>1.0.0-SNAPSHOT</version>
+                  <packaging>hpi</packaging>
+                  <name>Empty Plugin</name>
+                  <properties>
+                    <foo.bar>1.0.0</foo.bar>
+                  </properties>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
+                """,
+                        """
+                 <?xml version="1.0" encoding="UTF-8"?>
+                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                   <modelVersion>4.0.0</modelVersion>
+                   <parent>
+                     <groupId>org.jenkins-ci.plugins</groupId>
+                     <artifactId>plugin</artifactId>
+                     <version>4.88</version>
+                     <relativePath />
+                   </parent>
+                   <groupId>io.jenkins.plugins</groupId>
+                   <artifactId>empty</artifactId>
+                   <version>1.0.0-SNAPSHOT</version>
+                   <packaging>hpi</packaging>
+                   <name>Empty Plugin</name>
+                   <repositories>
+                     <repository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </repository>
+                   </repositories>
+                   <pluginRepositories>
+                     <pluginRepository>
+                       <id>repo.jenkins-ci.org</id>
+                       <url>https://repo.jenkins-ci.org/public/</url>
+                     </pluginRepository>
+                   </pluginRepositories>
+                 </project>
+                """));
+    }
+}


### PR DESCRIPTION
Fix #517 

Implement a smarter RemoveProperty to only remove a property if not referenced on the current sources

### Testing done

tests and ensure `addPluginBomTestAndRemoveProperties` is now passing by keeping `configuration-as-code.version`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

