### PR TITLE
Improve integration test for force-push and remove some warnings related to Maven and WireMock

### DIFF
--- a/plugin-modernizer-cli/pom-it.xml
+++ b/plugin-modernizer-cli/pom-it.xml
@@ -13,6 +13,15 @@
     <exec.args>-jar target/jenkins-plugin-modernizer-${project.version}.jar ${test.cliArgs}</exec.args>
     <test.cliArgs>--version</test.cliArgs>
   </properties>
+  <!-- Avoid warning and failure with Maven 4.0.0 due to unknown profiles -->
+  <profiles>
+    <profile>
+      <id>consume-incrementals</id>
+    </profile>
+    <profile>
+      <id>might-produce-incrementals</id>
+    </profile>
+  </profiles>
   <build>
     <plugins>
       <plugin>

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -433,6 +433,35 @@ public class CommandLineITCase {
                             .resolve(".github")
                             .resolve("dependabot.yml")),
                     "Dependabot file was not created");
+
+            // Ensure we reapply the changes when running again
+            InvocationRequest request2 = buildRequest(
+                    "run --recipe %s %s".formatted(recipe, getRunArgs(wmRuntimeInfo, Plugin.build(plugin))), logFile);
+            InvocationResult result2 = invoker.execute(request);
+
+            // Assert output
+            assertAll(
+                    () -> assertEquals(0, result.getExitCode()),
+                    () -> assertTrue(Files.readAllLines(logFile).stream()
+                            .anyMatch(line -> line.matches("(.*)Branch already exists. Checking out the branch(.*)"))),
+                    () -> assertTrue(
+                            Files.readAllLines(logFile).stream()
+                                    .anyMatch(
+                                            line -> line.matches(
+                                                    "(.*)Reseted the branch to plugin-modernizer/setupdependabot Checking out the branch to default branch main(.*)"))),
+                    () -> assertTrue(Files.readAllLines(logFile).stream()
+                            .anyMatch(line -> line.matches(
+                                    "(.*)Metadata already computed for plugin empty. Using cached metadata(.*)"))));
+
+            // Check that new file was created
+            assertTrue(
+                    Files.exists(cachePath
+                            .resolve("jenkins-plugin-modernizer-cli")
+                            .resolve(plugin)
+                            .resolve("sources")
+                            .resolve(".github")
+                            .resolve("dependabot.yml")),
+                    "Dependabot file was not created");
         }
     }
 

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/utils/GitHubServerContainer.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/utils/GitHubServerContainer.java
@@ -103,17 +103,17 @@ public class GitHubServerContainer extends GitServerContainer {
         wireMock.register(WireMock.get(WireMock.urlEqualTo("/api/user"))
                 .willReturn(WireMock.jsonResponse(new UserApiResponse("fake-owner", "User"), 200)));
 
+        RepoApiResponse repoApiResponse = new RepoApiResponse(
+                plugin,
+                "jenkinsci/%s".formatted(plugin),
+                "main",
+                "%s/%s/%s".formatted(wmRuntimeInfo.getHttpBaseUrl(), "fake-owner", plugin),
+                this.getGitRepoURIAsSSH().toString(),
+                new OwnerObject("jenkinsci"));
+
         // GET /api/repos/jenkinsci/<plugin>
         wireMock.register(WireMock.get(WireMock.urlEqualTo("/api/repos/jenkinsci/%s".formatted(plugin)))
-                .willReturn(WireMock.jsonResponse(
-                        new RepoApiResponse(
-                                plugin,
-                                "jenkinsci/%s".formatted(plugin),
-                                "main",
-                                "%s/%s/%s".formatted(wmRuntimeInfo.getHttpBaseUrl(), "fake-owner", plugin),
-                                this.getGitRepoURIAsSSH().toString(),
-                                new OwnerObject("jenkinsci")),
-                        200)));
+                .willReturn(WireMock.jsonResponse(repoApiResponse, 200)));
         var parentForkObject =
                 new ParentForkObject(plugin, "jenkinsci/%s".formatted(plugin), new OwnerObject("jenkinsci"));
         // GET /api/repos/fake-owner/<plugin>
@@ -140,6 +140,10 @@ public class GitHubServerContainer extends GitServerContainer {
                                         this.getGitRepoURIAsSSH().toString(),
                                         parentForkObject),
                                 200)));
+
+        // POST /api/repos/jenkinsci/empty/issues/0/labels
+        wireMock.register(WireMock.post(WireMock.urlEqualTo("/api/repos/jenkinsci/empty/issues/0/labels"))
+                .willReturn(WireMock.jsonResponse("[]", 200)));
 
         // GET /api/repos/jenkinsci/<plugin>/pulls?state=open
         wireMock.register(

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -693,7 +693,10 @@ public class GHService {
                         .setMode(ResetCommand.ResetType.HARD)
                         .setRef(defaultBranch)
                         .call();
-                LOG.debug("Reseted the branch to Checking out the branch to default branch {}", defaultBranch);
+                LOG.debug(
+                        "Reseted the branch to {} Checking out the branch to default branch {}",
+                        branchName,
+                        defaultBranch);
             }
         } catch (IOException | GitAPIException e) {
             plugin.addError("Failed to checkout branch", e);


### PR DESCRIPTION
Improve integration test for force-push and remove some warnings related to Maven and WireMock

### Testing done

Test changes only

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
