### PR TITLE
Avoid hardcoding implicit JDK and workarround #580

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/JenkinsfileVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/JenkinsfileVisitor.java
@@ -84,8 +84,8 @@ public class JenkinsfileVisitor extends GroovyIsoVisitor<PluginMetadata> {
 
             // Empty args means Java 8 in Windows and Linux
             if (args.size() == 1 && args.get(0) instanceof J.Empty) {
-                pluginMetadata.addPlatform(new PlatformConfig(Platform.LINUX, JDK.JAVA_8, null, true));
-                pluginMetadata.addPlatform(new PlatformConfig(Platform.WINDOWS, JDK.JAVA_8, null, true));
+                pluginMetadata.addPlatform(new PlatformConfig(Platform.LINUX, JDK.getImplicit(), null, true));
+                pluginMetadata.addPlatform(new PlatformConfig(Platform.WINDOWS, JDK.getImplicit(), null, true));
                 return method;
             }
 
@@ -112,7 +112,7 @@ public class JenkinsfileVisitor extends GroovyIsoVisitor<PluginMetadata> {
                 for (PlatformConfig pc : platforms) {
                     if (!pc.name().equals(Platform.UNKNOWN)) {
                         if (platforms.stream().allMatch(p -> p.jdk() == null)) {
-                            newPlatforms.add(new PlatformConfig(pc.name(), JDK.JAVA_8, null, false));
+                            newPlatforms.add(new PlatformConfig(pc.name(), JDK.getImplicit(), null, false));
                             continue;
                         }
                         for (PlatformConfig pc2 : platforms) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
@@ -140,6 +140,14 @@ public enum JDK {
     }
 
     /**
+     * Get the implicit JDK when not specified on Jenkinsfile
+     * @return The implicit JDK
+     */
+    public static JDK getImplicit() {
+        return JDK.JAVA_8;
+    }
+
+    /**
      * Has next predicate
      * @param jdk The JDK
      * @return True if there is a next JDK
@@ -219,6 +227,18 @@ public enum JDK {
             return JDK.min();
         }
         return jdks.stream().min(JDK::compareMajor).orElseThrow();
+    }
+
+    /**
+     * Return the minimum JDK
+     * @param jdks List of JDKS. Can be null or empty
+     * @return The minimum JDK. If the list is empty, return the minimum JDK available
+     */
+    public static JDK min(Set<JDK> jdks, String jenkinsVersion) {
+        if (jdks == null || jdks.isEmpty() && jenkinsVersion == null) {
+            return JDK.min();
+        }
+        return JDK.get(jenkinsVersion).stream().min(JDK::compareMajor).orElseThrow();
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/StaticPomParser.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/StaticPomParser.java
@@ -83,6 +83,20 @@ public class StaticPomParser {
     }
 
     /**
+     * Return the Jenkins baseline of the POM file.
+     * @return the Jenkins baseline or null if not found
+     */
+    public String getBaseline() {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        try {
+            return xPath.compile("/project/properties/jenkins.baseline").evaluate(document);
+        } catch (Exception e) {
+            LOG.warn("Error getting baseline: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Return the groupId of the POM file.
      * @return the groupId or null if not found
      */

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/FetchMetadataTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/FetchMetadataTest.java
@@ -554,8 +554,8 @@ public class FetchMetadataTest implements RewriteTest {
     void testPluginWithJenkinsfileDefault() {
 
         // Keep in sync with https://github.com/jenkins-infra/pipeline-library with default JDK and 2 platforms
-        EXPECTED_METADATA.addPlatform(Platform.LINUX, JDK.JAVA_8, null);
-        EXPECTED_METADATA.addPlatform(Platform.WINDOWS, JDK.JAVA_8, null);
+        EXPECTED_METADATA.addPlatform(Platform.LINUX, JDK.getImplicit(), null);
+        EXPECTED_METADATA.addPlatform(Platform.WINDOWS, JDK.getImplicit(), null);
 
         rewriteRun(
                 recipeSpec -> recipeSpec.recipe(new FetchMetadata()),
@@ -574,7 +574,7 @@ public class FetchMetadataTest implements RewriteTest {
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(1, jdkVersion.size());
         assertNull(pluginMetadata.isUseContainerAgent());
-        assertTrue(jdkVersion.contains(JDK.JAVA_8));
+        assertTrue(jdkVersion.contains(JDK.getImplicit()));
 
         // Assert platform
         Set<Platform> platforms = pluginMetadata.getPlatforms();

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
@@ -3,6 +3,7 @@ package io.jenkins.tools.pluginmodernizer.core.model;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 public class JDKTest {
@@ -45,6 +46,17 @@ public class JDKTest {
         assertEquals(JDK.JAVA_11, JDK.all().get(1));
         assertEquals(JDK.JAVA_17, JDK.all().get(2));
         assertEquals(JDK.JAVA_21, JDK.all().get(3));
+    }
+
+    @Test
+    public void min() {
+        assertEquals(JDK.JAVA_8, JDK.min());
+        assertEquals(JDK.JAVA_8, JDK.min(Set.of(JDK.values())));
+        assertEquals(JDK.JAVA_8, JDK.min(Set.of(JDK.values()), "2.164.1"));
+        assertEquals(JDK.JAVA_8, JDK.min(Set.of(JDK.values()), "2.346.1"));
+        assertEquals(JDK.JAVA_11, JDK.min(Set.of(JDK.values()), "2.361.1"));
+        assertEquals(JDK.JAVA_11, JDK.min(Set.of(JDK.values()), "2.462.3"));
+        assertEquals(JDK.JAVA_17, JDK.min(Set.of(JDK.values()), "2.479.1"));
     }
 
     @Test


### PR DESCRIPTION
Avoid hardcoding implicit JDK and workarround #580

### Testing done

Tested with #580 and confirmed Java 11 is used in that case 

Also avoid hardcoding implicit Java version if by any change https://github.com/jenkins-infra/pipeline-library/pull/897#issuecomment-2575014565 is merged

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
