### PR TITLE
Fix --plugin-path when running with run command and support default value

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
@@ -29,7 +29,7 @@ public class BuildMetadataCommand implements ICommand {
     /**
      * Plugins options
      */
-    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    @CommandLine.ArgGroup
     private PluginOptions pluginOptions;
 
     /**
@@ -56,6 +56,9 @@ public class BuildMetadataCommand implements ICommand {
     public Config setup(Config.Builder builder) {
         options.config(builder);
         envOptions.config(builder);
+        if (pluginOptions == null) {
+            pluginOptions = new PluginOptions();
+        }
         pluginOptions.config(builder);
         return builder.withSshPrivateKey(sshPrivateKey)
                 .withRecipe(Settings.FETCH_METADATA_RECIPE)

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
@@ -27,7 +27,7 @@ public class DryRunCommand implements ICommand {
     /**
      * Plugins options
      */
-    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    @CommandLine.ArgGroup
     private PluginOptions pluginOptions;
 
     /**
@@ -61,6 +61,9 @@ public class DryRunCommand implements ICommand {
     @Override
     public Config setup(Config.Builder builder) {
         options.config(builder);
+        if (pluginOptions == null) {
+            pluginOptions = new PluginOptions();
+        }
         pluginOptions.config(builder);
         githubOptions.config(builder);
         envOptions.config(builder);

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
@@ -75,8 +75,7 @@ public class RunCommand implements ICommand {
         envOptions.config(builder);
         pluginOptions.config(builder);
         githubOptions.config(builder);
-        return builder.withDryRun(false)
-                .withRecipe(recipe)
+        return builder.withRecipe(recipe)
                 .withDraft(draft)
                 .withRemoveForks(removeForks)
                 .build();

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
@@ -27,7 +27,7 @@ public class RunCommand implements ICommand {
     /**
      * Plugins options
      */
-    @CommandLine.ArgGroup(exclusive = true, multiplicity = "1")
+    @CommandLine.ArgGroup
     private PluginOptions pluginOptions;
 
     /**
@@ -73,6 +73,9 @@ public class RunCommand implements ICommand {
     public Config setup(Config.Builder builder) {
         options.config(builder);
         envOptions.config(builder);
+        if (pluginOptions == null) {
+            pluginOptions = new PluginOptions();
+        }
         pluginOptions.config(builder);
         githubOptions.config(builder);
         return builder.withRecipe(recipe)

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/PluginOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/PluginOptions.java
@@ -4,9 +4,9 @@ import io.jenkins.tools.pluginmodernizer.cli.converter.PluginConverter;
 import io.jenkins.tools.pluginmodernizer.cli.converter.PluginFileConverter;
 import io.jenkins.tools.pluginmodernizer.cli.converter.PluginPathConverter;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -70,9 +70,19 @@ public final class PluginOptions implements IOption {
         if (pluginsFromFile == null) {
             pluginsFromFile = List.of();
         }
-        return Stream.concat(
+        List<Plugin> effectivePlugins = Stream.concat(
                         pluginPath != null ? Stream.of(pluginPath) : Stream.empty(),
                         Stream.concat(plugins.stream(), pluginsFromFile.stream()))
-                .collect(Collectors.toList());
+                .toList();
+
+        // Use current folder as plugin if no plugin is provided
+        if (effectivePlugins.isEmpty()) {
+            try {
+                effectivePlugins.add(new PluginPathConverter().convert("."));
+            } catch (Exception e) {
+                throw new ModernizerException("Current directory doesn't seem to contains a plugin", e);
+            }
+        }
+        return effectivePlugins;
     }
 }


### PR DESCRIPTION
By default when running without plugin argument it will use the local directory using implicit `--plugin-path .` arg.

This would make very easy to run recipes during development or when refreshing a very old plugin (where some action are manual because we cannot do magic).

For example I use this approach on https://github.com/jenkinsci/pipeline-cps-http-plugin/pull/16 

### Testing done

Automated tests

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
