### PR TITLE
Skip some test from IDE due to environment mocking that require several surefire execution

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -295,6 +295,7 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <environmentVariables>
+            <RUN_IN_MAVEN>true</RUN_IN_MAVEN>
             <GH_TOKEN>fake-token</GH_TOKEN>
             <GH_OWNER>fake-owner</GH_OWNER>
             <GH_TARGET_ORGANISATION>jenkinsci</GH_TARGET_ORGANISATION>

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsEnvTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsEnvTest.java
@@ -1,9 +1,11 @@
 package io.jenkins.tools.pluginmodernizer.core.config;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
 import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -25,6 +27,13 @@ public class SettingsEnvTest {
             .set("JENKINS_UC", "https://example-com")
             .remove("MAVEN_HOME")
             .set("M2_HOME", "/opt/maven-test");
+
+    @BeforeEach
+    public void beforeEach() {
+        assumeTrue(
+                System.getenv("RUN_IN_MAVEN") != null,
+                "Skipping test from IDE: not running via Maven due to static mocking of env vars");
+    }
 
     @Test
     public void testCustomCache() throws Exception {

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsHomeDirTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/config/SettingsHomeDirTest.java
@@ -1,8 +1,10 @@
 package io.jenkins.tools.pluginmodernizer.core.config;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.nio.file.Paths;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
@@ -17,6 +19,13 @@ public class SettingsHomeDirTest {
 
     @SystemStub
     private SystemProperties properties = new SystemProperties("user.home", "/home/foobar");
+
+    @BeforeEach
+    public void beforeEach() {
+        assumeTrue(
+                System.getenv("RUN_IN_MAVEN") != null,
+                "Skipping test from IDE: not running via Maven due to static mocking of env vars");
+    }
 
     @Test
     public void test() throws Exception {


### PR DESCRIPTION
Such failing test (5) were quiet anoying when running from IDE.

They must be run via maven, because several surefire forking are done due to environment vars mocking.

So I would just skip them when running from IDE

### Testing done

Ensure they are skip from IDE, but still running via maven (`mvn -Dtest="SettingsHomeDirTest" clean test`)

![Screenshot from 2025-01-12 08-34-22](https://github.com/user-attachments/assets/87cdf6dd-4622-48a6-90cf-eadc9fd42b5b)


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
