### PR TITLE
Do not use `ExecutionContext` messaging

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataExecutionContext.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataExecutionContext.java
@@ -1,0 +1,53 @@
+package io.jenkins.tools.pluginmodernizer.core.extractor;
+
+/**
+ * Replace the ExecutionContext by our own MetadataContext.
+ * We are not planning to distribute recipes so we tolerate using execution context messaging.
+ */
+public class MetadataExecutionContext {
+    private PluginMetadata mergedMetadata;
+    private PluginMetadata jenkinsFileMetadata;
+    private PluginMetadata pomMetadata;
+    private PluginMetadata javaMetadata;
+    private PluginMetadata commonMetadata;
+
+    public PluginMetadata getMergedMetadata() {
+        return mergedMetadata == null ? new PluginMetadata() : mergedMetadata;
+    }
+
+    public void setMergedMetadata(PluginMetadata mergedMetadata) {
+        this.mergedMetadata = mergedMetadata;
+    }
+
+    public PluginMetadata getCommonMetadata() {
+        return commonMetadata == null ? new PluginMetadata() : commonMetadata;
+    }
+
+    public void setCommonMetadata(PluginMetadata commonMetadata) {
+        this.commonMetadata = commonMetadata;
+    }
+
+    public PluginMetadata getJavaMetadata() {
+        return javaMetadata == null ? new PluginMetadata() : javaMetadata;
+    }
+
+    public void setJavaMetadata(PluginMetadata javaMetadata) {
+        this.javaMetadata = javaMetadata;
+    }
+
+    public PluginMetadata getPomMetadata() {
+        return pomMetadata == null ? new PluginMetadata() : pomMetadata;
+    }
+
+    public void setPomMetadata(PluginMetadata pomMetadata) {
+        this.pomMetadata = pomMetadata;
+    }
+
+    public PluginMetadata getJenkinsFileMetadata() {
+        return jenkinsFileMetadata == null ? new PluginMetadata() : jenkinsFileMetadata;
+    }
+
+    public void setJenkinsFileMetadata(PluginMetadata jenkinsFileMetadata) {
+        this.jenkinsFileMetadata = jenkinsFileMetadata;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFinalizerVisitor.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/MetadataFinalizerVisitor.java
@@ -4,7 +4,6 @@ import static io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils.fromJson;
 import static io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils.merge;
 import static io.jenkins.tools.pluginmodernizer.core.utils.JsonUtils.toJson;
 
-import org.openrewrite.ExecutionContext;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.slf4j.Logger;
@@ -13,7 +12,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Visitor to finalize metadata from source files
  */
-public class MetadataFinalizerVisitor extends TreeVisitor<Tree, ExecutionContext> {
+public class MetadataFinalizerVisitor extends TreeVisitor<Tree, MetadataExecutionContext> {
 
     /**
      * LOGGER.
@@ -21,13 +20,13 @@ public class MetadataFinalizerVisitor extends TreeVisitor<Tree, ExecutionContext
     private static final Logger LOG = LoggerFactory.getLogger(MetadataFinalizerVisitor.class);
 
     @Override
-    public Tree visit(Tree tree, ExecutionContext ctx) {
+    public Tree visit(Tree tree, MetadataExecutionContext metadataContext) {
 
-        PluginMetadata mergedMetadata = ctx.getMessage("mergedMetadata", new PluginMetadata());
-        PluginMetadata commonMetadata = ctx.getMessage("commonMetadata", new PluginMetadata());
-        PluginMetadata pomMetadata = ctx.getMessage("pomMetadata", new PluginMetadata());
-        PluginMetadata javaMetadata = ctx.getMessage("javaMetadata", new PluginMetadata());
-        PluginMetadata jenkinsFileMetadata = ctx.getMessage("jenkinsFileMetadata", new PluginMetadata());
+        PluginMetadata mergedMetadata = metadataContext.getMergedMetadata();
+        PluginMetadata commonMetadata = metadataContext.getCommonMetadata();
+        PluginMetadata pomMetadata = metadataContext.getPomMetadata();
+        PluginMetadata javaMetadata = metadataContext.getJavaMetadata();
+        PluginMetadata jenkinsFileMetadata = metadataContext.getJenkinsFileMetadata();
 
         // Merge the metadata
         PluginMetadata merged =
@@ -41,7 +40,7 @@ public class MetadataFinalizerVisitor extends TreeVisitor<Tree, ExecutionContext
         // Write the metadata to a file for later use by the plugin modernizer.
         merged.save();
         LOG.debug("Plugin metadata written to {}", merged.getRelativePath());
-        ctx.putMessage("mergedMetadata", merged);
+        metadataContext.setMergedMetadata(merged);
         LOG.debug(toJson(merged));
 
         return tree;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/FetchMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/FetchMetadata.java
@@ -1,10 +1,12 @@
 package io.jenkins.tools.pluginmodernizer.core.recipes;
 
+import io.jenkins.tools.pluginmodernizer.core.extractor.MetadataExecutionContext;
 import io.jenkins.tools.pluginmodernizer.core.extractor.MetadataVisitor;
 import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.RecipeList;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 
 /**
@@ -25,14 +27,24 @@ public class FetchMetadata extends Recipe {
         return "Fetch metadata from source files.";
     }
 
+    /**
+     * Metadata context to store the metadata extracted from different sources.
+     */
+    private final MetadataExecutionContext metadataContext = new MetadataExecutionContext();
+
     @Override
     public void buildRecipeList(RecipeList list) {
         super.buildRecipeList(list);
-        list.recipe(new MetadataFinalizer());
+        list.recipe(new MetadataFinalizer(metadataContext));
     }
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new MetadataVisitor(new PluginMetadata());
+        return new TreeVisitor<>() {
+            @Override
+            public Tree visit(Tree tree, ExecutionContext ctx) {
+                return new MetadataVisitor(new PluginMetadata()).visit(tree, metadataContext);
+            }
+        };
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MetadataFinalizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MetadataFinalizer.java
@@ -1,8 +1,10 @@
 package io.jenkins.tools.pluginmodernizer.core.recipes;
 
+import io.jenkins.tools.pluginmodernizer.core.extractor.MetadataExecutionContext;
 import io.jenkins.tools.pluginmodernizer.core.extractor.MetadataFinalizerVisitor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 
 /**
@@ -20,8 +22,22 @@ public class MetadataFinalizer extends Recipe {
         return "Metadata finalizer";
     }
 
+    /**
+     * Metadata context.
+     */
+    private final MetadataExecutionContext metadataContext;
+
+    public MetadataFinalizer(MetadataExecutionContext metadataContext) {
+        this.metadataContext = metadataContext;
+    }
+
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
-        return new MetadataFinalizerVisitor();
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public Tree visit(Tree tree, ExecutionContext ctx) {
+                return new MetadataFinalizerVisitor().visit(tree, metadataContext);
+            }
+        };
     }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/FetchMetadataTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/extractor/FetchMetadataTest.java
@@ -26,8 +26,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.openrewrite.Issue;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RewriteTest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Tests for {@link FetchMetadata}.
@@ -36,8 +34,6 @@ import org.slf4j.LoggerFactory;
 // To fix at some point (maybe when adding concurrency in plugin modernizer)
 @Execution(ExecutionMode.SAME_THREAD)
 public class FetchMetadataTest implements RewriteTest {
-
-    private static final Logger LOG = LoggerFactory.getLogger(FetchMetadataTest.class);
 
     private static final PluginMetadata EXPECTED_METADATA;
 
@@ -201,7 +197,7 @@ public class FetchMetadataTest implements RewriteTest {
 
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         assertNotNull(pluginMetadata, "Plugin metadata was not written by the recipe");
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM), "POM file is missing");
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(0, jdkVersion.size());
         assertEquals(EXPECTED_METADATA.getParentVersion(), pluginMetadata.getParentVersion());
@@ -247,7 +243,7 @@ public class FetchMetadataTest implements RewriteTest {
 
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         assertNotNull(pluginMetadata, "Plugin metadata was not written by the recipe");
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM), "POM file is missing");
 
         // Check metadata
         assertEquals("5.2", pluginMetadata.getParentVersion());
@@ -308,7 +304,7 @@ public class FetchMetadataTest implements RewriteTest {
 
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         assertNotNull(pluginMetadata, "Plugin metadata was not written by the recipe");
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM), "POM file is missing");
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(0, jdkVersion.size());
         assertEquals(EXPECTED_METADATA.getParentVersion(), pluginMetadata.getParentVersion());
@@ -521,8 +517,8 @@ public class FetchMetadataTest implements RewriteTest {
 
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         // Files are present
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.POM), "POM is missing");
 
         // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
@@ -553,7 +549,7 @@ public class FetchMetadataTest implements RewriteTest {
 
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         // Files are present
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
 
         // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
@@ -583,7 +579,7 @@ public class FetchMetadataTest implements RewriteTest {
 
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         // Files are present
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
 
         // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
@@ -613,7 +609,7 @@ public class FetchMetadataTest implements RewriteTest {
 
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         // Files are present
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
 
         // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
@@ -643,7 +639,7 @@ public class FetchMetadataTest implements RewriteTest {
 
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         // Files are present
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
 
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
         assertEquals(2, jdkVersion.size());
@@ -670,7 +666,7 @@ public class FetchMetadataTest implements RewriteTest {
 
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
         // Files are present
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
 
         // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
@@ -715,7 +711,7 @@ public class FetchMetadataTest implements RewriteTest {
                         spec -> spec.path("Jenkinsfile")),
                 pomXml(POM_XML));
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
 
         // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();
@@ -753,7 +749,7 @@ public class FetchMetadataTest implements RewriteTest {
                         spec -> spec.path("Jenkinsfile")),
                 pomXml(POM_XML));
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
 
         // Assert other param
         assertNotNull(pluginMetadata.isUseContainerAgent());
@@ -801,7 +797,7 @@ public class FetchMetadataTest implements RewriteTest {
                         spec -> spec.path("Jenkinsfile")),
                 pomXml(POM_XML));
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
 
         // Assert other param
         assertNotNull(pluginMetadata.isUseContainerAgent());
@@ -848,7 +844,7 @@ public class FetchMetadataTest implements RewriteTest {
                         spec -> spec.path("Jenkinsfile")),
                 pomXml(POM_XML));
         PluginMetadata pluginMetadata = new PluginMetadata().refresh();
-        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE));
+        assertTrue(pluginMetadata.hasFile(ArchetypeCommonFile.JENKINSFILE), "Jenkinsfile is missing");
 
         // Assert JDK
         Set<JDK> jdkVersion = pluginMetadata.getJdks();

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <spotless.check.skip>false</spotless.check.skip>
 
     <!-- Version -->
-    <openrewrite.bom.version>3.0.1</openrewrite.bom.version>
+    <openrewrite.bom.version>3.0.2</openrewrite.bom.version>
     <openrewrite.maven.plugin.version>6.0.4</openrewrite.maven.plugin.version>
     <micrometer.version>1.14.3</micrometer.version>
     <slf4j.version>2.0.16</slf4j.version>


### PR DESCRIPTION
Supersedes https://github.com/jenkins-infra/plugin-modernizer-tool/pull/660

### Testing done

I know that using ExecutionContextMessage was discouraged by OpenRewrite due to leaking information between recipes.

As we are not distributing recipe, it was acceptable. But it looks (without further notice) that it's not possible anymore.

So using our own MetadataExecutionContext

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
