### PR TITLE
Scanning recipe to check ChartUtil is used or not when migrating to Stapler2 and Javax to Jakarta

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateStaplerAndJavaxToJakarta.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateStaplerAndJavaxToJakarta.java
@@ -1,0 +1,109 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.ScanningRecipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.ChangeMethodName;
+import org.openrewrite.java.ChangePackage;
+import org.openrewrite.java.ChangeType;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MigrateStaplerAndJavaxToJakarta extends ScanningRecipe<Set<String>> {
+
+    /**
+     * Logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(MigrateStaplerAndJavaxToJakarta.class);
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate Stapler types and methods and javax to jakarta";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrate Stapler types and methods and javax to jakarta.";
+    }
+
+    @Override
+    public Set<String> getInitialValue(ExecutionContext ctx) {
+        return new HashSet<>();
+    }
+
+    /**
+     *  Checks if ChartUtil is used or not, if used add it in accumulator.
+     */
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(Set<String> acc) {
+        return new JavaIsoVisitor<>() {
+            @Override
+            public J.Import visitImport(J.Import importStmt, ExecutionContext ctx) {
+                String importedClass = importStmt.getTypeName();
+
+                if (importedClass.equals("hudson.util.ChartUtil")) {
+                    LOG.info("Found usage of ChartUtil, skipping migration of stapler2 and jakarta");
+                    acc.add(importedClass);
+                }
+                return super.visitImport(importStmt, ctx);
+            }
+        };
+    }
+
+    /**
+     * Migrate To Stapler2 and javax to jakarta if accumulator is empty
+     */
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor(Set<String> acc) {
+
+        return new JavaIsoVisitor<>() {
+
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                if (acc.isEmpty()) {
+                    cu = (J.CompilationUnit) new ChangePackage("javax.servlet", "jakarta.servlet", false)
+                            .getVisitor()
+                            .visitNonNull(cu, ctx);
+                }
+                return super.visitCompilationUnit(cu, ctx);
+            }
+
+            @Override
+            public J.Identifier visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
+                if (acc.isEmpty()) {
+                    ident = (J.Identifier) new ChangeType(
+                                    "org.kohsuke.stapler.StaplerRequest", "org.kohsuke.stapler.StaplerRequest2", null)
+                            .getVisitor()
+                            .visitNonNull(ident, ctx);
+                    ident = (J.Identifier) new ChangeType(
+                                    "org.kohsuke.stapler.StaplerResponse", "org.kohsuke.stapler.StaplerResponse2", null)
+                            .getVisitor()
+                            .visitNonNull(ident, ctx);
+                }
+                return super.visitIdentifier(ident, ctx);
+            }
+
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (acc.isEmpty()) {
+                    method = (J.MethodInvocation) new ChangeMethodName(
+                                    "org.kohsuke.stapler.Stapler getCurrentRequest()", "getCurrentRequest2", null, null)
+                            .getVisitor()
+                            .visitNonNull(method, ctx);
+                    method = (J.MethodInvocation) new ChangeMethodName(
+                                    "org.kohsuke.stapler.Stapler getCurrentResponse()",
+                                    "getCurrentResponse2",
+                                    null,
+                                    null)
+                            .getVisitor()
+                            .visitNonNull(method, ctx);
+                }
+                return super.visitMethodInvocation(method, ctx);
+            }
+        };
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -152,22 +152,7 @@ recipeList:
       minimumVersion: 2.479.1
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
       jenkinsVersion: 2.479.1
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.kohsuke.stapler.StaplerRequest
-      newFullyQualifiedTypeName: org.kohsuke.stapler.StaplerRequest2
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: org.kohsuke.stapler.StaplerResponse
-      newFullyQualifiedTypeName: org.kohsuke.stapler.StaplerResponse2
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: org.kohsuke.stapler.Stapler getCurrentRequest()
-      newMethodName: getCurrentRequest2
-  - org.openrewrite.java.ChangeMethodName:
-      methodPattern: org.kohsuke.stapler.Stapler getCurrentResponse()
-      newMethodName: getCurrentResponse2
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.servlet
-      newPackageName: jakarta.servlet
-      recursive: false
+  - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateStaplerAndJavaxToJakartaTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateStaplerAndJavaxToJakartaTest.java
@@ -1,0 +1,98 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import static io.jenkins.tools.pluginmodernizer.core.recipes.DeclarativeRecipesTest.collectRewriteTestDependencies;
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.srcMainResources;
+import static org.openrewrite.java.Assertions.srcTestJava;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.test.RewriteTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test for {@link MigrateStaplerAndJavaxToJakarta}.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class MigrateStaplerAndJavaxToJakartaTest implements RewriteTest {
+
+    /**
+     * LOGGER.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(MigrateStaplerAndJavaxToJakartaTest.class);
+
+    @Test
+    void migrateStaplerAndJavaxToJakartaAsChartUtilIsNotUsed() {
+        rewriteRun(
+                spec -> {
+                    var parser = JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true);
+                    collectRewriteTestDependencies().forEach(parser::addClasspathEntry);
+                    spec.recipe(new MigrateStaplerAndJavaxToJakarta()).parser(parser);
+                },
+                srcMainResources(
+                        // language=java
+                        java(
+                                """
+                        import javax.servlet.ServletException;
+                        import org.kohsuke.stapler.Stapler;
+                        import org.kohsuke.stapler.StaplerRequest;
+                        import org.kohsuke.stapler.StaplerResponse;
+
+                        public class Foo {
+                            public void foo() {
+                                StaplerRequest req = Stapler.getCurrentRequest();
+                                StaplerResponse response = Stapler.getCurrentResponse();
+                            }
+                        }
+                        """,
+                                """
+                        import jakarta.servlet.ServletException;
+                        import org.kohsuke.stapler.Stapler;
+                        import org.kohsuke.stapler.StaplerRequest2;
+                        import org.kohsuke.stapler.StaplerResponse2;
+
+                        public class Foo {
+                            public void foo() {
+                                StaplerRequest2 req = Stapler.getCurrentRequest2();
+                                StaplerResponse2 response = Stapler.getCurrentResponse2();
+                            }
+                        }
+                        """)));
+    }
+
+    @Test
+    void notMigrateStaplerAndJavaxToJakartaAsChartUtilIsUsed() {
+        rewriteRun(
+                spec -> {
+                    var parser = JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true);
+                    collectRewriteTestDependencies().forEach(parser::addClasspathEntry);
+                    spec.recipe(new MigrateStaplerAndJavaxToJakarta()).parser(parser);
+                },
+                srcTestJava(
+                        java(
+                                """
+                        package hudson.util;
+                        public class ChartUtil {}
+                        """)),
+                srcMainResources(
+                        // language=java
+                        java(
+                                """
+                        import javax.servlet.ServletException;
+                        import org.kohsuke.stapler.Stapler;
+                        import org.kohsuke.stapler.StaplerRequest;
+                        import org.kohsuke.stapler.StaplerResponse;
+                        import hudson.util.ChartUtil;
+
+                        public class Foo {
+                            public void foo() {
+                                StaplerRequest req = Stapler.getCurrentRequest();
+                                StaplerResponse response = Stapler.getCurrentResponse();
+                            }
+                        }
+                        """)));
+    }
+}


### PR DESCRIPTION
#771 

Added a scanning recipe which scans the code base for usage of `ChartUtil`, if used it adds it in the accumulator.
In the editing phase we only perform the migration when `ChartUtil `is not used (i.e when accumulator is empty).

I confirmed that the `UpgradeNextMajorParentVersion` recipe is working on `log-parser`. 
As we are not  upgrading the `Stapler` in log-parser due to `ChartUtil` we are also not upgrading `javax` to `jakarta` as the `StaplerResponse `internally uses `javax.servelet`. So either if we perform the migrations as a whole or we don't.

```
Done
Plugin log-parser failed to verify with JDK 11
Plugin log-parser verified successfully with JDK 11 
Collecting metadata for plugin log-parser... Please be patient
Done
Skipping commits changes for plugin log-parser in dry-run mode
Skipping forking plugin log-parser in dry-run mode
Skipping sync plugin log-parser in dry-run mode
Skipping push changes for plugin log-parser in dry-run mode
Skipping pull request changes for plugin log-parser in dry-run mode
*************
Plugin: log-parser
Dry run mode. Changes were made on C:\Users\DELL PC\.cache\jenkins-plugin-modernizer-cli\log-parser\sources but not commited
Modified file: pom.xml
*************
```



### Testing done
Updated the test case to check if ChartUtil is used or not. Also checked that the recipe works on log-parser.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
