### PR TITLE
Bot cannot access the /user endpoint

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -788,12 +788,19 @@ public class GHService {
             return null;
         }
         try {
-            // Get myself
+            // Get for token
             if (config.getGithubAppId() == null) {
-                LOG.debug("Getting current user using token...");
-                return github.getMyself();
+                if (System.getenv("GITHUB_ACTIONS") == null) {
+                    LOG.debug("Getting current user using token...");
+                    return github.getMyself();
+                }
+                // Get the GitHub Actions user
+                else {
+                    LOG.debug("Getting current user using GitHub Actions...");
+                    return github.getUser("github-actions[bot]");
+                }
             }
-            // Get the bot user
+            // Get for app
             else {
                 LOG.debug("Getting current user using GitHub App...");
                 LOG.debug("GitHub App name: {}", app.getName());


### PR DESCRIPTION
Bot with GITHUB_TOKEN dont' have access to /user endpoint (https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-the-authenticated-user) since it require 'user' scope.

So fetcht he current bot from public endpoint : https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user that don't require any specific scope

Possible fix of https://github.com/jenkins-infra/plugin-modernizer-tool/issues/692

### Testing done

None but will perform some test when merged on main

Only rely on current unit test to avoid any regression

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
