### PR TITLE
Add updatecli manifest to keep jenkins-test-harness updated

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -202,8 +202,20 @@ public class Settings {
         return readProperty("%s.version".formatted(plugin), "versions.properties");
     }
 
+    /**
+     * Return the minimum Jenkins version
+     * @return The minimum Jenkins version
+     */
     public static String getJenkinsMinimumVersion() {
         return readProperty("jenkins.core.minimum.version", "versions.properties");
+    }
+
+    /**
+     * Return the Jenkins Test Harness version
+     * @return The Jenkins Test Harness version
+     */
+    public static String getJenkinsTestHarnessVersion() {
+        return readProperty("jenkins-test-harness.version", "versions.properties");
     }
 
     public static String getJenkinsMinimumBaseline() {

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -1481,8 +1481,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             </project>
                             """
                                 .formatted(
-                                        Settings.getJenkinsParentVersion(),
-                                        Settings.getPluginVersion("jenkins-test-harness"))),
+                                        Settings.getJenkinsParentVersion(), Settings.getJenkinsTestHarnessVersion())),
                 srcMainResources(
                         // language=java
                         java(
@@ -1641,7 +1640,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                         """
                                 .formatted(
                                         Settings.getJenkinsParentVersion(),
-                                        Settings.getPluginVersion("jenkins-test-harness"),
+                                        Settings.getJenkinsTestHarnessVersion(),
                                         Settings.getBomVersion())));
     }
 
@@ -1769,7 +1768,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                 """
                                 .formatted(
                                         Settings.getJenkinsParentVersion(),
-                                        Settings.getPluginVersion("jenkins-test-harness"),
+                                        Settings.getJenkinsTestHarnessVersion(),
                                         Settings.getBomVersion())));
     }
 

--- a/updatecli/updatecli.d/jenkins-test-harness.yaml
+++ b/updatecli/updatecli.d/jenkins-test-harness.yaml
@@ -1,0 +1,46 @@
+name: Update jenkins-test-harness plugin version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestJenkinsTestHarnessVersion:
+    kind: githubrelease
+    spec:
+      owner: "jenkinsci"
+      repository: "jenkins-test-harness"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateVersions:
+    name: "Update jenkins-test-harness version in versions.properties"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/versions.properties
+      matchPattern: "(?m)^(jenkins-test-harness.version =) (.*)"
+      replacePattern: '$1 {{ source "latestJenkinsTestHarnessVersion" }}'
+    sourceid: latestJenkinsTestHarnessVersion
+    scmid: default
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update jenkins-test-harness version to {{ source "latestJenkinsTestHarnessVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli


### PR DESCRIPTION
Add updatecli manifest to keep jenkins-test-harness updated

Follow-up of https://github.com/jenkins-infra/plugin-modernizer-tool/pull/673

### Testing done

CI and `updatecli diff --config ./updatecli/updatecli.d/jenkins-test-harness.yaml --values ./updatecli/values.github-action.yaml` ensuring no errors

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
