### PR TITLE
fix(recipes): Stapler migration in UpgradeNextMajorParentVersion recipe

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -153,6 +153,9 @@ recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: org.kohsuke.stapler.StaplerRequest
       newFullyQualifiedTypeName: org.kohsuke.stapler.StaplerRequest2
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.kohsuke.stapler.StaplerResponse
+      newFullyQualifiedTypeName: org.kohsuke.stapler.StaplerResponse2
   - org.openrewrite.java.ChangeMethodName:
       methodPattern: org.kohsuke.stapler.Stapler getCurrentRequest()
       newMethodName: getCurrentRequest2

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -1420,10 +1420,12 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                 import javax.servlet.ServletException;
                                 import org.kohsuke.stapler.Stapler;
                                 import org.kohsuke.stapler.StaplerRequest;
+                                import org.kohsuke.stapler.StaplerResponse;
 
                                 public class Foo {
                                     public void foo() {
                                         StaplerRequest req = Stapler.getCurrentRequest();
+                                        StaplerResponse response = Stapler.getCurrentResponse();
                                     }
                                 }
                                 """,
@@ -1431,10 +1433,12 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                 import jakarta.servlet.ServletException;
                                 import org.kohsuke.stapler.Stapler;
                                 import org.kohsuke.stapler.StaplerRequest2;
+                                import org.kohsuke.stapler.StaplerResponse2;
 
                                 public class Foo {
                                     public void foo() {
                                         StaplerRequest2 req = Stapler.getCurrentRequest2();
+                                        StaplerResponse2 response = Stapler.getCurrentResponse2();
                                     }
                                 }
                                 """)));


### PR DESCRIPTION
Fixes #739.

Add missing transformation for Stapler migration in `recipes.yml`.

* Add transformation for `org.kohsuke.stapler.StaplerResponse` to `org.kohsuke.stapler.StaplerResponse2`.
* Ensure the transformation is included in the `UpgradeNextMajorParentVersion` recipe.

We should add some tests in order to regularly check it's still working.

### Testing done

`mvnd clean install; java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar run --plugins sonargraph-integration --recipe UpgradeNextMajorParentVersion`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
