### PR TITLE
Return GHUser class when a GitHub action is detected

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -797,7 +797,23 @@ public class GHService {
                 // Get the GitHub Actions user
                 else {
                     LOG.debug("Getting current user using GitHub Actions...");
-                    return github.getUser("github-actions[bot]");
+                    // Comply with https://api.github.com/users/github-actions%5Bbot%5D
+                    return new GHUser() {
+                        @Override
+                        public String getLogin() {
+                            return "github-actions[bot]";
+                        }
+
+                        @Override
+                        public String getType() throws IOException {
+                            return "Bot";
+                        }
+
+                        @Override
+                        public String getEmail() {
+                            return "41898282+github-actions[bot]@users.noreply.github.com";
+                        }
+                    };
                 }
             }
             // Get for app
@@ -826,6 +842,10 @@ public class GHService {
             // Bot
             else if (app != null && user.getType().equalsIgnoreCase("bot")) {
                 return "%s+%s@users.noreply.github.com".formatted(user.getId(), user.getLogin());
+            }
+            // GitHub action
+            else if (System.getenv("GITHUB_ACTIONS") != null) {
+                return user.getEmail();
             }
             throw new ModernizerException("Unknown user type %s".formatted(user.getType()));
         } catch (IOException e) {


### PR DESCRIPTION
Even cannot access is now user information

Let's return a `GHUser` that comply with `https://api.github.com/users/github-actions%5Bbot%5D` since we only need email and login on plugin modernizer

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


