### PR TITLE
Scanning recipe to add dependency on detached plugin

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/DetachedPlugins.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/DetachedPlugins.java
@@ -1,0 +1,177 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+/**
+ * # Note that all split plugins between and including matrix-auth and jaxb incorrectly use the first
+ * # core release without the plugin's functionality when they should use the immediately prior release.
+ * # Fixing these retroactively won't help, as the difference only matters to those specific versions.
+ */
+import java.util.Set;
+
+/**
+ * Detached plugins.
+ */
+public enum DetachedPlugins {
+    MAVEN_PLUGIN(
+            "maven-plugin",
+            "1.296",
+            "1.296",
+            "org.jenkins-ci.main",
+            Set.of("hudson.maven"),
+            Set.of(
+                    "hudson.maven.MavenModule",
+                    "hudson.maven.MavenModuleSet",
+                    "hudson.maven.MavenModuleSetBuild",
+                    "hudson.maven.MavenBuild.java")),
+    SUBVERSION("subversion", "1.310", "1.0", "org.jenkins-ci.plugins", Set.of(), Set.of("hudson.scm.SubversionSCM")),
+    CVS("cvs", "1.340", "0.1", "org.jenkins-ci.plugins", Set.of(), Set.of("hudson.scm.CVSSCM")),
+    ANT("ant", "1.430", "1.0", "org.jenkins-ci.plugins", Set.of(), Set.of("hudson.tasks.Ant")),
+    JAVADOC("javadoc", "1.430", "1.0", "org.jenkins-ci.plugins", Set.of(), Set.of("hudson.tasks.JavadocArchiver")),
+    EXTERNAL_MONITOR_JOB(
+            "external-monitor-job",
+            "1.467",
+            "1.0",
+            "org.jenkins-ci.plugins",
+            Set.of(),
+            Set.of("hudson.model.ExternalJob", "hudson.model.ExternalRun")),
+    LDAP(
+            "ldap",
+            "1.467",
+            "1.0",
+            "org.jenkins-ci.plugins",
+            Set.of(),
+            Set.of("hudson.security.LDAPSecurityRealm", "hudson.security.GeneralizedTime")),
+    PAM_AUTH(
+            "pam-auth", "1.467", "1.0", "org.jenkins-ci.plugins", Set.of(), Set.of("hudson.security.PAMSecurityRealm")),
+    MAILER("mailer", "1.493", "1.2", "org.jenkins-ci.plugins", Set.of(), Set.of("hudson.tasks.Mailer")),
+    MATRIX_AUTH(
+            "matrix-auth",
+            "1.535",
+            "1.0.2",
+            "org.jenkins-ci.plugins",
+            Set.of(),
+            Set.of(
+                    "hudson.security.GlobalMatrixAuthorizationStrategy",
+                    "hudson.security.ProjectMatrixAuthorizationStrategy",
+                    "hudson.security.AuthorizationMatrixProperty")),
+    ANTISAMY_MARKUP_FORMATTER(
+            "antisamy-markup-formatter",
+            "1.553",
+            "1.0",
+            "org.jenkins-ci.plugins",
+            Set.of(),
+            Set.of("hudson.markup.RawHtmlMarkupFormatter")),
+    MATRIX_PROJECT(
+            "matrix-project",
+            "1.561",
+            "1.0",
+            "org.jenkins-ci.plugins",
+            Set.of("hudson.matrix"),
+            Set.of("hudson.matrix.MatrixProject")),
+    JUNIT(
+            "junit",
+            "1.577",
+            "1.0",
+            "org.jenkins-ci.plugins",
+            Set.of(),
+            Set.of("hudson.tasks.junit.JUnitResultArchiver")),
+    BOUNCYCASTLE_API(
+            "bouncycastle-api",
+            "2.16",
+            "2.16.0",
+            "org.jenkins-ci.plugins",
+            Set.of("jenkins.bouncycastle.api"),
+            Set.of("jenkins.bouncycastle.api.BouncyCastlePlugin")),
+    COMMAND_LAUNCHER(
+            "command-launcher",
+            "2.86",
+            "1.0",
+            "org.jenkins-ci.plugins",
+            Set.of(),
+            Set.of("hudson.slaves.CommandLauncher", "hudson.slaves.CommandConnector")),
+    JDK_TOOL("jdk-tool", "2.112", "1.0", "org.jenkins-ci.plugins", Set.of(), Set.of("hudson.tools.JDKInstaller")),
+    JAXB("jaxb", "2.163", "2.3.0", "io.jenkins.plugins", Set.of(), Set.of("javax.xml.bind.JAXBContext")),
+    TRILEAD_API(
+            "trilead-api",
+            "2.184",
+            "1.0.4",
+            "org.jenkins-ci.plugins",
+            Set.of(),
+            Set.of("com.trilead.ssh2.Connection", "com.trilead.ssh2.Session")),
+    SSHD(
+            "sshd",
+            "2.281",
+            "3.236.ved5e1b_cb_50b_2",
+            "org.jenkins-ci.modules",
+            Set.of(),
+            Set.of("org.jenkinsci.main.modules.sshd.SSHD")),
+    JAVAX_ACTIVATION_API(
+            "javax-activation-api",
+            "2.330",
+            "1.2.0-2",
+            "io.jenkins.plugins",
+            Set.of(),
+            Set.of("javax.activation.DataHandler")),
+    JAVAX_MAIL_API(
+            "javax-mail-api",
+            "2.330",
+            "1.6.2-5",
+            "io.jenkins.plugins",
+            Set.of(),
+            Set.of(
+                    "jenkins.plugins.javax.activation.CommandMapInitializer",
+                    "jenkins.plugins.javax.activation.FileTypeMapInitializer")),
+    INSTANCE_IDENTITY(
+            "instance-identity",
+            "2.356",
+            "3.1",
+            "org.jenkins-ci.modules",
+            Set.of("org.jenkinsci.main.modules.instance_identity"),
+            Set.of("org.jenkinsci.main.modules.instance_identity.InstanceIdentity")),
+    ;
+
+    private final String pluginId;
+    private final String lastCoreRelease;
+    private final String impliedVersion;
+    private final String groupId;
+    private final Set<String> packageName;
+    private final Set<String> classNames;
+
+    DetachedPlugins(
+            String pluginId,
+            String lastCoreRelease,
+            String impliedVersion,
+            String groupId,
+            Set<String> packageName,
+            Set<String> classNames) {
+        this.pluginId = pluginId;
+        this.lastCoreRelease = lastCoreRelease;
+        this.impliedVersion = impliedVersion;
+        this.groupId = groupId;
+        this.packageName = packageName;
+        this.classNames = classNames;
+    }
+
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    public String getLastCoreRelease() {
+        return lastCoreRelease;
+    }
+
+    public String getImpliedVersion() {
+        return impliedVersion;
+    }
+
+    public String getGroupId() {
+        return groupId;
+    }
+
+    public Set<String> getPackageName() {
+        return packageName;
+    }
+
+    public Set<String> getClassNames() {
+        return classNames;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/AddDetachedPluginDependency.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/AddDetachedPluginDependency.java
@@ -1,0 +1,116 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import io.jenkins.tools.pluginmodernizer.core.model.DetachedPlugins;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.maven.AddDependency;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.tree.Xml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AddDetachedPluginDependency extends ScanningRecipe<Set<String>> {
+
+    /**
+     * Logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(AddDetachedPluginDependency.class);
+
+    /**
+     * The jenkins version.
+     */
+    @Option(displayName = "Version", description = "Jenkins version.", example = "2.440.3")
+    String jenkinsVersion;
+
+    /**
+     * Constructor.
+     * @param jenkinsVersion The Jenkins version.
+     */
+    public AddDetachedPluginDependency(String jenkinsVersion) {
+        this.jenkinsVersion = jenkinsVersion;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Add missing detached plugins as dependencies";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Detects usage of detached plugins and automatically adds them to pom.xml.";
+    }
+
+    @Override
+    public Set<String> getInitialValue(ExecutionContext ctx) {
+        return new HashSet<>();
+    }
+
+    /**
+     * Detect usage of detached plugins.
+     */
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Set<String> acc) {
+        return new JavaIsoVisitor<>() {
+            @Override
+            public J.Import visitImport(J.Import importStmt, ExecutionContext ctx) {
+                String importedClass = importStmt.getTypeName();
+                String importedPackage = importedClass.substring(0, importedClass.lastIndexOf('.'));
+
+                LOG.info("Detected import: {}", importedClass);
+                for (DetachedPlugins plugin : DetachedPlugins.values()) {
+                    if (plugin.getPackageName().contains(importedPackage)
+                            || plugin.getClassNames().contains(importedClass)) {
+                        // Only add if jenkins version past lastCoreRelease
+                        if (new ComparableVersion(jenkinsVersion)
+                                        .compareTo(new ComparableVersion(plugin.getLastCoreRelease()))
+                                > 0) {
+                            LOG.info("Detected usage of detached plugin: {}", plugin.getPluginId());
+                            acc.add(plugin.getPluginId());
+                        }
+                    }
+                }
+                return super.visitImport(importStmt, ctx);
+            }
+        };
+    }
+
+    /**
+     * Add dependencies to pom.xml if they were detected.
+     */
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Set<String> acc) {
+        return new MavenIsoVisitor<>() {
+            @Override
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+                for (String pluginId : acc) {
+                    DetachedPlugins plugin =
+                            DetachedPlugins.valueOf(pluginId.toUpperCase().replace("-", "_"));
+                    document = (Xml.Document) new AddDependency(
+                                    plugin.getGroupId(),
+                                    plugin.getPluginId(),
+                                    "RELEASE",
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null)
+                            .getVisitor()
+                            .visitNonNull(document, ctx);
+                }
+                LOG.info("Document after adding dependency: {}", document.printAll());
+                return super.visitDocument(document, ctx);
+            }
+        };
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -456,6 +456,8 @@ recipeList:
       minimumVersion: 2.346.3
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
       jenkinsVersion: 2.346.1
+  - io.jenkins.tools.pluginmodernizer.core.recipes.AddDetachedPluginDependency:
+      jenkinsVersion: 2.346.3
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.core.recipes.code.ReplaceRemovedSSHLauncherConstructor
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/AddDetachedPluginDependencyTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/AddDetachedPluginDependencyTest.java
@@ -1,0 +1,350 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import static org.openrewrite.java.Assertions.*;
+import static org.openrewrite.maven.Assertions.pomXml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openrewrite.test.RewriteTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test for {@link AddDetachedPluginDependency}.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class AddDetachedPluginDependencyTest implements RewriteTest {
+
+    /**
+     * LOGGER.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(AddDetachedPluginDependencyTest.class);
+
+    @Test
+    void detectsDetachedPluginUsageAndAddsDependency() {
+        rewriteRun(
+                spec -> spec.recipe(new AddDetachedPluginDependency("2.440.3")), // language=xml
+                pomXml(
+                        """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                        <groupId>org.jenkins-ci.plugins</groupId>
+                        <artifactId>plugin</artifactId>
+                        <version>4.87</version>
+                        <relativePath />
+                      </parent>
+                      <groupId>io.jenkins.plugins</groupId>
+                      <artifactId>empty</artifactId>
+                      <version>1.0.0-SNAPSHOT</version>
+                      <packaging>hpi</packaging>
+                      <name>Empty Plugin</name>
+                      <properties>
+                        <jenkins.version>2.440.3</jenkins.version>
+                      </properties>
+                      <repositories>
+                        <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                        </repository>
+                      </repositories>
+                      <pluginRepositories>
+                        <pluginRepository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                        </pluginRepository>
+                      </pluginRepositories>
+                    </project>
+                    """,
+                        """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                    <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                        <groupId>org.jenkins-ci.plugins</groupId>
+                        <artifactId>plugin</artifactId>
+                        <version>4.87</version>
+                        <relativePath />
+                      </parent>
+                      <groupId>io.jenkins.plugins</groupId>
+                      <artifactId>empty</artifactId>
+                      <version>1.0.0-SNAPSHOT</version>
+                      <packaging>hpi</packaging>
+                      <name>Empty Plugin</name>
+                      <properties>
+                        <jenkins.version>2.440.3</jenkins.version>
+                      </properties>
+                      <dependencies>
+                        <dependency>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>javax-activation-api</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>javax-mail-api</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>jaxb</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.main</groupId>
+                          <artifactId>maven-plugin</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.modules</groupId>
+                          <artifactId>instance-identity</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.modules</groupId>
+                          <artifactId>sshd</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>ant</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>antisamy-markup-formatter</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>bouncycastle-api</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>command-launcher</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>external-monitor-job</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>javadoc</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>jdk-tool</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>junit</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>ldap</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>mailer</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>matrix-auth</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>matrix-project</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>pam-auth</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>subversion</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                        <dependency>
+                          <groupId>org.jenkins-ci.plugins</groupId>
+                          <artifactId>trilead-api</artifactId>
+                          <version>RELEASE</version>
+                        </dependency>
+                      </dependencies>
+                      <repositories>
+                        <repository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                        </repository>
+                      </repositories>
+                      <pluginRepositories>
+                        <pluginRepository>
+                          <id>repo.jenkins-ci.org</id>
+                          <url>https://repo.jenkins-ci.org/public/</url>
+                        </pluginRepository>
+                      </pluginRepositories>
+                    </project>
+                    """),
+                srcTestJava(
+                        java(
+                                """
+                    package hudson.maven;
+                    public class MavenModuleSet {}
+                    """),
+                        java(
+                                """
+                    package hudson.scm;
+                    public class SubversionSCM {}
+                    """),
+                        java(
+                                """
+                    package hudson.tasks;
+                    public class Ant {}
+                    """),
+                        java(
+                                """
+                    package hudson.tasks;
+                    public class JavadocArchiver {}
+                    """),
+                        java(
+                                """
+                    package hudson.tasks;
+                    public class Mailer {}
+                    """),
+                        java(
+                                """
+                    package hudson.tasks.junit;
+                    public class JUnitResultArchiver {}
+                    """),
+                        java(
+                                """
+                    package hudson.model;
+                    public class ExternalJob {}
+                    """),
+                        java(
+                                """
+                    package hudson.security;
+                    public class LDAPSecurityRealm {}
+                    """),
+                        java(
+                                """
+                    package hudson.security;
+                    public class PAMSecurityRealm {}
+                    """),
+                        java(
+                                """
+                    package hudson.security;
+                    public class GlobalMatrixAuthorizationStrategy {}
+                    """),
+                        java(
+                                """
+                    package hudson.security;
+                    public class ProjectMatrixAuthorizationStrategy {}
+                    """),
+                        java(
+                                """
+                    package hudson.security;
+                    public class AuthorizationMatrixProperty {}
+                    """),
+                        java(
+                                """
+                    package hudson.slaves;
+                    public class CommandLauncher {}
+                    """),
+                        java(
+                                """
+                    package hudson.tools;
+                    public class JDKInstaller {}
+                    """),
+                        java(
+                                """
+                    package javax.xml.bind;
+                    public class JAXBContext {}
+                    """),
+                        java(
+                                """
+                    package com.trilead.ssh2;
+                    public class Connection {}
+                    """),
+                        java(
+                                """
+                    package org.jenkinsci.main.modules.sshd;
+                    public class SSHD {}
+                    """),
+                        java(
+                                """
+                    package javax.activation;
+                    public class DataHandler {}
+                    """),
+                        java(
+                                """
+                    package jenkins.bouncycastle.api;
+                    public class BouncyCastlePlugin {}
+                    """),
+                        java(
+                                """
+                    package jenkins.plugins.javax.activation;
+                    public class CommandMapInitializer {}
+                    """),
+                        java(
+                                """
+                    package jenkins.plugins.javax.activation;
+                    public class FileTypeMapInitializer {}
+                    """),
+                        java(
+                                """
+                    package org.jenkinsci.main.modules.instance_identity;
+                    public class InstanceIdentity {}
+                    """),
+                        java(
+                                """
+                    package hudson.markup;
+                    public class RawHtmlMarkupFormatter {}
+                    """),
+                        java(
+                                """
+                    package hudson.matrix;
+                    public class MatrixProject {}
+                    """)),
+                srcMainJava(
+                        java(
+                                """
+                    import hudson.maven.MavenModuleSet;
+                    import hudson.scm.SubversionSCM;
+                    import hudson.tasks.Ant;
+                    import hudson.tasks.JavadocArchiver;
+                    import hudson.tasks.Mailer;
+                    import hudson.tasks.junit.JUnitResultArchiver;
+                    import hudson.model.ExternalJob;
+                    import hudson.security.LDAPSecurityRealm;
+                    import hudson.security.PAMSecurityRealm;
+                    import hudson.security.GlobalMatrixAuthorizationStrategy;
+                    import hudson.security.ProjectMatrixAuthorizationStrategy;
+                    import hudson.security.AuthorizationMatrixProperty;
+                    import hudson.slaves.CommandLauncher;
+                    import hudson.tools.JDKInstaller;
+                    import javax.xml.bind.JAXBContext;
+                    import com.trilead.ssh2.Connection;
+                    import org.jenkinsci.main.modules.sshd.SSHD;
+                    import javax.activation.DataHandler;
+                    import jenkins.bouncycastle.api.BouncyCastlePlugin;
+                    import jenkins.plugins.javax.activation.CommandMapInitializer;
+                    import jenkins.plugins.javax.activation.FileTypeMapInitializer;
+                    import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
+                    import hudson.markup.RawHtmlMarkupFormatter;
+                    import hudson.matrix.MatrixProject;
+                    """)));
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -3,6 +3,7 @@ package io.jenkins.tools.pluginmodernizer.core.recipes;
 import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.java.Assertions.srcMainJava;
 import static org.openrewrite.java.Assertions.srcMainResources;
 import static org.openrewrite.java.Assertions.srcTestJava;
 import static org.openrewrite.maven.Assertions.pomXml;
@@ -1367,10 +1368,92 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             </dependencies>
                           </dependencyManagement>
                             <dependencies>
+                            <dependency>
+                              <groupId>io.jenkins.plugins</groupId>
+                              <artifactId>javax-activation-api</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>io.jenkins.plugins</groupId>
+                              <artifactId>javax-mail-api</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>io.jenkins.plugins</groupId>
+                              <artifactId>jaxb</artifactId>
+                            </dependency>
                               <dependency>
                                 <groupId>org.jenkins-ci.main</groupId>
                                 <artifactId>jenkins-test-harness</artifactId>
                               </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.main</groupId>
+                              <artifactId>maven-plugin</artifactId>
+                              <version>RELEASE</version>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.modules</groupId>
+                              <artifactId>sshd</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>ant</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>antisamy-markup-formatter</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>bouncycastle-api</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>command-launcher</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>external-monitor-job</artifactId>
+                              <version>RELEASE</version>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>javadoc</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>jdk-tool</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>junit</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>ldap</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>mailer</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>matrix-auth</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>matrix-project</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>pam-auth</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>subversion</artifactId>
+                            </dependency>
+                            <dependency>
+                              <groupId>org.jenkins-ci.plugins</groupId>
+                              <artifactId>trilead-api</artifactId>
+                            </dependency>
                             </dependencies>
                           <repositories>
                             <repository>
@@ -1385,7 +1468,185 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             </pluginRepository>
                           </pluginRepositories>
                         </project>
-                        """));
+                        """),
+                srcTestJava(
+                        java(
+                                """
+                        package hudson.maven;
+                        public class MavenModuleSet {}
+                        """),
+                        java(
+                                """
+                        package hudson.scm;
+                        public class SubversionSCM {}
+                        """),
+                        java(
+                                """
+                        package hudson.tasks;
+                        public class Ant {}
+                        """),
+                        java(
+                                """
+                        package hudson.tasks;
+                        public class JavadocArchiver {}
+                        """),
+                        java(
+                                """
+                        package hudson.tasks;
+                        public class Mailer {}
+                        """),
+                        java(
+                                """
+                        package hudson.tasks.junit;
+                        public class JUnitResultArchiver {}
+                        """),
+                        java(
+                                """
+                        package hudson.model;
+                        public class ExternalJob {}
+                        """),
+                        java(
+                                """
+                        package hudson.security;
+                        public class LDAPSecurityRealm {}
+                        """),
+                        java(
+                                """
+                        package hudson.security;
+                        public class PAMSecurityRealm {}
+                        """),
+                        java(
+                                """
+                        package hudson.security;
+                        public class GlobalMatrixAuthorizationStrategy {}
+                        """),
+                        java(
+                                """
+                        package hudson.security;
+                        public class ProjectMatrixAuthorizationStrategy {}
+                        """),
+                        java(
+                                """
+                        package hudson.security;
+                        public class AuthorizationMatrixProperty {}
+                        """),
+                        java(
+                                """
+                        package hudson.slaves;
+                        public class CommandLauncher {}
+                        """),
+                        java(
+                                """
+                        package hudson.tools;
+                        public class JDKInstaller {}
+                        """),
+                        java(
+                                """
+                        package javax.xml.bind;
+                        public class JAXBContext {}
+                        """),
+                        java(
+                                """
+                        package com.trilead.ssh2;
+                        public class Connection {}
+                        """),
+                        java(
+                                """
+                        package org.jenkinsci.main.modules.sshd;
+                        public class SSHD {}
+                        """),
+                        java(
+                                """
+                        package javax.activation;
+                        public class DataHandler {}
+                        """),
+                        java(
+                                """
+                        package jenkins.bouncycastle.api;
+                        public class BouncyCastlePlugin {}
+                        """),
+                        java(
+                                """
+                        package jenkins.plugins.javax.activation;
+                        public class CommandMapInitializer {}
+                        """),
+                        java(
+                                """
+                        package jenkins.plugins.javax.activation;
+                        public class FileTypeMapInitializer {}
+                        """),
+                        java(
+                                """
+                        package org.jenkinsci.main.modules.instance_identity;
+                        public class InstanceIdentity {}
+                        """),
+                        java(
+                                """
+                        package hudson.markup;
+                        public class RawHtmlMarkupFormatter {}
+                        """),
+                        java(
+                                """
+                        package hudson.matrix;
+                        public class MatrixProject {}
+                        """)),
+                srcMainJava(
+                        java(
+                                """
+                        import hudson.maven.MavenModuleSet;
+                        import hudson.scm.SubversionSCM;
+                        import hudson.tasks.Ant;
+                        import hudson.tasks.JavadocArchiver;
+                        import hudson.tasks.Mailer;
+                        import hudson.tasks.junit.JUnitResultArchiver;
+                        import hudson.model.ExternalJob;
+                        import hudson.security.LDAPSecurityRealm;
+                        import hudson.security.PAMSecurityRealm;
+                        import hudson.security.GlobalMatrixAuthorizationStrategy;
+                        import hudson.security.ProjectMatrixAuthorizationStrategy;
+                        import hudson.security.AuthorizationMatrixProperty;
+                        import hudson.slaves.CommandLauncher;
+                        import hudson.tools.JDKInstaller;
+                        import javax.xml.bind.JAXBContext;
+                        import com.trilead.ssh2.Connection;
+                        import org.jenkinsci.main.modules.sshd.SSHD;
+                        import javax.activation.DataHandler;
+                        import jenkins.bouncycastle.api.BouncyCastlePlugin;
+                        import jenkins.plugins.javax.activation.CommandMapInitializer;
+                        import jenkins.plugins.javax.activation.FileTypeMapInitializer;
+                        import org.jenkinsci.main.modules.instance_identity.InstanceIdentity;
+                        import hudson.markup.RawHtmlMarkupFormatter;
+                        import hudson.matrix.MatrixProject;
+
+                        public class TestDetachedPluginsUsage {
+                            public void execute() {
+                                new MavenModuleSet();
+                                new SubversionSCM();
+                                new Ant();
+                                new JavadocArchiver();
+                                new Mailer();
+                                new JUnitResultArchiver();
+                                new ExternalJob();
+                                new LDAPSecurityRealm();
+                                new PAMSecurityRealm();
+                                new GlobalMatrixAuthorizationStrategy();
+                                new ProjectMatrixAuthorizationStrategy();
+                                new AuthorizationMatrixProperty();
+                                new CommandLauncher();
+                                new JDKInstaller();
+                                new JAXBContext();
+                                new Connection();
+                                new SSHD();
+                                new DataHandler();
+                                new BouncyCastlePlugin();
+                                new CommandMapInitializer();
+                                new FileTypeMapInitializer();
+                                new InstanceIdentity();
+                                new RawHtmlMarkupFormatter();
+                                new MatrixProject();
+                            }
+                        }
+                        """)));
     }
 
     @Test


### PR DESCRIPTION
Issue #548
Stored all the details of the split plugins in an `enum`, with the name of their `classes`.
Scanning recipe matches any of the plugins used from the `DetachedPlugins`, if found then it checks if the `jenkins version > last core release` of that plugin which means now it has been detached, so it adds it in the `accumulator`.
Then in the visitor phase we `add the dependency` of the detached plugin.

### Testing done
Added the unit test for the recipe and tested it with `UpgradeToLatestJava8CoreVersion`.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
