### PR TITLE
Added Github Actions to run Plugin Modernizer Tool to be used by Plugin Repositories

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -1,0 +1,78 @@
+name: Plugin Modernizer Workflow
+on:
+  workflow_dispatch:
+    inputs:
+      recipe:
+        description: "Plugin Modernizer Tool recipe to use"
+        required: true
+      dry-run:
+        description: "Dry-run the modernization process without making changes"
+        required: false
+        default: "true"
+
+jobs:
+  run-modernizer:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      MVN_INSTALL_PLUGIN_VERSION: 3.1.3
+      VERSION: 999999-SNAPSHOT
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install git
+        run: |
+          sudo apt-get install git
+          sudo apt-get update
+
+      - name: Set up Maven
+        run: |
+          wget --no-verbose "https://dlcdn.apache.org/maven/maven-3/$MAVEN_VERSION/binaries/apache-maven-$MAVEN_VERSION-bin.tar.gz"
+          echo "$CHECKSUM" "apache-maven-$MAVEN_VERSION-bin.tar.gz" | sha512sum --check
+          tar xzf "apache-maven-$MAVEN_VERSION-bin.tar.gz"
+          rm "apache-maven-$MAVEN_VERSION-bin.tar.gz"
+          sudo mv "apache-maven-$MAVEN_VERSION" /opt/maven
+          sudo rm -f /usr/bin/mvn
+          sudo ln -s /opt/maven/bin/mvn /usr/bin/mvn
+          mvn --version
+        env:
+          MAVEN_VERSION: 3.9.9
+          # https://downloads.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz.sha512
+          CHECKSUM: a555254d6b53d267965a3404ecb14e53c3827c09c3b94b5678835887ab404556bfaf78dcfe03ba76fa2508649dca8531c74bca4d5846513522404d48e8c4ac8b
+
+      - name: Build plugin modernizer
+        run: |
+          git clone https://github.com/jenkins-infra/plugin-modernizer-tool.git
+          cd plugin-modernizer-tool
+          mvn clean install
+          cd ..
+
+      - name: Dry-run plugin modernizer on the plugin repo
+        if: ${{ github.event.inputs.dry-run == 'true' }}
+        run: |
+          echo "Running in dry-run mode: No changes will be made."
+          java -jar plugin-modernizer-tool/plugin-modernizer-cli/target/jenkins-plugin-modernizer-${{ env.VERSION }}.jar dry-run
+            --maven-home=/opt/maven
+            --plugin-path . \
+            --recipe "${{ github.event.inputs.recipe }}"
+
+      - name: Run plugin modernizer on the plugin repo
+        if: ${{ github.event.inputs.dry-run == 'false' }}
+        run: |
+          echo "Running in normal mode: Changes will be made."
+          java -jar plugin-modernizer-tool/plugin-modernizer-cli/target/jenkins-plugin-modernizer-${{ env.VERSION }}.jar run
+            --maven-home=/opt/maven
+            --plugin-path . \
+            --recipe "${{ github.event.inputs.recipe }}"
+
+      - name: Test plugin after modernization
+        run: |
+          mvn test


### PR DESCRIPTION
Towards #537.
Added a GitHub Actions workflow to be used by the plugins using the Jenkins Plugin Modernizer tool .
I have included the `action.yml` file in the `.github/workflows/` folder although it won't be used by this repo but by the plugin repos. (Is there is a more suitable location to have this? )

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
