### PR TITLE
Reduce build time by skipping by default slow integration tests and use JUnit 5 Parallel execution for some classes

### DIFF
--- a/plugin-modernizer-cli/pom.xml
+++ b/plugin-modernizer-cli/pom.xml
@@ -165,6 +165,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <groups>Always</groups>
+        </configuration>
         <executions>
           <execution>
             <id>integration-tests</id>
@@ -255,6 +258,29 @@
   </build>
 
   <profiles>
+    <profile>
+      <!-- Activate slow test that modernize samples plugins -->
+      <!-- Only run such test on CI and linux -->
+      <id>slow-tests</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+        <property>
+          <name>env.CI</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <groups>Always,Slow</groups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>maven-repo-local</id>
       <activation>

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -31,10 +31,13 @@ import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.Invoker;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -49,6 +52,7 @@ import org.testcontainers.shaded.org.bouncycastle.jce.provider.BouncyCastleProvi
 @WireMockTest
 @Testcontainers(disabledWithoutDocker = true)
 @ExtendWith(ModernizerTestWatcher.class)
+@Execution(ExecutionMode.SAME_THREAD) // Need split or not using shared resources like logs folder
 public class CommandLineITCase {
 
     static {
@@ -125,6 +129,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Always")
     public void testVersion() throws Exception {
         Path logFile = setupLogs("testVersion");
         Invoker invoker = buildInvoker();
@@ -147,6 +152,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Always")
     public void testHelp() throws Exception {
         Path logFile = setupLogs("testHelp");
         Invoker invoker = buildInvoker();
@@ -159,6 +165,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testCleanupWithDryRun() throws Exception {
         Path logFile = setupLogs("testCleanupWithDryRun");
         Invoker invoker = buildInvoker();
@@ -171,6 +178,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testCleanup() throws Exception {
         Path logFile = setupLogs("testCleanup");
         Invoker invoker = buildInvoker();
@@ -183,6 +191,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testValidateWithSshKey(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         Path logFile = setupLogs("testValidateWithSshKey");
@@ -211,6 +220,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testValidate(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         Path logFile = setupLogs("testValidate");
@@ -234,6 +244,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testListRecipes() throws Exception {
         Path logFile = setupLogs("testListRecipes");
         Invoker invoker = buildInvoker();
@@ -250,6 +261,7 @@ public class CommandLineITCase {
 
     @ParameterizedTest
     @MethodSource("testsPlugins")
+    @Tag("Slow")
     public void testBuildMetadata(PluginMetadata expectedMetadata, WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         Path logFile = logFolder.resolve("testBuildMetadata-%s.txt".formatted(expectedMetadata.getPluginName()));
@@ -303,6 +315,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testDryRunReplaceLibrariesWithApiPlugin(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         Path logFile1 = setupLogs("testDryRunReplaceLibrariesWithApiPlugin1");
@@ -361,6 +374,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testRunAddDependabot(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         Path logFile = setupLogs("testRunAddDependabot");
@@ -401,6 +415,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testDryRunAddDependabot(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         Path logFile = setupLogs("testDryRunAddDependabot");
@@ -442,6 +457,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testRecipeOnLocalPlugin(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         Path logFile = setupLogs("testRecipeOnLocalPlugin");
@@ -487,6 +503,7 @@ public class CommandLineITCase {
     }
 
     @Test
+    @Tag("Slow")
     public void testRecipeOnLocalPluginWithRunMode(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
 
         Path logFile = setupLogs("testRecipeOnLocalPluginWithRunMode");

--- a/plugin-modernizer-cli/src/test/resources/junit-platform.properties
+++ b/plugin-modernizer-cli/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.execution.parallel.enabled=true

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/ConfigTest.java
@@ -11,8 +11,11 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mockito;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class ConfigTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsEnvTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsEnvTest.java
@@ -6,11 +6,14 @@ import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 
 @ExtendWith(SystemStubsExtension.class)
+@Execution(ExecutionMode.CONCURRENT)
 public class SettingsEnvTest {
 
     @SystemStub

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsHomeDirTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsHomeDirTest.java
@@ -5,11 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 @ExtendWith(SystemStubsExtension.class)
+@Execution(ExecutionMode.CONCURRENT)
 public class SettingsHomeDirTest {
 
     @SystemStub

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsUserDirTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsUserDirTest.java
@@ -5,11 +5,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 import uk.org.webcompere.systemstubs.properties.SystemProperties;
 
 @ExtendWith(SystemStubsExtension.class)
+@Execution(ExecutionMode.CONCURRENT)
 public class SettingsUserDirTest {
 
     @SystemStub

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/FetchMetadataTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/FetchMetadataTest.java
@@ -21,6 +21,8 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RewriteTest;
@@ -30,6 +32,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Tests for {@link FetchMetadata}.
  */
+// CacheManager is not thread safe. Test also manipulate shared metadata file.
+// To fix at some point (maybe when adding concurrency in plugin modernizer)
+@Execution(ExecutionMode.SAME_THREAD)
 public class FetchMetadataTest implements RewriteTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(FetchMetadataTest.class);

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
@@ -37,6 +37,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.kohsuke.github.GHCommitPointer;
 import org.kohsuke.github.GHIssueState;
@@ -53,6 +55,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({MockitoExtension.class})
+@Execution(ExecutionMode.CONCURRENT)
 public class GHServiceTest {
 
     @Mock
@@ -79,16 +82,17 @@ public class GHServiceTest {
     public void setup() throws Exception {
 
         // Create service
-        service = Guice.createInjector(new GuiceModule(config)).getInstance(GHService.class);
-
-        // Set github mock
-        Field field = ReflectionUtils.findFields(
-                        GHService.class,
-                        f -> f.getName().equals("github"),
-                        ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
-                .get(0);
-        field.setAccessible(true);
-        field.set(service, github);
+        if (service == null) {
+            service = Guice.createInjector(new GuiceModule(config)).getInstance(GHService.class);
+            // Set github mock
+            Field field = ReflectionUtils.findFields(
+                            GHService.class,
+                            f -> f.getName().equals("github"),
+                            ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
+                    .get(0);
+            field.setAccessible(true);
+            field.set(service, github);
+        }
     }
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class JDKTest {
 
     // Write tests for JDK enum here

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
@@ -10,12 +10,15 @@ import io.jenkins.tools.pluginmodernizer.core.impl.MavenInvoker;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
 @ExtendWith(MockitoExtension.class)
+@Execution(ExecutionMode.CONCURRENT)
 public class PluginTest {
 
     @Mock

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -21,6 +21,8 @@ import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.maven.MavenParser;
 import org.openrewrite.test.RewriteTest;
@@ -30,6 +32,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Test for declarative recipes from recipes.yml.
  */
+// ConcurrentModification on rewriteRun (need fix upstream?
+// This only occur on recipeFromResource
+@Execution(ExecutionMode.SAME_THREAD)
 public class DeclarativeRecipesTest implements RewriteTest {
 
     @Language("xml")

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/EnsureIndexJellyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/EnsureIndexJellyTest.java
@@ -7,11 +7,14 @@ import static org.openrewrite.test.SourceSpecs.text;
 
 import io.jenkins.tools.pluginmodernizer.core.extractor.ArchetypeCommonFile;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RewriteTest;
 
 /**
  * Test for {@link EnsureIndexJelly}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class EnsureIndexJellyTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/EnsureRelativePathTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/EnsureRelativePathTest.java
@@ -5,9 +5,12 @@ import static org.openrewrite.yaml.Assertions.yaml;
 
 import io.jenkins.tools.pluginmodernizer.core.extractor.ArchetypeCommonFile;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class EnsureRelativePathTest implements RewriteTest {
 
     @Override

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingArchetypeCommonFileTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingArchetypeCommonFileTest.java
@@ -6,11 +6,14 @@ import static org.openrewrite.yaml.Assertions.yaml;
 
 import io.jenkins.tools.pluginmodernizer.core.extractor.ArchetypeCommonFile;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RewriteTest;
 
 /**
  * Test for {@link IsUsingArchetypeCommonFile}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class IsUsingArchetypeCommonFileTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingBomTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/IsUsingBomTest.java
@@ -3,11 +3,14 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RewriteTest;
 
 /**
  * Test for {@link IsUsingBom}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class IsUsingBomTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateToJenkinsBaseLinePropertyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateToJenkinsBaseLinePropertyTest.java
@@ -3,11 +3,14 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RewriteTest;
 
 /**
  * Test for {@link MigrateToJenkinsBaseLineProperty}
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class MigrateToJenkinsBaseLinePropertyTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemovePropertyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemovePropertyTest.java
@@ -3,11 +3,14 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RewriteTest;
 
 /**
  * Test for {@link RemoveProperty}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class RemovePropertyTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemoveReleaseDrafterTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/RemoveReleaseDrafterTest.java
@@ -4,11 +4,14 @@ import static org.openrewrite.yaml.Assertions.yaml;
 
 import io.jenkins.tools.pluginmodernizer.core.extractor.ArchetypeCommonFile;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RewriteTest;
 
 /**
  * Test for {@link RemoveReleaseDrafter}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class RemoveReleaseDrafterTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/SetupDependabotTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/SetupDependabotTest.java
@@ -5,11 +5,14 @@ import static org.openrewrite.yaml.Assertions.yaml;
 
 import io.jenkins.tools.pluginmodernizer.core.extractor.ArchetypeCommonFile;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RewriteTest;
 
 /**
  * Test for {@link SetupDependabot}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class SetupDependabotTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateBomTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateBomTest.java
@@ -3,6 +3,8 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.Issue;
 import org.openrewrite.maven.MavenParser;
 import org.openrewrite.test.RewriteTest;
@@ -10,6 +12,7 @@ import org.openrewrite.test.RewriteTest;
 /**
  * Test for {@link UpdateBom}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class UpdateBomTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateScmUrlTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateScmUrlTest.java
@@ -3,11 +3,14 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RewriteTest;
 
 /**
  * Test for {@link UpdateScmUrl}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class UpdateScmUrlTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsVersionTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsVersionTest.java
@@ -4,6 +4,8 @@ import static org.openrewrite.maven.Assertions.pomXml;
 
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.test.RewriteTest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +13,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Test for {@link UpgradeJenkinsVersion}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class UpgradeJenkinsVersionTest implements RewriteTest {
 
     /**

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/code/ReplaceRemovedSSHLauncherConstructorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/code/ReplaceRemovedSSHLauncherConstructorTest.java
@@ -6,12 +6,15 @@ import static org.openrewrite.java.Assertions.srcTestJava;
 import io.jenkins.tools.pluginmodernizer.core.recipes.DeclarativeRecipesTest;
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RewriteTest;
 
 /**
  * Test for {@link ReplaceRemovedSSHLauncherConstructor}
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class ReplaceRemovedSSHLauncherConstructorTest implements RewriteTest {
 
     @Language("java")

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtilsTest.java
@@ -9,7 +9,10 @@ import io.jenkins.tools.pluginmodernizer.core.model.PreconditionError;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class JsonUtilsTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.platform.commons.util.ReflectionUtils;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -33,6 +35,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith({MockitoExtension.class})
 @WireMockTest
+@Execution(ExecutionMode.SAME_THREAD) // Shared some resources, need refactoring
 class PluginServiceTest {
 
     @Mock

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -9,7 +9,10 @@ import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
+@Execution(ExecutionMode.CONCURRENT)
 public class TemplateUtilsTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddBeforePropertyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddBeforePropertyTest.java
@@ -4,6 +4,8 @@ import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.test.RewriteTest;
@@ -12,6 +14,7 @@ import org.openrewrite.xml.tree.Xml;
 /**
  * Test for {@link AddBeforePropertyVisitor}
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class AddBeforePropertyTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddPropertyCommentVisitorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/AddPropertyCommentVisitorTest.java
@@ -4,6 +4,8 @@ import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.test.RewriteTest;
@@ -12,6 +14,7 @@ import org.openrewrite.xml.tree.Xml;
 /**
  * Tests for {@link AddPropertyCommentVisitor}.
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class AddPropertyCommentVisitorTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/visitors/RemovePropertyCommentVisitorTest.java
@@ -4,6 +4,8 @@ import static org.openrewrite.maven.Assertions.pomXml;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.test.RewriteTest;
@@ -12,6 +14,7 @@ import org.openrewrite.xml.tree.Xml;
 /**
  * Test for {@link RemovePropertyCommentVisitor}
  */
+@Execution(ExecutionMode.CONCURRENT)
 public class RemovePropertyCommentVisitorTest implements RewriteTest {
 
     @Test

--- a/plugin-modernizer-core/src/test/resources/junit-platform.properties
+++ b/plugin-modernizer-core/src/test/resources/junit-platform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.execution.parallel.enabled=true


### PR DESCRIPTION
Fix https://github.com/jenkins-infra/plugin-modernizer-tool/issues/605

![Screenshot from 2025-01-11 14-00-46](https://github.com/user-attachments/assets/45117ff2-5bfb-43f8-8b64-87ba056da8b3)


### Testing done
Ensuring only integration tests are executed instead of full suite. Will check on this PR if all test are executed on Linux host

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
