### PR TITLE
Add a Java ISO visitor for metadata collection

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -260,6 +260,17 @@
                   <artifactId>javax.servlet-api</artifactId>
                   <version>4.0.1</version>
                 </dependency>
+                <!-- Testcontainers and docker-fixtures to check if package exists -->
+                <dependency>
+                  <groupId>org.testcontainers</groupId>
+                  <artifactId>testcontainers</artifactId>
+                  <version>1.20.4</version>
+                </dependency>
+                <dependency>
+                  <groupId>org.jenkins-ci.test</groupId>
+                  <artifactId>docker-fixtures</artifactId>
+                  <version>200.v22a_e8766731c</version>
+                </dependency>
                 <!-- SSH slave migration from 1.12 to latest -->
                 <dependency>
                   <groupId>org.jenkins-ci.plugins</groupId>

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/JavaFileVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/JavaFileVisitor.java
@@ -1,0 +1,32 @@
+package io.jenkins.tools.pluginmodernizer.core.extractor;
+
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A visitor to extract metadata from Java files.
+ */
+public class JavaFileVisitor extends JavaIsoVisitor<PluginMetadata> {
+
+    /**
+     * LOGGER.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(JavaFileVisitor.class);
+
+    @Override
+    public J.Import visitImport(J.Import _import, PluginMetadata pluginMetadata) {
+        _import = super.visitImport(_import, pluginMetadata);
+        // Rather a naive approach, but let's assume we can detect testcontainers usage by the package name
+        if (_import.getPackageName().startsWith("org.testcontainers.containers")) {
+            LOG.info("Found testcontainers import: {}. Plugin is using container tests", _import.getPackageName());
+            pluginMetadata.setUseContainerTests(true);
+        }
+        if (_import.getPackageName().startsWith("org.jenkinsci.test.acceptance.docker")) {
+            LOG.info("Found docker-fixtures import: {}. Plugin is using container tests", _import.getPackageName());
+            pluginMetadata.setUseContainerTests(true);
+        }
+        return _import;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFinalizerVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFinalizerVisitor.java
@@ -1,6 +1,9 @@
 package io.jenkins.tools.pluginmodernizer.core.extractor;
 
-import io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils;
+import static io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils.fromJson;
+import static io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils.merge;
+import static io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils.toJson;
+
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
@@ -22,22 +25,24 @@ public class MetadataFinalizerVisitor extends TreeVisitor<Tree, ExecutionContext
 
         PluginMetadata mergedMetadata = ctx.getMessage("mergedMetadata", new PluginMetadata());
         PluginMetadata commonMetadata = ctx.getMessage("commonMetadata", new PluginMetadata());
-        PluginMetadata pluginMetadata = ctx.getMessage("pomMetadata", new PluginMetadata());
+        PluginMetadata pomMetadata = ctx.getMessage("pomMetadata", new PluginMetadata());
+        PluginMetadata javaMetadata = ctx.getMessage("javaMetadata", new PluginMetadata());
         PluginMetadata jenkinsFileMetadata = ctx.getMessage("jenkinsFileMetadata", new PluginMetadata());
 
         // Merge the metadata
-        PluginMetadata merged = JsonUtils.fromJson(
-                JsonUtils.merge(pluginMetadata.toJson(), jenkinsFileMetadata.toJson()), PluginMetadata.class);
-        merged = JsonUtils.fromJson(JsonUtils.merge(commonMetadata.toJson(), merged.toJson()), PluginMetadata.class);
-        merged = JsonUtils.fromJson(JsonUtils.merge(mergedMetadata.toJson(), merged.toJson()), PluginMetadata.class);
+        PluginMetadata merged =
+                fromJson(merge(pomMetadata.toJson(), jenkinsFileMetadata.toJson()), PluginMetadata.class);
+        merged = fromJson(merge(commonMetadata.toJson(), merged.toJson()), PluginMetadata.class);
+        merged = fromJson(merge(javaMetadata.toJson(), merged.toJson()), PluginMetadata.class);
+        merged = fromJson(merge(mergedMetadata.toJson(), merged.toJson()), PluginMetadata.class);
 
-        LOG.debug("Merged metadata: {}", JsonUtils.toJson(merged));
+        LOG.debug("Merged metadata: {}", toJson(merged));
 
         // Write the metadata to a file for later use by the plugin modernizer.
         merged.save();
         LOG.debug("Plugin metadata written to {}", merged.getRelativePath());
         ctx.putMessage("mergedMetadata", merged);
-        LOG.debug(JsonUtils.toJson(merged));
+        LOG.debug(toJson(merged));
 
         return tree;
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataVisitor.java
@@ -55,6 +55,14 @@ public class MetadataVisitor extends TreeVisitor<Tree, ExecutionContext> {
             executionContext.putMessage("pomMetadata", pomMetadata); // Is there better than context messaging ?
             return tree;
         }
+        // Extract metadata from java file
+        else if (PathUtils.matchesGlob(sourceFile.getSourcePath(), "**/*.java")) {
+            LOG.debug("Visiting Java file {}", sourceFile.getSourcePath());
+            PluginMetadata javaMetadata = new JavaFileVisitor().reduce(tree, commonMetadata);
+            LOG.debug("Java metadata: {}", JsonUtils.toJson(javaMetadata));
+            executionContext.putMessage("javaMetadata", javaMetadata); // Is there better than context messaging ?
+            return tree;
+        }
 
         // Just add the common
         else {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -52,6 +53,11 @@ public class PluginMetadata extends CacheEntry<PluginMetadata> {
      * Use container agent for build extracted from Jenkinsfile
      */
     private Boolean useContainerAgent;
+
+    /**
+     * If the plugin is using container tests
+     */
+    private Boolean useContainerTests;
 
     /**
      * forkCount extracted from Jenkinsfile
@@ -238,6 +244,14 @@ public class PluginMetadata extends CacheEntry<PluginMetadata> {
 
     public void setUseContainerAgent(Boolean useContainerAgent) {
         this.useContainerAgent = useContainerAgent;
+    }
+
+    public Boolean isUseContainerTests() {
+        return Objects.requireNonNullElse(useContainerTests, false);
+    }
+
+    public void setUseContainerTests(Boolean useContainerTests) {
+        this.useContainerTests = useContainerTests;
     }
 
     public String getForkCount() {


### PR DESCRIPTION
Insight from [this issue comment](https://github.com/jenkins-infra/plugin-modernizer-tool/issues/531#issuecomment-2581031104):

We need to be careful not to set `useContainerAgent: true` if the plugin is using container tests.

The Java ISO visitor could be used to enrich metadata from other Java source content, such as the usage of deprecated methods, etc.

### Testing done

Automated tests and check the metadata on plugin like saml and jobcacher. Ensuring they include `useContainerTests: true` in their metadata

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
