### PR TITLE
Storing logs close to the sources 

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/ConsoleLogFilter.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/ConsoleLogFilter.java
@@ -13,7 +13,7 @@ public class ConsoleLogFilter extends ThresholdFilter {
         if (event.getMarkerList() != null && !event.getMarkerList().isEmpty()) {
             return FilterReply.DENY;
         }
-        if (Config.DEBUG) {
+        if (Config.isDebug()) {
             setLevel(Level.DEBUG.levelStr);
         }
         return super.decide(event);

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -7,6 +7,7 @@ import io.jenkins.tools.pluginmodernizer.cli.command.ListRecipesCommand;
 import io.jenkins.tools.pluginmodernizer.cli.command.RunCommand;
 import io.jenkins.tools.pluginmodernizer.cli.command.ValidateCommand;
 import io.jenkins.tools.pluginmodernizer.cli.command.VersionCommand;
+import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 import picocli.AutoComplete;
 import picocli.CommandLine;
@@ -42,8 +43,10 @@ public class Main {
      */
     public static void main(final String[] args) {
         CommandLine cmd = new CommandLine(new Main());
+        GlobalOptions globalOptions = GlobalOptions.getInstance();
         CommandLine gen = cmd.getSubcommands().get("generate-completion");
         gen.getCommandSpec().usageMessage().hidden(true);
+        cmd.addMixin("globalOptions", globalOptions);
         System.exit(cmd.execute(args));
     }
 }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -42,11 +42,11 @@ public class Main {
      * @param args Command line arguments
      */
     public static void main(final String[] args) {
-        CommandLine cmd = new CommandLine(new Main());
         GlobalOptions globalOptions = GlobalOptions.getInstance();
+        CommandLine cmd = new CommandLine(new Main());
+        cmd.addMixin("globalOptions", globalOptions);
         CommandLine gen = cmd.getSubcommands().get("generate-completion");
         gen.getCommandSpec().usageMessage().hidden(true);
-        cmd.addMixin("globalOptions", globalOptions);
         System.exit(cmd.execute(args));
     }
 }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/PluginLoggerDiscriminator.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/PluginLoggerDiscriminator.java
@@ -2,6 +2,10 @@ package io.jenkins.tools.pluginmodernizer.cli;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.sift.AbstractDiscriminator;
+import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import java.nio.file.Path;
 import java.util.List;
 import org.slf4j.Marker;
 
@@ -10,11 +14,23 @@ public class PluginLoggerDiscriminator extends AbstractDiscriminator<ILoggingEve
     @Override
     public String getDiscriminatingValue(ILoggingEvent iLoggingEvent) {
         List<Marker> markers = iLoggingEvent.getMarkerList();
+
+        Config.Builder builder = Config.builder();
+        GlobalOptions globalOptions = GlobalOptions.getInstance();
+        globalOptions.config(builder);
+        Config config = builder.build();
+
+        String cachePath = config.getCachePath().toString();
+
         if (markers == null || markers.isEmpty()) {
-            return "modernizer";
+            return Path.of(cachePath, "modernizer.logs").toString();
         }
+
         final Marker marker = markers.get(0);
-        return marker.getName();
+        String markerName = marker.getName();
+        Plugin plugin = Plugin.build(markerName);
+
+        return Path.of(cachePath, plugin.getLogFile().toString()).toString();
     }
 
     @Override

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
@@ -44,7 +44,7 @@ public class BuildMetadataCommand implements ICommand {
      * Global options for all commands
      */
     @CommandLine.Mixin
-    private GlobalOptions options;
+    private GlobalOptions options = GlobalOptions.getInstance();
 
     /**
      * Environment options

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CleanupCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CleanupCommand.java
@@ -22,7 +22,7 @@ public class CleanupCommand implements ICommand {
      * Global options for all commands
      */
     @CommandLine.Mixin
-    private GlobalOptions options;
+    private GlobalOptions options = GlobalOptions.getInstance();
 
     @CommandLine.Option(
             names = {"--dry-run"},

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
@@ -51,7 +51,7 @@ public class DryRunCommand implements ICommand {
      * Global options for all commands
      */
     @CommandLine.Mixin
-    private GlobalOptions options;
+    private GlobalOptions options = GlobalOptions.getInstance();
 
     /**
      * GitHub options

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ListRecipesCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ListRecipesCommand.java
@@ -12,7 +12,7 @@ import picocli.CommandLine;
 public class ListRecipesCommand implements ICommand {
 
     @CommandLine.Mixin
-    private GlobalOptions options;
+    private GlobalOptions options = GlobalOptions.getInstance();
 
     @Override
     public Config setup(Config.Builder builder) {

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
@@ -62,7 +62,7 @@ public class RunCommand implements ICommand {
      * Global options for all commands
      */
     @CommandLine.Mixin
-    private GlobalOptions options;
+    private GlobalOptions options = GlobalOptions.getInstance();
 
     /**
      * GitHub options

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ValidateCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ValidateCommand.java
@@ -33,7 +33,7 @@ public class ValidateCommand implements ICommand {
      * Global options for all commands
      */
     @CommandLine.Mixin
-    private GlobalOptions options;
+    private GlobalOptions options = GlobalOptions.getInstance();
 
     /**
      * GitHub options

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/VersionCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/VersionCommand.java
@@ -2,6 +2,7 @@ package io.jenkins.tools.pluginmodernizer.cli.command;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.jenkins.tools.pluginmodernizer.cli.VersionProvider;
+import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -25,6 +26,9 @@ public class VersionCommand implements ICommand {
             names = {"--short"},
             description = "Display the short version")
     private boolean shortVersion;
+
+    @CommandLine.Mixin
+    private GlobalOptions options = GlobalOptions.getInstance();
 
     @Override
     public Integer call() throws Exception {

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
@@ -19,6 +19,18 @@ import picocli.CommandLine;
         commandListHeading = "%nCommands:%n")
 public class GlobalOptions implements IOption {
 
+    private static GlobalOptions instance;
+
+    private GlobalOptions() {}
+
+    // Static method to get the singleton instance
+    public static synchronized GlobalOptions getInstance() {
+        if (instance == null) {
+            instance = new GlobalOptions();
+        }
+        return instance;
+    }
+
     @CommandLine.Option(
             names = {"--debug"},
             description = "Enable debug logging.")

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
@@ -30,6 +30,10 @@ public class GlobalOptions implements IOption {
         }
         return instance;
     }
+    // reset to default
+    public static void reset() {
+        instance = null;
+    }
 
     @CommandLine.Option(
             names = {"--debug"},
@@ -56,7 +60,7 @@ public class GlobalOptions implements IOption {
      */
     @Override
     public void config(Config.Builder builder) {
-        Config.DEBUG = debug;
+        Config.setDebug(debug);
         builder.withVersion(getVersion())
                 .withCachePath(
                         !cachePath.endsWith(Settings.CACHE_SUBDIR)

--- a/plugin-modernizer-cli/src/main/resources/logback.xml
+++ b/plugin-modernizer-cli/src/main/resources/logback.xml
@@ -24,9 +24,9 @@
                 <encoder>
                     <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z', 'UTC'} [%level] [Thread=%t] - %logger{36} # %msg %n</pattern>
                 </encoder>
-                <file>logs/${filename}.log</file>
+                <file>${filename}</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
-                    <fileNamePattern>logs/${filename}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                    <fileNamePattern>${filename}-%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
                     <maxHistory>7</maxHistory>
                     <maxFileSize>5MB</maxFileSize>
                 </rollingPolicy>

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -161,7 +161,8 @@ public class CommandLineITCase {
         assertAll(
                 () -> assertEquals(0, result.getExitCode()),
                 () -> assertTrue(Files.readAllLines(logFile).stream()
-                        .anyMatch(line -> line.matches("(.*)Usage: plugin-modernizer (.*) COMMAND(.*)"))));
+                        .anyMatch(
+                                line -> line.matches("Usage:") || line.matches("plugin-modernizer (.*) COMMAND(.*)"))));
     }
 
     @Test

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/ConsoleLogFilterTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/ConsoleLogFilterTest.java
@@ -40,7 +40,7 @@ public class ConsoleLogFilterTest {
     @Test
     public void testDecideMarkerListEmptyDebugEnabled() {
         when(mockEvent.getMarkerList()).thenReturn(null);
-        Config.DEBUG = true;
+        Config.setDebug(true);
         FilterReply reply = consoleLogFilter.decide(mockEvent);
         assertEquals(FilterReply.NEUTRAL, reply);
     }
@@ -48,7 +48,7 @@ public class ConsoleLogFilterTest {
     @Test
     public void testDecideMarkerListEmptyDebugDisabled() {
         when(mockEvent.getMarkerList()).thenReturn(null);
-        Config.DEBUG = false;
+        Config.setDebug(false);
         FilterReply reply = consoleLogFilter.decide(mockEvent);
         assertEquals(FilterReply.NEUTRAL, reply);
     }

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/PluginLoggerDiscriminatorTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/PluginLoggerDiscriminatorTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import java.nio.file.Path;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Marker;
@@ -17,8 +18,11 @@ public class PluginLoggerDiscriminatorTest {
         ILoggingEvent event = mock(ILoggingEvent.class);
         when(event.getMarkerList()).thenReturn(null);
 
+        String expectedValue = Path.of(
+                        System.getProperty("user.home"), ".cache", "jenkins-plugin-modernizer-cli", "modernizer.logs")
+                .toString();
         String discriminatingValue = discriminator.getDiscriminatingValue(event);
-        assertEquals("modernizer", discriminatingValue);
+        assertEquals(expectedValue, discriminatingValue);
     }
 
     @Test
@@ -27,8 +31,11 @@ public class PluginLoggerDiscriminatorTest {
         ILoggingEvent event = mock(ILoggingEvent.class);
         when(event.getMarkerList()).thenReturn(Collections.emptyList());
 
+        String expectedValue = Path.of(
+                        System.getProperty("user.home"), ".cache", "jenkins-plugin-modernizer-cli", "modernizer.logs")
+                .toString();
         String discriminatingValue = discriminator.getDiscriminatingValue(event);
-        assertEquals("modernizer", discriminatingValue);
+        assertEquals(expectedValue, discriminatingValue);
     }
 
     @Test
@@ -40,7 +47,15 @@ public class PluginLoggerDiscriminatorTest {
         when(event.getMarkerList()).thenReturn(Collections.singletonList(marker));
 
         String discriminatingValue = discriminator.getDiscriminatingValue(event);
-        assertEquals("testMarker", discriminatingValue);
+        String expectedValue = Path.of(
+                        System.getProperty("user.home"),
+                        ".cache",
+                        "jenkins-plugin-modernizer-cli",
+                        "testMarker",
+                        "logs",
+                        "invoker.logs")
+                .toString();
+        assertEquals(expectedValue, discriminatingValue);
     }
 
     @Test

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/PluginLoggerDiscriminatorTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/PluginLoggerDiscriminatorTest.java
@@ -5,12 +5,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
+import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import java.nio.file.Path;
 import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Marker;
 
 public class PluginLoggerDiscriminatorTest {
+
+    @BeforeEach
+    void resetSingleton() {
+        GlobalOptions.reset();
+    }
 
     @Test
     void testGetDiscriminatingValueNoMarkers() {

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptionsTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptionsTest.java
@@ -6,10 +6,16 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import java.lang.reflect.Field;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.platform.commons.util.ReflectionUtils;
 
 public class GlobalOptionsTest {
+
+    @BeforeEach
+    void resetSingleton() {
+        GlobalOptions.reset();
+    }
 
     @Test
     public void testGlobalOptionsWithoutDefault() {

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptionsTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptionsTest.java
@@ -14,7 +14,7 @@ public class GlobalOptionsTest {
     @Test
     public void testGlobalOptionsWithoutDefault() {
         Config.Builder builder = Config.builder();
-        GlobalOptions globalOptions = new GlobalOptions();
+        GlobalOptions globalOptions = GlobalOptions.getInstance();
         globalOptions.config(builder);
 
         // Check defaults
@@ -31,7 +31,7 @@ public class GlobalOptionsTest {
     @Test
     public void testGlobalOptionsWithCustom() throws Exception {
         Config.Builder builder = Config.builder();
-        GlobalOptions globalOptions = new GlobalOptions();
+        GlobalOptions globalOptions = GlobalOptions.getInstance();
 
         // Set debug
         Field debugField = ReflectionUtils.findFields(

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -10,7 +10,11 @@ import java.util.List;
 public class Config {
 
     @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Because usage on ConsoleLogFilter")
-    public static boolean DEBUG = false;
+    private static boolean DEBUG = false;
+
+    public static void setDebug(boolean debug) {
+        DEBUG = debug;
+    }
 
     private final String version;
     private final List<Plugin> plugins;
@@ -163,7 +167,7 @@ public class Config {
         return dryRun;
     }
 
-    public boolean isDebug() {
+    public static boolean isDebug() {
         return DEBUG;
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -8,7 +8,9 @@ import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
 import io.jenkins.tools.pluginmodernizer.core.impl.MavenInvoker;
 import io.jenkins.tools.pluginmodernizer.core.utils.PluginService;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
@@ -468,7 +470,7 @@ public class Plugin {
      * @return Path of the log file
      */
     public Path getLogFile() {
-        return Path.of("logs", getName() + ".log");
+        return Path.of(getName(), "logs", "invoker.logs");
     }
 
     /**
@@ -477,6 +479,18 @@ public class Plugin {
      */
     public Marker getMarker() {
         return MarkerFactory.getMarker(name);
+    }
+
+    /**
+     * Ensures that the directories exist to store the logs.
+     * @param logPath The path to check for the missing directories
+     */
+    private void ensureLogDirectoryExists(Path logPath) {
+        try {
+            Files.createDirectories(logPath.getParent());
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to create log directory: " + logPath.getParent(), e);
+        }
     }
 
     /**


### PR DESCRIPTION
Fix #506 

Changes include:
Store the plugin logs to `/home/user/.cache/jenkins-plugin-modernizer-cli/<plugin>/logs/invoker.logs` and the default logs to `/home/user/.cache/jenkins-plugin-modernizer-cli/modernizer.logs`. In `getDiscriminatorValue()` build the plugin based on the name of the marker, and then we return the full absolute path for the plugin specefic log directory via the `getMarker().`

### Testing done
Updated the test cases.
Did the testing for `PluginLoggerDiscriminator `and of `getMarker()` method. 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
