### PR TITLE
Add commons-compress-api.version into versions.properties

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -193,6 +193,15 @@ public class Settings {
         return readProperty("bom.version", "versions.properties");
     }
 
+    /**
+     * Return a plugin version from versions.properties
+     * @param plugin The plugin name (for example commons-compress-api)
+     * @return The version of the plugin
+     */
+    public static String getPluginVersion(String plugin) {
+        return readProperty("%s.version".formatted(plugin), "versions.properties");
+    }
+
     public static String getJenkinsMinimumVersion() {
         return readProperty("jenkins.core.minimum.version", "versions.properties");
     }

--- a/plugin-modernizer-core/src/main/resources/versions.properties
+++ b/plugin-modernizer-core/src/main/resources/versions.properties
@@ -3,3 +3,4 @@ jenkins.parent.version = 5.6
 bom.version = 4023.va_eeb_b_4e45f07
 remediation.jenkins.plugin.parent.version = 2.37
 jenkins.core.minimum.version = 2.462.3
+commons-compress-api.version = 1.27.1-1

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -2227,7 +2227,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                     <dependency>
                       <groupId>io.jenkins.plugins</groupId>
                       <artifactId>commons-compress-api</artifactId>
-                      <version>1.27.1-1</version>
+                      <version>%s</version>
                     </dependency>
                   </dependencies>
                   <repositories>
@@ -2243,7 +2243,8 @@ public class DeclarativeRecipesTest implements RewriteTest {
                     </pluginRepository>
                   </pluginRepositories>
                 </project>
-                """));
+                """
+                                .formatted(Settings.getPluginVersion("commons-compress-api"))));
     }
 
     @Test

--- a/updatecli/updatecli.d/compress-api.yaml
+++ b/updatecli/updatecli.d/compress-api.yaml
@@ -36,6 +36,15 @@ targets:
       replacePattern: '$1$2$3 {{ source "latestCompressApiVersion" }}'
     sourceid: latestCompressApiVersion
     scmid: default
+  updateVersions:
+    name: "Update compress-api plugin version in versions.properties"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/versions.properties
+      matchPattern: "(?m)^(commons-compress-api.version =) (.*)"
+      replacePattern: '$1 {{ source "latestCompressApiVersion" }}'
+    sourceid: latestCompressApiVersion
+    scmid: default
 
 actions:
   createPullRequest:


### PR DESCRIPTION
We need to add all API plugin but no time right now.

At least will fix compress-api update

I expect updatecli workflow to fail but works on main since the properties doesn't exists

We will see when merged on main if the PR works https://github.com/jenkins-infra/plugin-modernizer-tool/pull/742


### Testing done

Updated tests and `updatecli diff --config ./updatecli/updatecli.d/compress-api.yaml --values ./updatecli/values.github-action.yaml` to ensure to syntax issue

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
