### PR TITLE
Ensure old bom version can be upgraded

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/RecipesConsts.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/RecipesConsts.java
@@ -14,8 +14,9 @@ public final class RecipesConsts {
 
     public static final String PLUGIN_POM_GROUP_ID = "org.jenkins-ci.plugins";
     public static final String PLUGINS_BOM_GROUP_ID = "io.jenkins.tools.bom";
-    public static final String ANALYSIS_POM_GROUP_ID = "org.jvnet.hudson.plugins";
     public static final String ANALYSIS_POM_ARTIFACT_ID = "analysis-pom";
     public static final String VERSION_METADATA_PATTERN = "\\.v[a-f0-9_]+";
+    public static final String OLD_BOM_VERSION_PATTERN =
+            ""; // Old release line like 2.150.x, no need to filter by pattern
     public static final String INCREMENTAL_REPO_ID = "incrementals";
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -321,6 +321,101 @@ public class DeclarativeRecipesTest implements RewriteTest {
     }
 
     @Test
+    void testUpgradeOldBomVersionFormat() {
+        rewriteRun(
+                spec -> spec.recipeFromResource(
+                        "/META-INF/rewrite/recipes.yml", "io.jenkins.tools.pluginmodernizer.UpgradeBomVersion"),
+                // language=xml
+                pomXml(
+                        """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                          <modelVersion>4.0.0</modelVersion>
+                          <parent>
+                            <groupId>org.jenkins-ci.plugins</groupId>
+                            <artifactId>plugin</artifactId>
+                            <version>4.0</version>
+                            <relativePath />
+                          </parent>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>empty</artifactId>
+                          <version>1.0.0-SNAPSHOT</version>
+                          <packaging>hpi</packaging>
+                          <name>Empty Plugin</name>
+                          <properties>
+                             <jenkins.version>2.164.3</jenkins.version>
+                          </properties>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>io.jenkins.tools.bom</groupId>
+                                <artifactId>bom-2.164.x</artifactId>
+                                <version>3</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                          <repositories>
+                            <repository>
+                              <id>repo.jenkins-ci.org</id>
+                              <url>https://repo.jenkins-ci.org/public/</url>
+                            </repository>
+                          </repositories>
+                          <pluginRepositories>
+                            <pluginRepository>
+                              <id>repo.jenkins-ci.org</id>
+                              <url>https://repo.jenkins-ci.org/public/</url>
+                            </pluginRepository>
+                          </pluginRepositories>
+                        </project>
+                        """,
+                        """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                          <modelVersion>4.0.0</modelVersion>
+                          <parent>
+                            <groupId>org.jenkins-ci.plugins</groupId>
+                            <artifactId>plugin</artifactId>
+                            <version>4.0</version>
+                            <relativePath />
+                          </parent>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>empty</artifactId>
+                          <version>1.0.0-SNAPSHOT</version>
+                          <packaging>hpi</packaging>
+                          <name>Empty Plugin</name>
+                          <properties>
+                             <jenkins.version>2.164.3</jenkins.version>
+                          </properties>
+                          <dependencyManagement>
+                            <dependencies>
+                              <dependency>
+                                <groupId>io.jenkins.tools.bom</groupId>
+                                <artifactId>bom-2.164.x</artifactId>
+                                <version>10</version>
+                                <type>pom</type>
+                                <scope>import</scope>
+                              </dependency>
+                            </dependencies>
+                          </dependencyManagement>
+                          <repositories>
+                            <repository>
+                              <id>repo.jenkins-ci.org</id>
+                              <url>https://repo.jenkins-ci.org/public/</url>
+                            </repository>
+                          </repositories>
+                          <pluginRepositories>
+                            <pluginRepository>
+                              <id>repo.jenkins-ci.org</id>
+                              <url>https://repo.jenkins-ci.org/public/</url>
+                            </pluginRepository>
+                          </pluginRepositories>
+                        </project>
+                        """));
+    }
+
+    @Test
     void testRemoveDependenciesOverride() {
         rewriteRun(
                 spec -> spec.recipeFromResource(


### PR DESCRIPTION
Fix #714

Not a real use case by itself, but the visitor is called during some recipes execution and was failing the recipe

This should not be the case anymore

### Testing done

Added a test that upgrade a old bom (bom-2.164.x) from 3 to 10

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
