### PR TITLE
Use value of gitHubRepo for local plugin if present

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -181,6 +181,7 @@ public class PluginModernizer {
             // Determine repo name
             plugin.withRepositoryName(pluginService.extractRepoName(plugin));
 
+            LOG.debug("Repository name: {}", plugin.getRepositoryName());
             LOG.debug("Plugin {} latest version: {}", plugin.getName(), pluginService.extractVersion(plugin));
             LOG.debug("Plugin {} health score: {}", plugin.getName(), pluginService.extractScore(plugin));
             LOG.debug("Plugin {} installations: {}", plugin.getName(), pluginService.extractInstallationStats(plugin));

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/StaticPomParser.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/StaticPomParser.java
@@ -97,6 +97,20 @@ public class StaticPomParser {
     }
 
     /**
+     * Return gitHubRepo property of the POM file or null if not found.
+     * @return the gitHubRepo property or null if not found
+     */
+    public String getGithubRepoProperty() {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        try {
+            return xPath.compile("/project/properties/gitHubRepo").evaluate(document);
+        } catch (Exception e) {
+            LOG.warn("Error getting github.repo: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Return the groupId of the POM file.
      * @return the groupId or null if not found
      */

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
@@ -18,6 +18,7 @@ import io.jenkins.tools.pluginmodernizer.core.model.PluginInstallationStatsData;
 import io.jenkins.tools.pluginmodernizer.core.model.UpdateCenterData;
 import java.lang.reflect.Field;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -123,6 +124,48 @@ class PluginServiceTest {
         PluginService service = getService();
         String result = service.extractRepoName(Plugin.build("valid-plugin").withConfig(config));
         assertEquals("valid-url", result);
+    }
+
+    @Test
+    public void shouldExtractRepoNameForLocalDefaultPluginWithGitHubRepo() throws Exception {
+        PluginService service = getService();
+
+        // language=xml
+        String pom =
+                """
+                    <project>
+                        <properties>
+                            <gitHubRepo>jenkinsci/foobar</gitHubRepo>
+                        </properties>
+                    </project>
+                    """;
+
+        Plugin plugin = Plugin.build("valid-plugin").withConfig(config);
+        plugin.withLocal(true);
+        plugin.withLocalRepository(tempDir);
+        Files.writeString(tempDir.resolve("pom.xml"), pom);
+        String result = service.extractRepoName(plugin);
+        assertEquals("foobar", result);
+    }
+
+    @Test
+    public void shouldExtractRepoNameForLocalDefaultPluginFallbackFolder() throws Exception {
+        PluginService service = getService();
+
+        // language=xml
+        String pom =
+                """
+                    <project>
+                        <properties/>
+                    </project>
+                    """;
+
+        Plugin plugin = Plugin.build("valid-plugin").withConfig(config);
+        plugin.withLocal(true);
+        plugin.withLocalRepository(tempDir);
+        Files.writeString(tempDir.resolve("pom.xml"), pom);
+        String result = service.extractRepoName(plugin);
+        assertEquals(tempDir.getFileName().toString(), result);
     }
 
     @Test


### PR DESCRIPTION
Still some issue with implicit --plugin-path .

Use value of gitHubRepo if present and fallback to folder name if we cannot determine the repo name

Integration didn't catch it because always use explicit --plugin-path

### Testing done

Write 2 unit tests to catch this behavior

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


