### PR TITLE
Handle local plugin without incrementals and gitHubRepo property

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/StaticPomParser.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/StaticPomParser.java
@@ -111,6 +111,20 @@ public class StaticPomParser {
     }
 
     /**
+     * Return scm connection property of the POM file or null if not found.
+     * @return the scm connection property or null if not found
+     */
+    public String getScmConnectionProperty() {
+        XPath xPath = XPathFactory.newInstance().newXPath();
+        try {
+            return xPath.compile("/project/properties/scm/connection").evaluate(document);
+        } catch (Exception e) {
+            LOG.warn("Error getting scm connection: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Return the groupId of the POM file.
      * @return the groupId or null if not found
      */

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
@@ -152,6 +152,30 @@ class PluginServiceTest {
     }
 
     @Test
+    public void shouldExtractRepoNameForLocalDefaultPluginWithScmRepoRepo() throws Exception {
+        PluginService service = getService();
+
+        // language=xml
+        String pom =
+                """
+                    <project>
+                        <properties>
+                            <scm>
+                               <connection>scm:git:https://github.com/jenkinsci/FOO_Bar-plugin.git</connection>
+                            </scm>
+                        </properties>
+                    </project>
+                    """;
+
+        Plugin plugin = Plugin.build("valid-plugin").withConfig(config);
+        plugin.withLocal(true);
+        plugin.withLocalRepository(tempDir);
+        Files.writeString(tempDir.resolve("pom.xml"), pom);
+        String result = service.extractRepoName(plugin);
+        assertEquals("FOO_Bar-plugin", result);
+    }
+
+    @Test
     public void shouldExtractRepoNameForLocalDefaultPluginFallbackFolder() throws Exception {
         PluginService service = getService();
 
@@ -169,6 +193,16 @@ class PluginServiceTest {
         Files.writeString(tempDir.resolve("pom.xml"), pom);
         String result = service.extractRepoName(plugin);
         assertEquals(tempDir.getFileName().toString(), result);
+    }
+
+    @Test
+    public void shouldExtractRepoNameForLocalDefaultPluginFallbackFolderParent() throws Exception {
+        PluginService service = getService();
+        Plugin plugin = Plugin.build("valid-plugin").withConfig(config);
+        plugin.withLocal(true);
+        plugin.withLocalRepository(Path.of(".").toAbsolutePath());
+        String result = service.extractRepoName(plugin);
+        assertEquals("plugin-modernizer-core", result);
     }
 
     @Test


### PR DESCRIPTION
When trying to run recipes on a local (old plugin) that was not yet using incremental I faces the errors the repo wasn't found.

Added 2 more unit test to cover this use case

### Testing done

Automated only

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
