### PR TITLE
fix(jte): Warning message and hopefully a slightly better PR title.

### DIFF
--- a/plugin-modernizer-core/src/main/jte/pr-body-UpgradeToRecommendCoreVersion.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-UpgradeToRecommendCoreVersion.jte
@@ -24,4 +24,18 @@ If the plugin is already using the plugin bill of materials, then the bill of ma
 
 This means your plugin POM was already using the `${plugin.getMetadata().getJenkinsVersion()}` version but still required a few adjustments.
 
-Thanks for taking the time to review this PR. :pray:
+## The checks fail, why?
+
+For security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.
+Instead, it builds the code using the Jenkinsfile from the default branch.
+
+In this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.
+To resolve this,
+a maintainer can replay the failed build
+by substituting the current Jenkinsfile content with our proposed changes using the "replay the build"
+feature in Jenkins.
+
+Please let us know if you need any assistance with this process.
+
+Thanks for taking the time to review this PR.
+:pray:

--- a/plugin-modernizer-core/src/main/jte/pr-title-UpgradeToRecommendCoreVersion.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-UpgradeToRecommendCoreVersion.jte
@@ -2,4 +2,4 @@
 @import io.jenkins.tools.pluginmodernizer.core.model.Recipe
 @param Plugin plugin
 @param Recipe recipe
-chore(pom): Require ${plugin.getMetadata().getJenkinsVersion()}
+chore(pom): Use recommended core version ${plugin.getMetadata().getJenkinsVersion()}, and Java 11.

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -238,7 +238,7 @@ public class TemplateUtilsTest {
         String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
 
         // Assert
-        assertEquals("chore(pom): Require 2.452.4", result);
+        assertEquals("chore(pom): Use recommended core version 2.452.4, and Java 11.", result);
     }
 
     @Test


### PR DESCRIPTION
As a reminder, the Jenkins infrastructure is set up to execute builds using the `Jenkinsfile` from the default branch, not with any modifications proposed in pull requests. This means that if a PR aims to transition from JDK 8 to JDK 11, the checks will likely fail since the default branch still utilizes JDK 8.

To address this, we should issue a warning to maintainers, informing them that the failure is expected under these circumstances. Additionally, maintainers can resolve the issue by using the "replay the build" feature. This allows them to test the build with the updated Jenkinsfile content manually.

### Testing done

`mvnd clean install`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
