### PR TITLE
Upgrade jenkins test harness version if not compatible

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
@@ -5,7 +5,10 @@ import io.jenkins.tools.pluginmodernizer.core.utils.JdkFetcher;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
 /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
@@ -5,10 +5,7 @@ import io.jenkins.tools.pluginmodernizer.core.utils.JdkFetcher;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
 /**
@@ -24,10 +21,10 @@ public enum JDK {
      * Available JDKs
      * See <a href="https://www.jenkins.io/doc/book/platform-information/support-policy-java/">Java Support Policy</a> for details
      */
-    JAVA_8(8, true, null, "2.346.1"),
-    JAVA_11(11, true, "2.164.1", "2.462.3"),
-    JAVA_17(17, true, "2.346.1", null),
-    JAVA_21(21, true, "2.426.1", null);
+    JAVA_8(8, true, null, "2.346.1", "1900.v9e128c991ef4"),
+    JAVA_11(11, true, "2.164.1", "2.462.3", "2225.v04fa_3929c9b_5"),
+    JAVA_17(17, true, "2.346.1", null, null),
+    JAVA_21(21, true, "2.426.1", null, null);
 
     /**
      * The major version
@@ -50,15 +47,24 @@ public enum JDK {
     private final String maximumCoreVersion;
 
     /**
+     * The latest compatible version of jenkins-test-harness version
+     */
+    private final String latestTestHarnessVersion;
+
+    /**
      * Constructor
      * @param major The Java major version
      * @param lts If the version is LTS
+     * @param compatibleSince The compatibility since for this JDK
+     * @param maximumCoreVersion The maximum required core version
+     * @param latestTestHarnessVersion The latest compatible version of jenkins-test-harness
      */
-    JDK(int major, boolean lts, String compatibleSince, String maximumCoreVersion) {
+    JDK(int major, boolean lts, String compatibleSince, String maximumCoreVersion, String latestTestHarnessVersion) {
         this.major = major;
         this.lts = lts;
         this.compatibleSince = compatibleSince;
         this.maximumCoreVersion = maximumCoreVersion;
+        this.latestTestHarnessVersion = latestTestHarnessVersion;
     }
 
     /**
@@ -75,6 +81,26 @@ public enum JDK {
      */
     public String getCompatibleSince() {
         return compatibleSince;
+    }
+
+    public String getLatestTestHarnessVersion() {
+        return latestTestHarnessVersion;
+    }
+
+    /**
+     * Get the latest compatible jenkins-test-harness version based on the Jenkins version.
+     * @param jenkinsVersion The Jenkins version.
+     * @return The latest compatible jenkins-test-harness version, or null.
+     */
+    public static String getLatestTestHarnessVersion(String jenkinsVersion) {
+        if (jenkinsVersion == null || jenkinsVersion.isEmpty()) {
+            throw new IllegalArgumentException("Jenkins version cannot be null or empty");
+        }
+
+        JDK oldestCompatibleJdk = min(Set.of(JDK.values()), jenkinsVersion);
+
+        // Return the latest test-harness version for the oldest compatible JDK
+        return oldestCompatibleJdk != null ? oldestCompatibleJdk.getLatestTestHarnessVersion() : null;
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsTestHarnessVersion.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsTestHarnessVersion.java
@@ -1,0 +1,84 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import io.jenkins.tools.pluginmodernizer.core.model.JDK;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.maven.ChangePropertyValue;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.maven.RemoveRedundantDependencyVersions;
+import org.openrewrite.xml.tree.Xml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Upgrade Jenkins Test Harness version to ensure compatibility with jenkins.version.
+ */
+public class UpgradeJenkinsTestHarnessVersion extends Recipe {
+    /**
+     * Logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(UpgradeJenkinsTestHarnessVersion.class);
+
+    /**
+     * The jenkins version.
+     */
+    @Option(displayName = "Version", description = "Jenkins version.", example = "2.440.3")
+    String jenkinsVersion;
+
+    /**
+     * Constructor.
+     * @param jenkinsVersion The Jenkins version.
+     */
+    public UpgradeJenkinsTestHarnessVersion(String jenkinsVersion) {
+        this.jenkinsVersion = jenkinsVersion;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Upgrade Jenkins Test Harness version";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Upgrade Jenkins Test Harness version to ensure compatibility with jenkins.version.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MavenIsoVisitor<>() {
+
+            @Override
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+
+                String latestCompatibleVersion = JDK.getLatestTestHarnessVersion(jenkinsVersion);
+
+                if (latestCompatibleVersion == null) {
+                    LOG.info(
+                            "No compatible Jenkins Test Harness version found for Jenkins version {},  Defaulting to latest release.",
+                            jenkinsVersion);
+                    latestCompatibleVersion = Settings.getPluginVersion("jenkins-test-harness");
+                }
+
+                document = (Xml.Document)
+                        new ChangePropertyValue("jenkins-test-harness.version", latestCompatibleVersion, false, false)
+                                .getVisitor()
+                                .visitNonNull(document, ctx);
+
+                LOG.info("Removing redundant dependencies of jenkins-test-harness if any...");
+                document = (Xml.Document) new RemoveRedundantDependencyVersions(
+                                "org.jenkins-ci.main",
+                                "jenkins-test-harness",
+                                false,
+                                RemoveRedundantDependencyVersions.Comparator.ANY,
+                                null)
+                        .getVisitor()
+                        .visitNonNull(document, ctx);
+
+                return super.visitDocument(document, ctx);
+            }
+        };
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -150,6 +150,8 @@ recipeList:
       newVersion: 5.X
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: 2.479.1
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
+      jenkinsVersion: 2.479.1
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.kohsuke.stapler.StaplerRequest
       newFullyQualifiedTypeName: org.kohsuke.stapler.StaplerRequest2
@@ -199,8 +201,6 @@ description: Remove extra maven properties from the pom.
 recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty:
       propertyName: configuration-as-code.version
-  - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty:
-      propertyName: jenkins-test-harness.version
   - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty:
       propertyName: java.version
   - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty:
@@ -404,6 +404,8 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.AddPluginsBom
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: 2.462.3
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
+      jenkinsVersion: 2.462.3
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
@@ -423,6 +425,8 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.AddPluginsBom
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: 2.462.3
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
+        jenkinsVersion: 2.462.3
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
@@ -450,6 +454,8 @@ recipeList:
       newVersion: 4.51 # See https://www.jenkins.io/blog/2022/12/14/require-java-11/
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: 2.346.3
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
+      jenkinsVersion: 2.346.1
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.core.recipes.code.ReplaceRemovedSSHLauncherConstructor
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties

--- a/plugin-modernizer-core/src/main/resources/versions.properties
+++ b/plugin-modernizer-core/src/main/resources/versions.properties
@@ -12,3 +12,4 @@ gson-api.version = 2.11.0-109.v1ef91dd0829a_
 joda-time-api.version = 2.13.0-93.v9934da_29b_a_e9
 json-api.version = 20250107-125.v28b_a_ffa_eb_f01
 json-path-api.version = 2.9.0-138.vc943da_d833b_6
+jenkins-test-harness.version = 2391.v9b_3e2d3351a_2

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
@@ -149,4 +149,14 @@ public class JDKTest {
         assertEquals(JDK.JAVA_17, JDK.get("2.479.1").get(0));
         assertEquals(JDK.JAVA_21, JDK.get("2.479.1").get(1));
     }
+
+    @Test
+    public void getLatestTestHarnessVersion() {
+        assertEquals("2225.v04fa_3929c9b_5", JDK.getLatestTestHarnessVersion("2.426.1"));
+        assertEquals("1900.v9e128c991ef4", JDK.getLatestTestHarnessVersion("2.346.1"));
+        assertNull(JDK.getLatestTestHarnessVersion("2.463"));
+        assertNull(JDK.getLatestTestHarnessVersion("2.479.1"));
+        assertEquals("2225.v04fa_3929c9b_5", JDK.getLatestTestHarnessVersion("2.361.1"));
+        assertEquals("1900.v9e128c991ef4", JDK.getLatestTestHarnessVersion("2.164.1"));
+    }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -644,16 +644,19 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             <connection>scm:git:git://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
                           <properties>
+                            <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                             <jenkins.version>2.440.3</jenkins.version>
-                             <maven.compiler.source>17</maven.compiler.source>
-                             <maven.compiler.release>17</maven.compiler.release>
-                             <maven.compiler.target>17</maven.compiler.target>
                           </properties>
                           <dependencies>
                             <dependency>
                               <groupId>io.jenkins.plugins</groupId>
                               <artifactId>asm-api</artifactId>
                               <version>9.6-3.v2e1fa_b_338cd7</version>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.main</groupId>
+                              <artifactId>jenkins-test-harness</artifactId>
+                              <version>2.41.1</version>
                             </dependency>
                           </dependencies>
                           <repositories>
@@ -689,6 +692,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             <connection>scm:git:https://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
                           <properties>
+                            <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
                             <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
                             <jenkins.baseline>2.462</jenkins.baseline>
                             <jenkins.version>${jenkins.baseline}.3</jenkins.version>
@@ -708,6 +712,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             <dependency>
                               <groupId>io.jenkins.plugins</groupId>
                               <artifactId>asm-api</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.main</groupId>
+                              <artifactId>jenkins-test-harness</artifactId>
                             </dependency>
                           </dependencies>
                           <repositories>
@@ -764,6 +772,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           </scm>
                           <properties>
                             <jenkins.version>2.440.3</jenkins.version>
+                            <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                              <maven.compiler.source>17</maven.compiler.source>
                              <maven.compiler.release>17</maven.compiler.release>
                              <maven.compiler.target>17</maven.compiler.target>
@@ -802,6 +811,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           </scm>
                           <properties>
                             <jenkins.version>2.462.3</jenkins.version>
+                            <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
                           </properties>
                           <repositories>
                             <repository>
@@ -853,8 +863,9 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
                           <properties>
-                             <jenkins.baseline>2.440</jenkins.baseline>
-                             <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                            <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
+                            <jenkins.baseline>2.440</jenkins.baseline>
+                            <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -867,6 +878,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               </dependency>
                             </dependencies>
                           </dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.jenkins-ci.main</groupId>
+                                <artifactId>jenkins-test-harness</artifactId>
+                                <version>2.41.1</version>
+                              </dependency>
+                            </dependencies>
                           <repositories>
                             <repository>
                               <id>repo.jenkins-ci.org</id>
@@ -897,9 +915,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
                           <properties>
-                             <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                             <jenkins.baseline>2.462</jenkins.baseline>
-                             <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                            <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+                            <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                            <jenkins.baseline>2.462</jenkins.baseline>
+                            <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -912,6 +931,12 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               </dependency>
                             </dependencies>
                           </dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.jenkins-ci.main</groupId>
+                                <artifactId>jenkins-test-harness</artifactId>
+                              </dependency>
+                            </dependencies>
                           <repositories>
                             <repository>
                               <id>repo.jenkins-ci.org</id>
@@ -965,6 +990,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <packaging>hpi</packaging>
                       <name>My API Plugin</name>
                       <properties>
+                        <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                         <revision>2.17.0</revision>
                         <changelist>999999-SNAPSHOT</changelist>
                         <jenkins.version>2.401.3</jenkins.version>
@@ -1005,6 +1031,11 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <artifactId>jackson-databind</artifactId>
                         </dependency>
                         <dependency>
+                          <groupId>org.jenkins-ci.main</groupId>
+                          <artifactId>jenkins-test-harness</artifactId>
+                          <version>2.41.1</version>
+                        </dependency>
+                        <dependency>
                           <groupId>io.jenkins.plugins</groupId>
                           <artifactId>json-api</artifactId>
                         </dependency>
@@ -1026,6 +1057,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <packaging>hpi</packaging>
                       <name>My API Plugin</name>
                       <properties>
+                        <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
                         <revision>2.17.0</revision>
                         <changelist>999999-SNAPSHOT</changelist>
                         <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
@@ -1066,6 +1098,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                         <dependency>
                           <groupId>com.fasterxml.jackson.core</groupId>
                           <artifactId>jackson-databind</artifactId>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.main</groupId>
+                          <artifactId>jenkins-test-harness</artifactId>
                         </dependency>
                         <dependency>
                           <groupId>io.jenkins.plugins</groupId>
@@ -1113,7 +1149,8 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             <connection>scm:git:git://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
                           <properties>
-                             <jenkins.version>2.440.3</jenkins.version>
+                            <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
+                            <jenkins.version>2.440.3</jenkins.version>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -1126,6 +1163,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               </dependency>
                             </dependencies>
                           </dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.jenkins-ci.main</groupId>
+                                <artifactId>jenkins-test-harness</artifactId>
+                                <version>2.41.1</version>
+                              </dependency>
+                            </dependencies>
                           <repositories>
                             <repository>
                               <id>repo.jenkins-ci.org</id>
@@ -1159,9 +1203,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             <connection>scm:git:https://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
                           <properties>
-                             <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                             <jenkins.baseline>2.462</jenkins.baseline>
-                             <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                            <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+                            <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                            <jenkins.baseline>2.462</jenkins.baseline>
+                            <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -1174,6 +1219,12 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               </dependency>
                             </dependencies>
                           </dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.jenkins-ci.main</groupId>
+                                <artifactId>jenkins-test-harness</artifactId>
+                              </dependency>
+                            </dependencies>
                           <repositories>
                             <repository>
                               <id>repo.jenkins-ci.org</id>
@@ -1238,7 +1289,8 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             <connection>scm:git:git://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
                           <properties>
-                             <jenkins.version>2.303.3</jenkins.version>
+                            <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
+                            <jenkins.version>2.303.3</jenkins.version>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -1251,6 +1303,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               </dependency>
                             </dependencies>
                           </dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.jenkins-ci.main</groupId>
+                                <artifactId>jenkins-test-harness</artifactId>
+                                <version>2.41.1</version>
+                              </dependency>
+                            </dependencies>
                           <repositories>
                             <repository>
                               <id>repo.jenkins-ci.org</id>
@@ -1284,9 +1343,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             <connection>scm:git:https://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
                           <properties>
-                             <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                             <jenkins.baseline>2.346</jenkins.baseline>
-                             <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                            <jenkins-test-harness.version>1900.v9e128c991ef4</jenkins-test-harness.version>
+                            <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                            <jenkins.baseline>2.346</jenkins.baseline>
+                            <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -1299,6 +1359,12 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               </dependency>
                             </dependencies>
                           </dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.jenkins-ci.main</groupId>
+                                <artifactId>jenkins-test-harness</artifactId>
+                              </dependency>
+                            </dependencies>
                           <repositories>
                             <repository>
                               <id>repo.jenkins-ci.org</id>
@@ -1357,6 +1423,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                 <connection>scm:git:https://github.com/jenkinsci/empty-plugin.git</connection>
                               </scm>
                               <properties>
+                                <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                                 <maven.compiler.release>11</maven.compiler.release>
                                 <jenkins.version>2.440.3</jenkins.version>
                                 <maven.compiler.source>11</maven.compiler.source>
@@ -1396,6 +1463,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                 <connection>scm:git:https://github.com/jenkinsci/empty-plugin.git</connection>
                               </scm>
                               <properties>
+                                <jenkins-test-harness.version>%s</jenkins-test-harness.version>
                                 <jenkins.version>2.479.1</jenkins.version>
                               </properties>
                               <repositories>
@@ -1412,7 +1480,9 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               </pluginRepositories>
                             </project>
                             """
-                                .formatted(Settings.getJenkinsParentVersion())),
+                                .formatted(
+                                        Settings.getJenkinsParentVersion(),
+                                        Settings.getPluginVersion("jenkins-test-harness"))),
                 srcMainResources(
                         // language=java
                         java(
@@ -1478,11 +1548,12 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
                           <properties>
-                             <java.version>17</java.version>
-                             <jenkins.version>2.440.3</jenkins.version>
-                             <maven.compiler.source>17</maven.compiler.source>
-                             <maven.compiler.release>17</maven.compiler.release>
-                             <maven.compiler.target>17</maven.compiler.target>
+                            <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
+                            <java.version>17</java.version>
+                            <jenkins.version>2.440.3</jenkins.version>
+                            <maven.compiler.source>17</maven.compiler.source>
+                            <maven.compiler.release>17</maven.compiler.release>
+                            <maven.compiler.target>17</maven.compiler.target>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -1495,6 +1566,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               </dependency>
                             </dependencies>
                           </dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.jenkins-ci.main</groupId>
+                                <artifactId>jenkins-test-harness</artifactId>
+                                <version>2.41.1</version>
+                              </dependency>
+                            </dependencies>
                           <repositories>
                             <repository>
                               <id>repo.jenkins-ci.org</id>
@@ -1525,9 +1603,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
                           <properties>
-                             <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                             <jenkins.baseline>2.479</jenkins.baseline>
-                             <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                            <jenkins-test-harness.version>%s</jenkins-test-harness.version>
+                            <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                            <jenkins.baseline>2.479</jenkins.baseline>
+                            <jenkins.version>${jenkins.baseline}.1</jenkins.version>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -1540,6 +1619,12 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               </dependency>
                             </dependencies>
                           </dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>org.jenkins-ci.main</groupId>
+                                <artifactId>jenkins-test-harness</artifactId>
+                              </dependency>
+                            </dependencies>
                           <repositories>
                             <repository>
                               <id>repo.jenkins-ci.org</id>
@@ -1554,7 +1639,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           </pluginRepositories>
                         </project>
                         """
-                                .formatted(Settings.getJenkinsParentVersion(), Settings.getBomVersion())));
+                                .formatted(
+                                        Settings.getJenkinsParentVersion(),
+                                        Settings.getPluginVersion("jenkins-test-harness"),
+                                        Settings.getBomVersion())));
     }
 
     @Test
@@ -1591,8 +1679,9 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                     <jenkins.baseline>2.440</jenkins.baseline>
-                     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                    <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
+                    <jenkins.baseline>2.440</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                   </properties>
                   <dependencyManagement>
                     <dependencies>
@@ -1605,6 +1694,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.jenkins-ci.main</groupId>
+                        <artifactId>jenkins-test-harness</artifactId>
+                        <version>2.41.1</version>
+                      </dependency>
+                    </dependencies>
                   <repositories>
                     <repository>
                       <id>repo.jenkins-ci.org</id>
@@ -1635,9 +1731,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                     <jenkins.baseline>2.479</jenkins.baseline>
-                     <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                    <jenkins-test-harness.version>%s</jenkins-test-harness.version>
+                    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                    <jenkins.baseline>2.479</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
                   </properties>
                   <dependencyManagement>
                     <dependencies>
@@ -1650,6 +1747,12 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.jenkins-ci.main</groupId>
+                        <artifactId>jenkins-test-harness</artifactId>
+                      </dependency>
+                    </dependencies>
                   <repositories>
                     <repository>
                       <id>repo.jenkins-ci.org</id>
@@ -1664,7 +1767,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   </pluginRepositories>
                 </project>
                 """
-                                .formatted(Settings.getJenkinsParentVersion(), Settings.getBomVersion())));
+                                .formatted(
+                                        Settings.getJenkinsParentVersion(),
+                                        Settings.getPluginVersion("jenkins-test-harness"),
+                                        Settings.getBomVersion())));
     }
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsTestHarnessVersionTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsTestHarnessVersionTest.java
@@ -2,7 +2,6 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
-import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -11,20 +10,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Test for {@link UpgradeJenkinsVersion}.
+ * Test for {@link UpgradeJenkinsTestHarnessVersion}.
  */
 @Execution(ExecutionMode.CONCURRENT)
-public class UpgradeJenkinsVersionTest implements RewriteTest {
+public class UpgradeJenkinsTestHarnessVersionTest implements RewriteTest {
 
     /**
      * LOGGER.
      */
-    private static final Logger LOG = LoggerFactory.getLogger(UpgradeJenkinsVersionTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UpgradeJenkinsTestHarnessVersionTest.class);
 
     @Test
-    void testPerformUpgradeWithoutBom() {
+    void testPerformUpgradePropertyWithoutBom() {
         rewriteRun(
-                spec -> spec.recipe(new UpgradeJenkinsVersion(Settings.getJenkinsMinimumVersion())),
+                spec -> spec.recipe(new UpgradeJenkinsTestHarnessVersion("2.440.3")),
                 // language=xml
                 pomXml(
                         """
@@ -43,6 +42,7 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
+                    <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                     <jenkins.version>2.440.3</jenkins.version>
                   </properties>
                   <repositories>
@@ -75,7 +75,8 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                    <jenkins.version>%s</jenkins.version>
+                    <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+                    <jenkins.version>2.440.3</jenkins.version>
                   </properties>
                   <repositories>
                     <repository>
@@ -90,14 +91,13 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                     </pluginRepository>
                   </pluginRepositories>
                 </project>
-                """
-                                .formatted(Settings.getJenkinsMinimumVersion())));
+                """));
     }
 
     @Test
-    void testPerformUpgradeWithBaselineWithoutBom() {
+    void testPerformUpgradePropertyAndRemoveDependencyWithoutBom() {
         rewriteRun(
-                spec -> spec.recipe(new UpgradeJenkinsVersion(Settings.getJenkinsMinimumVersion())),
+                spec -> spec.recipe(new UpgradeJenkinsTestHarnessVersion("2.440.3")),
                 // language=xml
                 pomXml(
                         """
@@ -116,9 +116,16 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                    <jenkins.baseline>2.440</jenkins.baseline>
-                    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                    <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
+                    <jenkins.version>2.440.3</jenkins.version>
                   </properties>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.jenkins-ci.main</groupId>
+                        <artifactId>jenkins-test-harness</artifactId>
+                        <version>2.41.1</version>
+                      </dependency>
+                    </dependencies>
                   <repositories>
                     <repository>
                       <id>repo.jenkins-ci.org</id>
@@ -134,47 +141,50 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                 </project>
                 """,
                         """
-                 <?xml version="1.0" encoding="UTF-8"?>
-                 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-                   <modelVersion>4.0.0</modelVersion>
-                   <parent>
-                     <groupId>org.jenkins-ci.plugins</groupId>
-                     <artifactId>plugin</artifactId>
-                     <version>4.87</version>
-                     <relativePath />
-                   </parent>
-                   <groupId>io.jenkins.plugins</groupId>
-                   <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
-                   <packaging>hpi</packaging>
-                   <name>Empty Plugin</name>
-                   <properties>
-                     <jenkins.baseline>%s</jenkins.baseline>
-                     <jenkins.version>${jenkins.baseline}.%s</jenkins.version>
-                   </properties>
-                   <repositories>
-                     <repository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </repository>
-                   </repositories>
-                   <pluginRepositories>
-                     <pluginRepository>
-                       <id>repo.jenkins-ci.org</id>
-                       <url>https://repo.jenkins-ci.org/public/</url>
-                     </pluginRepository>
-                   </pluginRepositories>
-                 </project>
-                 """
-                                .formatted(
-                                        Settings.getJenkinsMinimumBaseline(),
-                                        Settings.getJenkinsMinimumPatchVersion())));
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.87</version>
+                    <relativePath />
+                  </parent>
+                  <groupId>io.jenkins.plugins</groupId>
+                  <artifactId>empty</artifactId>
+                  <version>1.0.0-SNAPSHOT</version>
+                  <packaging>hpi</packaging>
+                  <name>Empty Plugin</name>
+                  <properties>
+                    <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+                    <jenkins.version>2.440.3</jenkins.version>
+                  </properties>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.jenkins-ci.main</groupId>
+                        <artifactId>jenkins-test-harness</artifactId>
+                      </dependency>
+                    </dependencies>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
+                """));
     }
 
     @Test
-    void testPerformUpgradeWithoutBaselineWithBomAndUpgradeBomIfDoesntExistsForNewJenkinsVersion() {
+    void testPerformUpgradePropertyWithBom() {
         rewriteRun(
-                spec -> spec.recipe(new UpgradeJenkinsVersion(Settings.getJenkinsMinimumVersion())),
+                spec -> spec.recipe(new UpgradeJenkinsTestHarnessVersion("2.440.3")),
                 // language=xml
                 pomXml(
                         """
@@ -193,6 +203,7 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
+                    <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                     <jenkins.version>2.440.3</jenkins.version>
                   </properties>
                   <dependencyManagement>
@@ -236,14 +247,15 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
-                     <jenkins.version>%s</jenkins.version>
+                     <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+                     <jenkins.version>2.440.3</jenkins.version>
                    </properties>
                    <dependencyManagement>
                      <dependencies>
                        <dependency>
                          <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>%s</artifactId>
-                         <version>%s</version>
+                         <artifactId>bom-2.440.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
                          <type>pom</type>
                          <scope>import</scope>
                        </dependency>
@@ -262,17 +274,13 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                      </pluginRepository>
                    </pluginRepositories>
                  </project>
-                 """
-                                .formatted(
-                                        Settings.getJenkinsMinimumVersion(),
-                                        Settings.getBomArtifactId(),
-                                        Settings.getBomVersion())));
+                 """));
     }
 
     @Test
-    void testPerformUpgradeWithBaselineWithBomAndUpgradeBomIfDoesntExistsForNewJenkinsVersion() {
+    void testPerformUpgradePropertyAndRemoveDependencyWithBom() {
         rewriteRun(
-                spec -> spec.recipe(new UpgradeJenkinsVersion(Settings.getJenkinsMinimumVersion())),
+                spec -> spec.recipe(new UpgradeJenkinsTestHarnessVersion("2.440.3")),
                 // language=xml
                 pomXml(
                         """
@@ -291,8 +299,8 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                    <jenkins.baseline>2.440</jenkins.baseline>
-                    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
+                    <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
+                    <jenkins.version>2.440.3</jenkins.version>
                   </properties>
                   <dependencyManagement>
                     <dependencies>
@@ -305,6 +313,13 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                       </dependency>
                     </dependencies>
                   </dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.jenkins-ci.main</groupId>
+                        <artifactId>jenkins-test-harness</artifactId>
+                        <version>2.41.1</version>
+                      </dependency>
+                    </dependencies>
                   <repositories>
                     <repository>
                       <id>repo.jenkins-ci.org</id>
@@ -335,20 +350,26 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
-                     <jenkins.baseline>%s</jenkins.baseline>
-                     <jenkins.version>${jenkins.baseline}.%s</jenkins.version>
+                     <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+                     <jenkins.version>2.440.3</jenkins.version>
                    </properties>
                    <dependencyManagement>
                      <dependencies>
                        <dependency>
                          <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                         <version>%s</version>
+                         <artifactId>bom-2.440.x</artifactId>
+                         <version>3435.v238d66a_043fb_</version>
                          <type>pom</type>
                          <scope>import</scope>
                        </dependency>
                      </dependencies>
                    </dependencyManagement>
+                     <dependencies>
+                       <dependency>
+                         <groupId>org.jenkins-ci.main</groupId>
+                         <artifactId>jenkins-test-harness</artifactId>
+                       </dependency>
+                     </dependencies>
                    <repositories>
                      <repository>
                        <id>repo.jenkins-ci.org</id>
@@ -362,10 +383,6 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                      </pluginRepository>
                    </pluginRepositories>
                  </project>
-                 """
-                                .formatted(
-                                        Settings.getJenkinsMinimumBaseline(),
-                                        Settings.getJenkinsMinimumPatchVersion(),
-                                        Settings.getBomVersion())));
+                 """));
     }
 }


### PR DESCRIPTION
Fix #554 

Add Recipe for upgrading test harness version. We are maintaining a `Map` of compatible version between the two, if the version in the pom.xml is >= it , then we don't upgrade, else upgrade the test harness. The map can be extended further to store more values.

If any of the version (jenkins version and test harness) is not referenced via the properties it gets removed from the properties via calling the RemoveProperty recipe internally. 

### Testing done

Tested the unit cases.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

