### PR TITLE
Fix possible nullpointer if jenkinsVersion is null

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
@@ -284,6 +284,9 @@ public enum JDK {
      * @return The list of buildable JDKs
      */
     public static List<JDK> get(String jenkinsVersion) {
+        if (jenkinsVersion == null || jenkinsVersion.isEmpty()) {
+            return List.of(JDK.min());
+        }
         ComparableVersion jenkinsVersionComparable = new ComparableVersion(jenkinsVersion);
         return Arrays.stream(JDK.values())
 

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -182,7 +182,7 @@ recipeList:
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
 displayName: Remove developers tag
-tags: ['chore']
+tags: ['chore', 'skip-verification']
 description: Remove developers tag from the pom.xml.
 recipeList:
   - org.openrewrite.xml.RemoveXmlTag:

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
@@ -107,6 +107,9 @@ public class JDKTest {
     @Test
     public void getBuildableJdk() {
 
+        assertEquals(1, JDK.get(null).size());
+        assertEquals(JDK.JAVA_8, JDK.get(null).get(0));
+
         assertEquals(1, JDK.get("2.163").size());
         assertEquals(JDK.JAVA_8, JDK.get("2.163").get(0));
 
@@ -148,6 +151,10 @@ public class JDKTest {
         assertEquals(2, JDK.get("2.479.1").size());
         assertEquals(JDK.JAVA_17, JDK.get("2.479.1").get(0));
         assertEquals(JDK.JAVA_21, JDK.get("2.479.1").get(1));
+
+        assertEquals(2, JDK.get("2.492.1").size());
+        assertEquals(JDK.JAVA_17, JDK.get("2.492.1").get(0));
+        assertEquals(JDK.JAVA_21, JDK.get("2.492.1").get(1));
     }
 
     @Test


### PR DESCRIPTION
Fix possible nullpointer if jenkinsVersion is null

Saw when running 

```
plugin-modernizer run --plugins jsoup --recipe RemoveDevelopersTag
```

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
