### PR TITLE
Add meaningful message when default branch was removed but not present on local directory

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -27,6 +27,7 @@ import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.Status;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefAlreadyExistsException;
+import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.errors.UnsupportedCredentialItem;
 import org.eclipse.jgit.internal.signing.ssh.SshSigner;
 import org.eclipse.jgit.lib.Ref;
@@ -617,9 +618,9 @@ public class GHService {
 
         // Fetch latest changes
         if (Files.isDirectory(plugin.getLocalRepository())) {
+            String defaultBranch = plugin.getRemoteRepository(this).getDefaultBranch();
             // Ensure to set the correct remote, reset changes and pull
             try (Git git = Git.open(plugin.getLocalRepository().toFile())) {
-                String defaultBranch = plugin.getRemoteRepository(this).getDefaultBranch();
                 git.remoteSetUrl()
                         .setRemoteName("origin")
                         .setRemoteUri(remoteUri)
@@ -644,6 +645,13 @@ public class GHService {
                         .setRemoteBranchName(defaultBranch)
                         .call();
                 LOG.info("Fetched repository from {} to branch {}", remoteUri, ref.getName());
+            } catch (RefNotFoundException e) {
+                String message =
+                        "Unable to find branch %s in repository. Probably the default branch was renamed. You can remove the local repository at %s and try again."
+                                .formatted(defaultBranch, plugin.getLocalRepository());
+                LOG.error(message);
+                plugin.addError(message);
+                plugin.raiseLastError();
             } catch (IOException e) {
                 plugin.addError("Failed fetch repository", e);
                 plugin.raiseLastError();


### PR DESCRIPTION
This should ideally be fixed to fetch the new default branch from remote, before checking out.

Until them add a better message

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

