### PR TITLE
Move recipe Replace Libraries With Api Plugin

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/ReplaceLibrariesWithApiPlugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/ReplaceLibrariesWithApiPlugin.java
@@ -1,0 +1,176 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.maven.AddDependencyVisitor;
+import org.openrewrite.maven.MavenVisitor;
+import org.openrewrite.maven.RemoveDependency;
+import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.xml.AddToTagVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReplaceLibrariesWithApiPlugin extends Recipe {
+    /**
+     * Logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(ReplaceLibrariesWithApiPlugin.class);
+
+    private static final XPathMatcher DEPENDENCIES_MATCHER = new XPathMatcher("/project/dependencies");
+
+    @Option(
+            displayName = "API Plugin's groupId",
+            description = "The first part of a dependency coordinate 'io.jenkins.plugins:ARTIFACT_ID:VERSION'.",
+            example = "io.jenkins.plugins")
+    String pluginGroupId;
+
+    @Option(
+            displayName = "API Plugin's artifactId",
+            description = "The second part of a dependency coordinate 'GROUP_ID:jackson2-api:VERSION'.",
+            example = "jackson2-api")
+    String pluginArtifactId;
+
+    @Option(
+            displayName = "API Plugin's version",
+            description = "An exact version number.",
+            example = "1981.v17df70e84a_a_1")
+    String pluginVersion;
+
+    @Option(
+            displayName = "Replaced Libraries",
+            description = "The set of library coordinates replaced by this API Plugin.",
+            example = "groupId: org.apache.commons\nartifactId: commons-text")
+    Set<Library> replaces;
+
+    /**
+     * The groupId:artifactId combos to be replaced if present.
+     */
+    public static final class Library {
+        private final String groupId;
+        private final String artifactId;
+
+        public Library(String groupId, String artifactId) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+        }
+    }
+
+    /**
+     * Replaces a set of libraries with an api plugin.
+     * @param pluginGroupId api plugin's groupId
+     * @param pluginArtifactId api plugin's artifactId
+     * @param pluginVersion api plugin's version
+     * @param replaces set of libraries included in the api plugin
+     */
+    public ReplaceLibrariesWithApiPlugin(
+            String pluginGroupId, String pluginArtifactId, String pluginVersion, Set<Library> replaces) {
+        this.pluginGroupId = pluginGroupId;
+        this.pluginArtifactId = pluginArtifactId;
+        this.pluginVersion = pluginVersion;
+        this.replaces = replaces;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Use Jenkins API plugin instead of libraries";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Prefer Jenkins API plugins over bundling libraries for slimmer plugins.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MavenVisitor<ExecutionContext>() {
+            @Override
+            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                if (isDependencyTag()) {
+                    ResolvedDependency dependency = findDependency(tag);
+                    if (dependency != null && !isApiPlugin(dependency)) {
+                        for (Library replaced : replaces) {
+                            String groupId = replaced.groupId;
+                            String artifactId = replaced.artifactId;
+                            ResolvedDependency found = dependency.findDependency(groupId, artifactId);
+                            if (found == null) {
+                                continue;
+                            }
+                            doAfterVisit(new AddDependencyVisitor(
+                                    pluginGroupId,
+                                    pluginArtifactId,
+                                    pluginVersion,
+                                    null,
+                                    null,
+                                    true,
+                                    null,
+                                    null,
+                                    false,
+                                    null));
+                            doAfterVisit(new RemoveDependency(groupId, artifactId, null).getVisitor());
+                            // transitive dependency
+                            if (found != dependency) {
+                                if (isApiProvidedLibrary(groupId, artifactId)) {
+                                    continue; // Skip exclusions if the library is already part of the API plugin
+                                }
+                                Optional<Xml.Tag> maybeExclusions = tag.getChild("exclusions");
+                                if (maybeExclusions.isPresent()) {
+                                    Xml.Tag exclusions = maybeExclusions.get();
+
+                                    List<Xml.Tag> individualExclusions = exclusions.getChildren("exclusion");
+                                    boolean alreadyExcluded = individualExclusions.stream()
+                                            .anyMatch(exclusion -> groupId.equals(exclusion
+                                                            .getChildValue("groupId")
+                                                            .orElse(null))
+                                                    && artifactId.equals(exclusion
+                                                            .getChildValue("artifactId")
+                                                            .orElse(null)));
+                                    if (!alreadyExcluded) {
+                                        doAfterVisit(new AddToTagVisitor<>(
+                                                exclusions,
+                                                Xml.Tag.build("<exclusion>\n"
+                                                        + "<!-- brought in by " + pluginGroupId + ":" + pluginArtifactId
+                                                        + " -->\n"
+                                                        + "<groupId>" + groupId + "</groupId>\n"
+                                                        + "<artifactId>" + artifactId + "</artifactId>\n"
+                                                        + "</exclusion>")));
+                                    }
+                                } else {
+                                    doAfterVisit(new AddToTagVisitor<>(
+                                            tag,
+                                            Xml.Tag.build("<exclusions>\n"
+                                                    + "<exclusion>\n"
+                                                    + "<!-- brought in by " + pluginGroupId + ":" + pluginArtifactId
+                                                    + " -->\n"
+                                                    + "<groupId>" + groupId + "</groupId>\n"
+                                                    + "<artifactId>" + artifactId + "</artifactId>\n"
+                                                    + "</exclusion>\n"
+                                                    + "</exclusions>")));
+                                }
+                                maybeUpdateModel();
+                            }
+                        }
+                    }
+                }
+                return super.visitTag(tag, ctx);
+            }
+
+            private boolean isApiProvidedLibrary(String groupId, String artifactId) {
+                return replaces.stream()
+                        .anyMatch(
+                                replaced -> replaced.groupId.equals(groupId) && replaced.artifactId.equals(artifactId));
+            }
+
+            private boolean isApiPlugin(ResolvedDependency dependency) {
+                return pluginGroupId.equals(dependency.getGroupId())
+                        && pluginArtifactId.equals(dependency.getArtifactId());
+            }
+        };
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -233,7 +233,7 @@ tags: ['developer']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.conditions.IsUsingRecommendCoreVersion
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: json-api
       pluginVersion: 20250107-125.v28b_a_ffa_eb_f01
@@ -249,7 +249,7 @@ tags: ['developer']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.conditions.IsUsingRecommendCoreVersion
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: json-path-api
       pluginVersion: 2.9.0-138.vc943da_d833b_6
@@ -265,7 +265,7 @@ tags: ['developer']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.conditions.IsUsingCoreVersionWithASMRemoved
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: asm-api
       pluginVersion: 9.7.1-97.v4cc844130d97
@@ -289,7 +289,7 @@ tags: ['developer']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.conditions.IsUsingRecommendCoreVersion
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: joda-time-api
       pluginVersion: 2.13.1-115.va_6b_5f8efb_1d8
@@ -305,7 +305,7 @@ tags: ['developer']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.conditions.IsUsingRecommendCoreVersion
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: gson-api
       pluginVersion: 2.12.1-113.v347686d6729f
@@ -321,7 +321,7 @@ tags: ['developer']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.conditions.IsUsingRecommendCoreVersion
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: org.jenkins-ci.plugins
       pluginArtifactId: jsoup
       pluginVersion: 1.18.3-30.v952e9442d416
@@ -337,7 +337,7 @@ tags: ['developer']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.conditions.IsUsingCoreVersionWithCommonsCompressRemoved
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: commons-compress-api
       pluginVersion: 1.27.1-2
@@ -356,7 +356,7 @@ preconditions:
   - org.openrewrite.jenkins.IsJenkinsPlugin:
       version: "[2.361.4,)"
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: commons-lang3-api
       pluginVersion: 3.17.0-84.vb_b_938040b_078
@@ -372,7 +372,7 @@ tags: ['developer']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.conditions.IsUsingRecommendCoreVersion
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: byte-buddy-api
       pluginVersion: 1.17.0-117.v025ccb_c559d7
@@ -388,7 +388,7 @@ tags: ['developer']
 preconditions:
   - io.jenkins.tools.pluginmodernizer.conditions.IsUsingRecommendCoreVersion
 recipeList:
-  - org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin:
       pluginGroupId: io.jenkins.plugins
       pluginArtifactId: commons-text-api
       pluginVersion: 1.13.0-153.v91dcd89e2a_22

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -2587,6 +2587,140 @@ public class DeclarativeRecipesTest implements RewriteTest {
     }
 
     @Test
+    void replaceLibrariesByApiPluginWithBom() {
+        rewriteRun(
+                spec -> spec.recipeFromResource(
+                        "/META-INF/rewrite/recipes.yml",
+                        "io.jenkins.tools.pluginmodernizer.ReplaceLibrariesWithApiPlugin"),
+                // language=xml
+                pomXml(
+                        """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.88</version>
+                    <relativePath />
+                  </parent>
+                  <artifactId>antexec</artifactId>
+                  <version>${changelist}</version>
+                  <packaging>hpi</packaging>
+                  <properties>
+                    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                    <jenkins.baseline>2.479</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.jenkins.tools.bom</groupId>
+                        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                        <version>4051.v78dce3ce8b_d6</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                      </dependency>
+                      <dependency>
+                        <groupId>org.jenkins-ci.tools</groupId>
+                        <artifactId>maven-hpi-plugin</artifactId>
+                        <version>3.61</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>ant</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>token-macro</artifactId>
+                    </dependency>
+                  </dependencies>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
+                """,
+                        """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.88</version>
+                    <relativePath />
+                  </parent>
+                  <artifactId>antexec</artifactId>
+                  <version>${changelist}</version>
+                  <packaging>hpi</packaging>
+                  <properties>
+                    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                    <jenkins.baseline>2.479</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.jenkins.tools.bom</groupId>
+                        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                        <version>4051.v78dce3ce8b_d6</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                      </dependency>
+                      <dependency>
+                        <groupId>org.jenkins-ci.tools</groupId>
+                        <artifactId>maven-hpi-plugin</artifactId>
+                        <version>3.61</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.jenkins.plugins</groupId>
+                      <artifactId>asm-api</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>io.jenkins.plugins</groupId>
+                      <artifactId>json-path-api</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>ant</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>token-macro</artifactId>
+                    </dependency>
+                  </dependencies>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
+                """));
+    }
+
+    @Test
     void replaceLibrariesByApiPluginsAsm() {
         rewriteRun(
                 spec -> spec.recipeFromResource(
@@ -3187,7 +3321,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
     private String getApiPluginVersion(String apiPlugin) throws IOException {
         return YamlPath.from(getClass().getResourceAsStream("/META-INF/rewrite/recipes.yml"))
                 .readSingle(
-                        "recipeList.'org.openrewrite.jenkins.ReplaceLibrariesWithApiPlugin'.(pluginArtifactId == %s).pluginVersion"
+                        "recipeList.'io.jenkins.tools.pluginmodernizer.core.recipes.ReplaceLibrariesWithApiPlugin'.(pluginArtifactId == %s).pluginVersion"
                                 .formatted(apiPlugin));
     }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/ReplaceLibrariesWithApiPluginTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/ReplaceLibrariesWithApiPluginTest.java
@@ -1,0 +1,299 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openrewrite.test.RewriteTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test for {@link ReplaceLibrariesWithApiPlugin}.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class ReplaceLibrariesWithApiPluginTest implements RewriteTest {
+
+    /**
+     * LOGGER.
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(ReplaceLibrariesWithApiPluginTest.class);
+
+    @Test
+    void replaceAsmByApiPluginWithBom() {
+        rewriteRun(
+                spec -> spec.recipe(new ReplaceLibrariesWithApiPlugin(
+                        "io.jenkins.plugins",
+                        "asm-api",
+                        "9.7.1-97.v4cc844130d97",
+                        Set.of(
+                                new ReplaceLibrariesWithApiPlugin.Library("org.ow2.asm", "asm"),
+                                new ReplaceLibrariesWithApiPlugin.Library("org.ow2.asm", "asm-analysis"),
+                                new ReplaceLibrariesWithApiPlugin.Library("org.ow2.asm", "asm-commons"),
+                                new ReplaceLibrariesWithApiPlugin.Library("org.ow2.asm", "asm-tree"),
+                                new ReplaceLibrariesWithApiPlugin.Library("org.ow2.asm", "asm-util")))),
+
+                // language=xml
+                pomXml(
+                        """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.88</version>
+                    <relativePath />
+                  </parent>
+                  <artifactId>antexec</artifactId>
+                  <version>${changelist}</version>
+                  <packaging>hpi</packaging>
+                  <properties>
+                    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                    <jenkins.baseline>2.479</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.jenkins.tools.bom</groupId>
+                        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                        <version>4051.v78dce3ce8b_d6</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                      </dependency>
+                      <dependency>
+                        <groupId>org.jenkins-ci.tools</groupId>
+                        <artifactId>maven-hpi-plugin</artifactId>
+                        <version>3.61</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>ant</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>token-macro</artifactId>
+                    </dependency>
+                  </dependencies>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
+                """,
+                        """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.88</version>
+                    <relativePath />
+                  </parent>
+                  <artifactId>antexec</artifactId>
+                  <version>${changelist}</version>
+                  <packaging>hpi</packaging>
+                  <properties>
+                    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                    <jenkins.baseline>2.479</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.jenkins.tools.bom</groupId>
+                        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                        <version>4051.v78dce3ce8b_d6</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                      </dependency>
+                      <dependency>
+                        <groupId>org.jenkins-ci.tools</groupId>
+                        <artifactId>maven-hpi-plugin</artifactId>
+                        <version>3.61</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.jenkins.plugins</groupId>
+                      <artifactId>asm-api</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>ant</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>token-macro</artifactId>
+                    </dependency>
+                  </dependencies>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
+                """));
+    }
+
+    @Test
+    void replaceJsonByApiPluginWithBom() {
+        rewriteRun(
+                spec -> spec.recipe(new ReplaceLibrariesWithApiPlugin(
+                        "io.jenkins.plugins",
+                        "json-api",
+                        "20250107-125.v28b_a_ffa_eb_f01",
+                        Set.of(new ReplaceLibrariesWithApiPlugin.Library("org.json", "json")))),
+
+                // language=xml
+                pomXml(
+                        """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.88</version>
+                    <relativePath />
+                  </parent>
+                  <artifactId>antexec</artifactId>
+                  <version>${changelist}</version>
+                  <packaging>hpi</packaging>
+                  <properties>
+                    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                    <jenkins.baseline>2.479</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.jenkins.tools.bom</groupId>
+                        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                        <version>4051.v78dce3ce8b_d6</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                      </dependency>
+                      <dependency>
+                        <groupId>org.jenkins-ci.tools</groupId>
+                        <artifactId>maven-hpi-plugin</artifactId>
+                        <version>3.61</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.json</groupId>
+                      <artifactId>json</artifactId>
+                      <version>20240303</version>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>ant</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>token-macro</artifactId>
+                    </dependency>
+                  </dependencies>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
+                """,
+                        """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+                  <modelVersion>4.0.0</modelVersion>
+                  <parent>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>plugin</artifactId>
+                    <version>4.88</version>
+                    <relativePath />
+                  </parent>
+                  <artifactId>antexec</artifactId>
+                  <version>${changelist}</version>
+                  <packaging>hpi</packaging>
+                  <properties>
+                    <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+                    <jenkins.baseline>2.479</jenkins.baseline>
+                    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+                  </properties>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>io.jenkins.tools.bom</groupId>
+                        <artifactId>bom-${jenkins.baseline}.x</artifactId>
+                        <version>4051.v78dce3ce8b_d6</version>
+                        <scope>import</scope>
+                        <type>pom</type>
+                      </dependency>
+                      <dependency>
+                        <groupId>org.jenkins-ci.tools</groupId>
+                        <artifactId>maven-hpi-plugin</artifactId>
+                        <version>3.61</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>io.jenkins.plugins</groupId>
+                      <artifactId>json-api</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>ant</artifactId>
+                    </dependency>
+                    <dependency>
+                      <groupId>org.jenkins-ci.plugins</groupId>
+                      <artifactId>token-macro</artifactId>
+                    </dependency>
+                  </dependencies>
+                  <repositories>
+                    <repository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </repository>
+                  </repositories>
+                  <pluginRepositories>
+                    <pluginRepository>
+                      <id>repo.jenkins-ci.org</id>
+                      <url>https://repo.jenkins-ci.org/public/</url>
+                    </pluginRepository>
+                  </pluginRepositories>
+                </project>
+                """));
+    }
+}


### PR DESCRIPTION
Issue #637 
Moved the Recipe `ReplaceLibrariesWithApiPlugin` in the plugin-modernizer-tool recipes. Exclusions are not added for libraries that the API plugin handles, as the API plugin is designed to bring those dependencies to the consumer.

### Testing done
Added the `same pom.xml as a test case` where the duplicate tag issue was occurring.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue