### PR TITLE
Fix invoker.logs path for junit-attachement

### DIFF
--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -284,8 +284,7 @@ public class CommandLineITCase {
         String plugin = expectedMetadata.getPluginName();
 
         // Junit attachment with logs file for the plugin build
-        System.out.printf(
-                "[[ATTACHMENT|%s]]%n", Plugin.build(plugin).getLogFile().toAbsolutePath());
+        System.out.printf("[[ATTACHMENT|%s]]%n", getMavenInvokerLog(plugin));
         System.out.printf("[[ATTACHMENT|%s]]%n", logFile.toAbsolutePath());
 
         try (GitHubServerContainer gitRemote = new GitHubServerContainer(wmRuntimeInfo, keysPath, plugin, "main")) {
@@ -339,8 +338,7 @@ public class CommandLineITCase {
         final String recipe = "ReplaceLibrariesWithApiPlugin";
 
         // Junit attachment with logs file for the plugin build
-        System.out.printf(
-                "[[ATTACHMENT|%s]]%n", Plugin.build(plugin).getLogFile().toAbsolutePath());
+        System.out.printf("[[ATTACHMENT|%s]]%n", getMavenInvokerLog(plugin));
         System.out.printf("[[ATTACHMENT|%s]]%n", logFile1.toAbsolutePath());
         System.out.printf("[[ATTACHMENT|%s]]%n", logFile2.toAbsolutePath());
 
@@ -401,8 +399,7 @@ public class CommandLineITCase {
         final String recipe = "SetupDependabot";
 
         // Junit attachment with logs file for the plugin build
-        System.out.printf(
-                "[[ATTACHMENT|%s]]%n", Plugin.build(plugin).getLogFile().toAbsolutePath());
+        System.out.printf("[[ATTACHMENT|%s]]%n", getMavenInvokerLog(plugin));
         System.out.printf("[[ATTACHMENT|%s]]%n", logFile.toAbsolutePath());
 
         try (GitHubServerContainer gitRemote = new GitHubServerContainer(wmRuntimeInfo, keysPath, plugin, "main")) {
@@ -475,8 +472,7 @@ public class CommandLineITCase {
         final String recipe = "SetupDependabot";
 
         // Junit attachment with logs file for the plugin build
-        System.out.printf(
-                "[[ATTACHMENT|%s]]%n", Plugin.build(plugin).getLogFile().toAbsolutePath());
+        System.out.printf("[[ATTACHMENT|%s]]%n", getMavenInvokerLog(plugin));
         System.out.printf("[[ATTACHMENT|%s]]%n", logFile.toAbsolutePath());
 
         try (GitHubServerContainer gitRemote = new GitHubServerContainer(wmRuntimeInfo, keysPath, plugin, "main")) {
@@ -532,8 +528,7 @@ public class CommandLineITCase {
             gitRemote.start();
 
             // Junit attachment with logs file for the plugin build
-            System.out.printf(
-                    "[[ATTACHMENT|%s]]%n", Plugin.build(plugin).getLogFile().toAbsolutePath());
+            System.out.printf("[[ATTACHMENT|%s]]%n", getMavenInvokerLog(plugin));
             System.out.printf("[[ATTACHMENT|%s]]%n", logFile.toAbsolutePath());
 
             Invoker invoker = buildInvoker();
@@ -582,8 +577,7 @@ public class CommandLineITCase {
             gitRemote.start();
 
             // Junit attachment with logs file for the plugin build
-            System.out.printf(
-                    "[[ATTACHMENT|%s]]%n", Plugin.build(plugin).getLogFile().toAbsolutePath());
+            System.out.printf("[[ATTACHMENT|%s]]%n", getMavenInvokerLog(plugin));
             System.out.printf("[[ATTACHMENT|%s]]%n", logFile.toAbsolutePath());
 
             Invoker invoker = buildInvoker();
@@ -709,6 +703,17 @@ public class CommandLineITCase {
         LOG.debug("Created log file: {}", logFile.toAbsolutePath());
         System.out.printf("[[ATTACHMENT|%s]]%n", logFile.toAbsolutePath());
         return logFile;
+    }
+
+    /**
+     * Get the location of the maven invoker log for the given plugin
+     * @param plugin The plugin
+     * @return the path
+     */
+    private Path getMavenInvokerLog(String plugin) {
+        return cachePath
+                .resolve("jenkins-plugin-modernizer-cli")
+                .resolve(Plugin.build(plugin).getLogFile());
     }
 
     /**


### PR DESCRIPTION
When we moved the logs to cache we forget to change tests to archive the new location

This was working by chance before because we were creating logs on the current folder

### Testing done

Check the correct location is printed

Will check on ci.jenkins.io that the junit-attachement correcly archive invoker.logs

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
