### PR TITLE
Add `MergeGitIgnoreRecipe` to merge existing .gitignore file with common entries

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipe.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipe.java
@@ -1,5 +1,10 @@
 package io.jenkins.tools.pluginmodernizer.core.recipes;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
@@ -7,12 +12,6 @@ import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.xml.tree.Xml;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.stream.Collectors;
 
 public class MergeGitIgnoreRecipe extends Recipe {
     private static final Logger LOG = LoggerFactory.getLogger(MergeGitIgnoreRecipe.class);
@@ -54,9 +53,7 @@ public class MergeGitIgnoreRecipe extends Recipe {
             try {
                 if (Files.exists(gitIgnorePath) && Files.exists(archetypeGitIgnorePath)) {
                     String merged = mergeGitIgnoreFiles(
-                        Files.readString(gitIgnorePath),
-                        Files.readString(archetypeGitIgnorePath)
-                    );
+                            Files.readString(gitIgnorePath), Files.readString(archetypeGitIgnorePath));
                     Files.writeString(gitIgnorePath, merged);
                 }
             } catch (IOException e) {
@@ -68,7 +65,7 @@ public class MergeGitIgnoreRecipe extends Recipe {
         private String mergeGitIgnoreFiles(String existing, String fromArchetype) {
             List<String> existingLines = existing.lines().collect(Collectors.toList());
             List<String> archetypeLines = fromArchetype.lines().collect(Collectors.toList());
-            
+
             StringBuilder merged = new StringBuilder(existing);
             if (!existing.endsWith("\n")) {
                 merged.append("\n");

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipe.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipe.java
@@ -1,0 +1,92 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MergeGitIgnoreRecipe extends Recipe {
+    private static final Logger LOG = LoggerFactory.getLogger(MergeGitIgnoreRecipe.class);
+    private final Path archetypeGitIgnorePath;
+
+    public MergeGitIgnoreRecipe(Path archetypeGitIgnorePath) {
+        this.archetypeGitIgnorePath = archetypeGitIgnorePath;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Merge .gitignore Entries";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Merges .gitignore entries from archetype with existing .gitignore file.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new GitIgnoreMerger(archetypeGitIgnorePath);
+    }
+
+    private static class GitIgnoreMerger extends MavenIsoVisitor<ExecutionContext> {
+        private final Path archetypeGitIgnorePath;
+
+        GitIgnoreMerger(Path archetypeGitIgnorePath) {
+            this.archetypeGitIgnorePath = archetypeGitIgnorePath;
+        }
+
+        @Override
+        public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+            Path projectPath = document.getSourcePath().getParent();
+            if (projectPath == null) return document;
+
+            Path gitIgnorePath = projectPath.resolve(".gitignore");
+
+            try {
+                if (Files.exists(gitIgnorePath) && Files.exists(archetypeGitIgnorePath)) {
+                    String merged = mergeGitIgnoreFiles(
+                        Files.readString(gitIgnorePath),
+                        Files.readString(archetypeGitIgnorePath)
+                    );
+                    Files.writeString(gitIgnorePath, merged);
+                }
+            } catch (IOException e) {
+                LOG.error("Error processing .gitignore files", e);
+            }
+            return document;
+        }
+
+        private String mergeGitIgnoreFiles(String existing, String fromArchetype) {
+            List<String> existingLines = existing.lines().collect(Collectors.toList());
+            List<String> archetypeLines = fromArchetype.lines().collect(Collectors.toList());
+            
+            StringBuilder merged = new StringBuilder(existing);
+            if (!existing.endsWith("\n")) {
+                merged.append("\n");
+            }
+            merged.append("\n# Added from archetype\n");
+
+            for (String line : archetypeLines) {
+                String trimmed = line.trim();
+                if (!trimmed.isEmpty() && !trimmed.startsWith("#") && !existingContains(existingLines, trimmed)) {
+                    merged.append(line).append("\n");
+                }
+            }
+
+            return merged.toString();
+        }
+
+        private boolean existingContains(List<String> existingLines, String newLine) {
+            return existingLines.contains(newLine) || existingLines.contains(newLine + "/");
+        }
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipe.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipe.java
@@ -7,9 +7,9 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.maven.MavenIsoVisitor;
-import org.openrewrite.xml.tree.Xml;
+import org.openrewrite.text.PlainText;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +36,7 @@ public class MergeGitIgnoreRecipe extends Recipe {
         return new GitIgnoreMerger(archetypeGitIgnorePath);
     }
 
-    private static class GitIgnoreMerger extends MavenIsoVisitor<ExecutionContext> {
+    private static class GitIgnoreMerger extends TreeVisitor<PlainText, ExecutionContext> {
         private final Path archetypeGitIgnorePath;
 
         GitIgnoreMerger(Path archetypeGitIgnorePath) {
@@ -44,22 +44,33 @@ public class MergeGitIgnoreRecipe extends Recipe {
         }
 
         @Override
-        public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
-            Path projectPath = document.getSourcePath().getParent();
-            if (projectPath == null) return document;
+        public PlainText visit(Tree tree, ExecutionContext ctx) {
+            PlainText text = (PlainText) tree;
+            if (!(tree instanceof PlainText)) {
+                return null;
+            }
+            // Check if the current file is a `.gitignore` file
+            if (!text.getSourcePath().getFileName().toString().equals(".gitignore")) {
+                return text;
+            }
 
-            Path gitIgnorePath = projectPath.resolve(".gitignore");
-
+            Path gitIgnorePath = text.getSourcePath();
             try {
                 if (Files.exists(gitIgnorePath) && Files.exists(archetypeGitIgnorePath)) {
-                    String merged = mergeGitIgnoreFiles(
-                            Files.readString(gitIgnorePath), Files.readString(archetypeGitIgnorePath));
-                    Files.writeString(gitIgnorePath, merged);
+                    String existingContent = Files.readString(gitIgnorePath);
+                    String archetypeContent = Files.readString(archetypeGitIgnorePath);
+                    String mergedContent = mergeGitIgnoreFiles(existingContent, archetypeContent);
+
+                    // Write back the merged content to the file
+                    Files.writeString(gitIgnorePath, mergedContent);
+                    LOG.info("Merged .gitignore at {}", gitIgnorePath);
                 }
             } catch (IOException e) {
-                LOG.error("Error processing .gitignore files", e);
+                LOG.error("Error processing .gitignore files at {}", gitIgnorePath, e);
+                throw new RuntimeException("Failed to process .gitignore files", e);
             }
-            return document;
+
+            return text;
         }
 
         private String mergeGitIgnoreFiles(String existing, String fromArchetype) {
@@ -74,16 +85,12 @@ public class MergeGitIgnoreRecipe extends Recipe {
 
             for (String line : archetypeLines) {
                 String trimmed = line.trim();
-                if (!trimmed.isEmpty() && !trimmed.startsWith("#") && !existingContains(existingLines, trimmed)) {
+                if (!trimmed.isEmpty() && !trimmed.startsWith("#") && !existingLines.contains(trimmed)) {
                     merged.append(line).append("\n");
                 }
             }
 
             return merged.toString();
-        }
-
-        private boolean existingContains(List<String> existingLines, String newLine) {
-            return existingLines.contains(newLine) || existingLines.contains(newLine + "/");
         }
     }
 }

--- a/plugin-modernizer-core/src/main/jte/pr-title-MergeGitIgnoreRecipe.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-MergeGitIgnoreRecipe.jte
@@ -1,0 +1,5 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+Merges .gitignore entries from archetype with existing .gitignore file.

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -8,6 +8,14 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.FetchMetadata
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.MergeGitIgnoreRecipe
+displayName: Merge .gitignore Entries
+description: Merges the .gitignore entries from the archetype with the existing .gitignore file.
+tags: ['chore']
+recipeList:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.MergeGitIgnoreRecipe
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.SetupJenkinsfile
 displayName: Setup the Jenkinsfile
 description: Add a missing Jenkinsfile to the Jenkins plugin.

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -8,6 +8,14 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.FetchMetadata
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.MergeGitIgnoreRecipe
+displayName: Merge .gitignore Entries
+description: Merges the .gitignore entries from the archetype with the existing .gitignore file.
+tags: ['chore']
+recipeList:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.MergeGitIgnoreRecipe
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpdateScmUrl
 displayName: Update scm urls from git:// to https://
 description: Updates scm urls in POM files from git:// to https:// protocol as git:// protocol is deprecated by GitHub

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -8,14 +8,6 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.FetchMetadata
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: io.jenkins.tools.pluginmodernizer.MergeGitIgnoreRecipe
-displayName: Merge .gitignore Entries
-description: Merges the .gitignore entries from the archetype with the existing .gitignore file.
-tags: ['chore']
-recipeList:
-  - io.jenkins.tools.pluginmodernizer.core.recipes.MergeGitIgnoreRecipe
----
-type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.SetupJenkinsfile
 displayName: Setup the Jenkinsfile
 description: Add a missing Jenkinsfile to the Jenkins plugin.

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipeTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipeTest.java
@@ -1,0 +1,68 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RewriteTest;
+import static org.openrewrite.test.SourceSpecs.text;
+import java.nio.file.Path;
+
+public class MergeGitIgnoreRecipeTest implements RewriteTest {
+    @Test
+    void shouldMergeGitIgnoreEntries() {
+        rewriteRun(
+            spec -> spec.recipe(new MergeGitIgnoreRecipe(Path.of("archetypes/common-files/.gitignore"))),
+            text(
+                """
+                # Existing user-defined entries
+                *.log
+                build/
+                .idea/
+                
+                # Custom section
+                custom/*.tmp
+                """,
+                sourceSpecs -> sourceSpecs.path(".gitignore")
+            ),
+            text(
+                """
+                target
+                work
+                
+                # mvn hpi:run
+                # IntelliJ IDEA project files
+                *.iml
+                *.iws
+                *.ipr
+                .idea
+                
+                # Eclipse project files
+                .settings
+                .classpath
+                .project
+                """,
+                sourceSpecs -> sourceSpecs.path("archetypes/common-files/.gitignore")
+            ),
+            text(
+                """
+                # Existing user-defined entries
+                *.log
+                build/
+                .idea/
+                
+                # Custom section
+                custom/*.tmp
+                
+                # Added from archetype
+                target
+                work
+                *.iml
+                *.iws
+                *.ipr
+                .settings
+                .classpath
+                .project
+                """,
+                sourceSpecs -> sourceSpecs.path(".gitignore")
+            )
+        );
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipeTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MergeGitIgnoreRecipeTest.java
@@ -1,56 +1,55 @@
 package io.jenkins.tools.pluginmodernizer.core.recipes;
 
+import static org.openrewrite.test.SourceSpecs.text;
+
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.test.RewriteTest;
-import static org.openrewrite.test.SourceSpecs.text;
-import java.nio.file.Path;
 
 public class MergeGitIgnoreRecipeTest implements RewriteTest {
     @Test
     void shouldMergeGitIgnoreEntries() {
         rewriteRun(
-            spec -> spec.recipe(new MergeGitIgnoreRecipe(Path.of("archetypes/common-files/.gitignore"))),
-            text(
-                """
+                spec -> spec.recipe(new MergeGitIgnoreRecipe(Path.of("archetypes/common-files/.gitignore"))),
+                text(
+                        """
                 # Existing user-defined entries
                 *.log
                 build/
                 .idea/
-                
+
                 # Custom section
                 custom/*.tmp
                 """,
-                sourceSpecs -> sourceSpecs.path(".gitignore")
-            ),
-            text(
-                """
+                        sourceSpecs -> sourceSpecs.path(".gitignore")),
+                text(
+                        """
                 target
                 work
-                
+
                 # mvn hpi:run
                 # IntelliJ IDEA project files
                 *.iml
                 *.iws
                 *.ipr
                 .idea
-                
+
                 # Eclipse project files
                 .settings
                 .classpath
                 .project
                 """,
-                sourceSpecs -> sourceSpecs.path("archetypes/common-files/.gitignore")
-            ),
-            text(
-                """
+                        sourceSpecs -> sourceSpecs.path("archetypes/common-files/.gitignore")),
+                text(
+                        """
                 # Existing user-defined entries
                 *.log
                 build/
                 .idea/
-                
+
                 # Custom section
                 custom/*.tmp
-                
+
                 # Added from archetype
                 target
                 work
@@ -61,8 +60,6 @@ public class MergeGitIgnoreRecipeTest implements RewriteTest {
                 .classpath
                 .project
                 """,
-                sourceSpecs -> sourceSpecs.path(".gitignore")
-            )
-        );
+                        sourceSpecs -> sourceSpecs.path(".gitignore")));
     }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -256,4 +256,23 @@ public class TemplateUtilsTest {
         // Assert
         assertEquals("Setup .gitignore file", result);
     }
+
+    @Test
+    public void testPrTitleForMergeGitIgnoreRecipe() {
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata metadata = mock(PluginMetadata.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn(metadata).when(plugin).getMetadata();
+        doReturn("io.jenkins.tools.pluginmodernizer.MergeGitIgnoreRecipe")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
+
+        // Assert
+        assertEquals("Merges .gitignore entries from archetype with existing .gitignore file.", result);
+    }
 }


### PR DESCRIPTION
Added the logic to merge the existing gitignore files with the archetype gitignore files

Fixes  #532

### Testing done
Yes

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
-> Added the MergeGitIgnoreRecipe to handle the merging of the existing gitignore files with the archetype gitignore files.
-> Added tests to verify that the recipe is working as expected.
-> Logic such that the archetype file can be provided as a constructor argument and the recipe takes care of merging.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
