### PR TITLE
Fix incompatibility for OpenRewrite and jackson-dataformat-yaml

### DIFF
--- a/plugin-modernizer-cli/src/test/resources/logback-test.xml
+++ b/plugin-modernizer-cli/src/test/resources/logback-test.xml
@@ -18,6 +18,8 @@
     <logger name="io.jenkins.tools.pluginmodernizer" level="TRACE" />
     <logger name="io.jenkins.tools.pluginmodernizer.cli.utils" level="INFO" />
     <logger name="org.apache.sshd.common.util" level="WARN" />
+    <logger name="org.eclipse.jgit.internal" level="INFO" />
+    <logger name="org.eclipse.jgit.util" level="INFO" />
     <logger name="org.testcontainers" level="INFO" />
     <logger name="com.github.sparsick.testcontainers" level="INFO" />
     <logger name="tc.rockstorm/git-server:2.47" level="WARN" />

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/PluginMetadata.java
@@ -1,5 +1,7 @@
 package io.jenkins.tools.pluginmodernizer.core.extractor;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
 import io.jenkins.tools.pluginmodernizer.core.model.CacheEntry;
 import io.jenkins.tools.pluginmodernizer.core.model.JDK;
@@ -105,7 +107,8 @@ public class PluginMetadata extends CacheEntry<PluginMetadata> {
      * Create a new plugin metadata with the given key
      * @param key The key
      */
-    public PluginMetadata(String key) {
+    @JsonCreator
+    public PluginMetadata(@JsonProperty("key") String key) {
         super(new CacheManager(Path.of("target")), PluginMetadata.class, key, Path.of("."));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <common.text.version>1.13.0</common.text.version>
     <asm.version>9.7.1</asm.version>
     <gson.version>2.12.1</gson.version>
-    <jackson.version>2.18.2</jackson.version>
+    <jackson.version>2.17.2</jackson.version>
     <maven.version>3.9.9</maven.version>
     <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
     <jgit.version>7.1.0.202411261347-r</jgit.version>
@@ -249,6 +249,12 @@
         <groupId>org.kohsuke</groupId>
         <artifactId>github-api</artifactId>
         <version>${github-api.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Fix original classpath issue on #754

Seems some binary compatibility exists between 2.17 (used by OpenRewrite) and 2.18 (used by Modernizer).

I've confirmed with new tests that was failing before this fix. And worked after using 2.17.x of Jackson

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue


