### PR TITLE
Render commit message and unique branch name

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -56,9 +56,7 @@ import org.slf4j.LoggerFactory;
 public class GHService {
 
     private static final Logger LOG = LoggerFactory.getLogger(GHService.class);
-
-    // TODO: Use unique branch name (with prefix ?) to avoid conflicts
-    private static final String BRANCH_NAME = "plugin-modernizer-tool";
+    private static final Logger BRANCH_NAMELOG = LoggerFactory.getLogger(GHService.class);
 
     /**
      * Allowed github tags for PR
@@ -641,15 +639,16 @@ public class GHService {
             LOG.info("Plugin {} is local. Not checking out branch", plugin);
             return;
         }
+        String branchName = TemplateUtils.renderBranchName(plugin, config.getRecipe());
         try (Git git = Git.open(plugin.getLocalRepository().toFile())) {
             try {
-                git.checkout().setCreateBranch(true).setName(BRANCH_NAME).call();
+                git.checkout().setCreateBranch(true).setName(branchName).call();
             } catch (RefAlreadyExistsException e) {
                 String defaultBranch = config.isDryRun() || config.isFetchMetadataOnly() || plugin.isArchived(this)
                         ? plugin.getRemoteRepository(this).getDefaultBranch()
                         : plugin.getRemoteForkRepository(this).getDefaultBranch();
                 LOG.debug("Branch already exists. Checking out the branch");
-                git.checkout().setName(BRANCH_NAME).call();
+                git.checkout().setName(branchName).call();
                 git.reset()
                         .setMode(ResetCommand.ResetType.HARD)
                         .setRef(defaultBranch)
@@ -805,12 +804,13 @@ public class GHService {
             return;
         }
         try (Git git = Git.open(plugin.getLocalRepository().toFile())) {
+            String branchName = TemplateUtils.renderBranchName(plugin, config.getRecipe());
             List<PushResult> results = StreamSupport.stream(
                             git.push()
                                     .setForce(true)
                                     .setRemote("origin")
                                     .setCredentialsProvider(getCredentialProvider())
-                                    .setRefSpecs(new RefSpec(BRANCH_NAME + ":" + BRANCH_NAME))
+                                    .setRefSpecs(new RefSpec(branchName + ":" + branchName))
                                     .call()
                                     .spliterator(),
                             false)
@@ -873,9 +873,10 @@ public class GHService {
         }
 
         try {
+            String branchName = TemplateUtils.renderBranchName(plugin, config.getRecipe());
             GHPullRequest pr = repository.createPullRequest(
                     prTitle,
-                    getGithubOwner() + ":" + BRANCH_NAME,
+                    getGithubOwner() + ":" + branchName,
                     repository.getDefaultBranch(),
                     prBody,
                     false,
@@ -949,6 +950,7 @@ public class GHService {
      */
     private Optional<GHPullRequest> checkIfPullRequestExists(Plugin plugin) {
         GHRepository repository = plugin.getRemoteRepository(this);
+        String branchName = TemplateUtils.renderBranchName(plugin, config.getRecipe());
         try {
             List<GHPullRequest> pullRequests = repository
                     .queryPullRequests()
@@ -956,7 +958,7 @@ public class GHService {
                     .list()
                     .toList();
             return pullRequests.stream()
-                    .filter(pr -> pr.getHead().getRef().equals(BRANCH_NAME))
+                    .filter(pr -> pr.getHead().getRef().equals(branchName))
                     .findFirst();
         } catch (IOException e) {
             plugin.addError("Failed to check if pull request exists", e);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtils.java
@@ -52,7 +52,26 @@ public class TemplateUtils {
      * @return The rendered commit message
      */
     public static String renderCommitMessage(Plugin plugin, Recipe recipe) {
+        if (hasCommitTemplate(recipe)) {
+            return renderTemplate(
+                    getTemplateNameForRecipe("commit", recipe), Map.of("plugin", plugin, "recipe", recipe));
+        }
+        // Fallback to title if exists
+        if (hasTitleTemplate(recipe)) {
+            return renderPullRequestTitle(plugin, recipe);
+        }
         return renderTemplate("commit.jte", Map.of("plugin", plugin, "recipe", recipe));
+    }
+
+    /**
+     * Render the branch name
+     *
+     * @param plugin Plugin to modernize
+     * @param recipe Recipe to apply
+     * @return The rendered commit message
+     */
+    public static String renderBranchName(Plugin plugin, Recipe recipe) {
+        return renderTemplate("branch.jte", Map.of("plugin", plugin, "recipe", recipe));
     }
 
     /**
@@ -99,6 +118,18 @@ public class TemplateUtils {
         String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
         TemplateEngine templateEngine = TemplateEngine.createPrecompiled(ContentType.Html);
         return templateEngine.hasTemplate("pr-title-%s.jte".formatted(shortName));
+    }
+
+    /**
+     * Check if a commit template exists for one recipe
+     *
+     * @param recipe The recipe to check
+     * @return True if a commit template exists
+     */
+    private static boolean hasCommitTemplate(Recipe recipe) {
+        String shortName = recipe.getName().replaceAll(Settings.RECIPE_FQDN_PREFIX + ".", "");
+        TemplateEngine templateEngine = TemplateEngine.createPrecompiled(ContentType.Html);
+        return templateEngine.hasTemplate("commit-%s.jte".formatted(shortName));
     }
 
     /**

--- a/plugin-modernizer-core/src/main/jte/branch.jte
+++ b/plugin-modernizer-core/src/main/jte/branch.jte
@@ -1,0 +1,6 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@import static io.jenkins.tools.pluginmodernizer.core.config.Settings.RECIPE_FQDN_PREFIX
+@param Plugin plugin
+@param Recipe recipe
+plugin-modernizer/${recipe.getName().replaceAll(RECIPE_FQDN_PREFIX + ".", "").toLowerCase()}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -34,6 +34,42 @@ public class TemplateUtilsTest {
     }
 
     @Test
+    public void testDefaultCommit() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata metadata = mock(PluginMetadata.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn(metadata).when(plugin).getMetadata();
+        doReturn("io.jenkins.tools.pluginmodernizer.FakeRecipe").when(recipe).getName();
+
+        // Test
+        String result = TemplateUtils.renderCommitMessage(plugin, recipe);
+
+        // Assert
+        assertEquals("Applied recipe FakeRecipe", result);
+    }
+
+    @Test
+    public void testDefaultBranchName() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata metadata = mock(PluginMetadata.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn(metadata).when(plugin).getMetadata();
+        doReturn("io.jenkins.tools.pluginmodernizer.FakeRecipe").when(recipe).getName();
+
+        // Test
+        String result = TemplateUtils.renderBranchName(plugin, recipe);
+
+        // Assert
+        assertEquals("plugin-modernizer/fakerecipe", result);
+    }
+
+    @Test
     public void testFriendlyPrTitleUpgradeBomVersion() {
 
         // Mocks
@@ -49,6 +85,27 @@ public class TemplateUtilsTest {
 
         // Test
         String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
+
+        // Assert
+        assertEquals("Bump bom to 3208.vb_21177d4b_cd9", result);
+    }
+
+    @Test
+    public void testFriendlyCommitUpgradeBomVersion() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata metadata = mock(PluginMetadata.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn(metadata).when(plugin).getMetadata();
+        doReturn("3208.vb_21177d4b_cd9").when(metadata).getBomVersion();
+        doReturn("io.jenkins.tools.pluginmodernizer.UpgradeBomVersion")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderCommitMessage(plugin, recipe);
 
         // Assert
         assertEquals("Bump bom to 3208.vb_21177d4b_cd9", result);


### PR DESCRIPTION
Fix old todo about branch name. This was preventing opening several PR againts same plugin

Also now the commit message is more user friendly and use the PR title if present

### Testing done

Existing tests and add 3 new unit tests to validate 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
