### PR TITLE
Top level recipe to Remove <developers> tag

### DIFF
--- a/plugin-modernizer-core/src/main/jte/pr-body-RemoveDevelopersTag.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-RemoveDevelopersTag.jte
@@ -1,0 +1,29 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+
+Hello `${plugin.getName()}` developers! :wave:
+
+This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool) tool. The tool has applied the following recipe to modernize the plugin:
+
+<details aria-label="Recipe details for ${recipe.getDisplayName()}">
+    <summary>${recipe.getDisplayName()}</summary>
+    <p><em>${recipe.getName()}</em></p>
+    <blockquote>${recipe.getDescription()}</blockquote>
+</details>
+
+## Why is this important?
+
+### Removing `developers` Tag from `pom.xml`
+
+Jenkins no longer requires the `developers` tag in `pom.xml` since the `developers` section in the pom.xml file was traditionally used to specify individuals responsible for the plugin.
+However, Jenkins has transitioned to using the Repository Permission Updater (RPU) for managing permissions and developer information.
+
+Benefits of Removing `developers` Tag:
+
+- **Simplification:** Eliminates unnecessary metadata from the pom.xml, making it cleaner and more maintainable.
+- **Consistency:** Ensures that developer information is managed centrally through the RPU, reducing discrepancies.
+- **Security:** Relies on the RPU's controlled permission management, enhancing the security of artifact deployments.
+
+By removing the `developers` tag, we adhere to the modern Jenkins infrastructure standards and prevent the inclusion of outdated or redundant developer information in plugin metadata.

--- a/plugin-modernizer-core/src/main/jte/pr-title-RemoveDevelopersTag.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-RemoveDevelopersTag.jte
@@ -1,0 +1,6 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+
+chore: Remove `developers` tag from pom.xml

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -153,6 +153,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
       jenkinsVersion: 2.479.1
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
+  - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
@@ -177,6 +178,16 @@ tags: ['dependencies']
 recipeList:
   - org.openrewrite.maven.RemoveRedundantDependencyVersions:
       onlyIfVersionsMatch: false # Keep newer dependencies
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
+displayName: Remove <developers> tag
+tags: ['chore']
+description: Remove <developers> tag from the pom.xml.
+recipeList:
+  - org.openrewrite.xml.RemoveXmlTag:
+      xPath: /project/developers
+      fileMatcher: '**/pom.xml'
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
@@ -391,6 +402,7 @@ recipeList:
       minimumVersion: ${jenkins.core.minimum.version}
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
       jenkinsVersion: ${jenkins.core.minimum.version}
+  - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
@@ -412,6 +424,7 @@ recipeList:
       minimumVersion: 2.462.3
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
         jenkinsVersion: 2.462.3
+  - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
@@ -443,6 +456,7 @@ recipeList:
       jenkinsVersion: 2.346.1
   - io.jenkins.tools.pluginmodernizer.core.recipes.AddDetachedPluginDependency:
       jenkinsVersion: 2.346.3
+  - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.core.recipes.code.ReplaceRemovedSSHLauncherConstructor
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -181,9 +181,9 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
-displayName: Remove <developers> tag
+displayName: Remove developers tag
 tags: ['chore']
-description: Remove <developers> tag from the pom.xml.
+description: Remove developers tag from the pom.xml.
 recipeList:
   - org.openrewrite.xml.RemoveXmlTag:
       xPath: /project/developers

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -610,6 +610,42 @@ public class DeclarativeRecipesTest implements RewriteTest {
     }
 
     @Test
+    void removeDevelopersTag() {
+        rewriteRun(
+                spec -> spec.recipeFromResource(
+                        "/META-INF/rewrite/recipes.yml", "io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag"),
+                // language=xml
+                pomXml(
+                        """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>empty</artifactId>
+                          <version>1.0.0-SNAPSHOT</version>
+                          <name>Empty pom</name>
+                          <developers>
+                            <developer>
+                              <id>bhacker</id>
+                              <name>Bob Q. Hacker</name>
+                              <email>bhacker@nowhere.net</email>
+                            </developer>
+                          </developers>
+                        </project>
+                        """,
+                        """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>empty</artifactId>
+                          <version>1.0.0-SNAPSHOT</version>
+                          <name>Empty pom</name>
+                        </project>
+                        """));
+    }
+
+    @Test
     void upgradeToRecommendCoreVersionTest() {
         rewriteRun(
                 spec -> spec.recipeFromResource(
@@ -648,6 +684,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <version>1.0.0-SNAPSHOT</version>
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
+                          <developers>
+                            <developer>
+                              <id>bhacker</id>
+                              <name>Bob Q. Hacker</name>
+                              <email>bhacker@nowhere.net</email>
+                            </developer>
+                          </developers>
                           <scm>
                             <connection>scm:git:git://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
@@ -778,6 +821,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <version>1.0.0-SNAPSHOT</version>
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
+                          <developers>
+                            <developer>
+                              <id>bhacker</id>
+                              <name>Bob Q. Hacker</name>
+                              <email>bhacker@nowhere.net</email>
+                            </developer>
+                          </developers>
                           <scm>
                             <connection>scm:git:git://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
@@ -873,6 +923,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <version>1.0.0-SNAPSHOT</version>
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
+                          <developers>
+                            <developer>
+                              <id>bhacker</id>
+                              <name>Bob Q. Hacker</name>
+                              <email>bhacker@nowhere.net</email>
+                            </developer>
+                          </developers>
                           <properties>
                             <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                             <jenkins.baseline>2.440</jenkins.baseline>
@@ -1003,6 +1060,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <version>${revision}-${changelist}</version>
                       <packaging>hpi</packaging>
                       <name>My API Plugin</name>
+                      <developers>
+                        <developer>
+                          <id>bhacker</id>
+                          <name>Bob Q. Hacker</name>
+                          <email>bhacker@nowhere.net</email>
+                        </developer>
+                      </developers>
                       <properties>
                         <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                         <revision>2.17.0</revision>
@@ -1162,6 +1226,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <version>1.0.0-SNAPSHOT</version>
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
+                          <developers>
+                            <developer>
+                              <id>bhacker</id>
+                              <name>Bob Q. Hacker</name>
+                              <email>bhacker@nowhere.net</email>
+                            </developer>
+                          </developers>
                           <scm>
                             <connection>scm:git:git://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
@@ -1302,6 +1373,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <version>1.0.0-SNAPSHOT</version>
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
+                          <developers>
+                            <developer>
+                              <id>bhacker</id>
+                              <name>Bob Q. Hacker</name>
+                              <email>bhacker@nowhere.net</email>
+                            </developer>
+                          </developers>
                           <scm>
                             <connection>scm:git:git://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
@@ -1696,6 +1774,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                               <version>1.0.0-SNAPSHOT</version>
                               <packaging>hpi</packaging>
                               <name>Empty Plugin</name>
+                              <developers>
+                                <developer>
+                                  <id>bhacker</id>
+                                  <name>Bob Q. Hacker</name>
+                                  <email>bhacker@nowhere.net</email>
+                                </developer>
+                              </developers>
                               <scm>
                                 <connection>scm:git:https://github.com/jenkinsci/empty-plugin.git</connection>
                               </scm>
@@ -1827,6 +1912,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <version>1.0.0-SNAPSHOT</version>
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
+                          <developers>
+                            <developer>
+                              <id>bhacker</id>
+                              <name>Bob Q. Hacker</name>
+                              <email>bhacker@nowhere.net</email>
+                            </developer>
+                          </developers>
                           <properties>
                             <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                             <java.version>17</java.version>
@@ -1981,6 +2073,13 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   <version>1.0.0-SNAPSHOT</version>
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
+                  <developers>
+                    <developer>
+                      <id>bhacker</id>
+                      <name>Bob Q. Hacker</name>
+                      <email>bhacker@nowhere.net</email>
+                    </developer>
+                  </developers>
                   <properties>
                     <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                     <jenkins.baseline>2.440</jenkins.baseline>

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -541,4 +541,43 @@ public class TemplateUtilsTest {
         // Assert
         assertEquals("Merges .gitignore entries from archetype with existing .gitignore file.", result);
     }
+
+    @Test
+    public void testFriendlyPrTitleRemoveDevelopersTag() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn("io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
+
+        // Assert
+        assertEquals("chore: Remove `developers` tag from pom.xml", result);
+    }
+
+    @Test
+    public void testFriendlyPrBodyRemoveDevelopersTag() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn("io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestBody(plugin, recipe);
+
+        // Just ensure it's using some key overall text
+        assertTrue(result.contains("Why is this important?"), "Missing 'Why is this important?' section");
+        assertTrue(
+                result.contains("Removing `developers` Tag from `pom.xml"),
+                "Missing 'Removing `developers` Tag' section");
+    }
 }


### PR DESCRIPTION
#717 

Implemented existing recipe from open rewrite to remove the developers tag from every pom.xml. This also make sure to remove developers tag in multimodule projects when there are multiple pom.xml in different packages.
Added the recipe in `UpgradeNextMajorParentVersion`, `UpgradeToRecommendCoreVersion`, `UpgradeToLatestJava11CoreVersion` and `UpgradeToLatestJava8CoreVersion`.

### Testing done
- Updated test coverage for `UpgradeNextMajorParentVersion`, `UpgradeToRecommendCoreVersion`, `UpgradeToLatestJava11CoreVersion` and `UpgradeToLatestJava8CoreVersion`.
- Added test case for the top level recipe in `DeclartiveRecipeTest`.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
