### PR TITLE
Update io.jenkins.tools.bom:bom-2.452.x version to 4136.vca_c3202a_7fd1

### DIFF
--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateBomTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateBomTest.java
@@ -27,7 +27,7 @@ public class UpdateBomTest implements RewriteTest {
                    <modelVersion>4.0.0</modelVersion>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
@@ -49,7 +49,7 @@ public class UpdateBomTest implements RewriteTest {
                    <modelVersion>4.0.0</modelVersion>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
@@ -60,7 +60,7 @@ public class UpdateBomTest implements RewriteTest {
                         <dependency>
                           <groupId>io.jenkins.tools.bom</groupId>
                           <artifactId>bom-2.440.x</artifactId>
-                          <version>2746.vb_79a_1d3e7b_c8</version>
+                          <version>4136.vca_c3202a_7fd1</version>
                           <type>pom</type>
                           <scope>import</scope>
                         </dependency>
@@ -80,7 +80,7 @@ public class UpdateBomTest implements RewriteTest {
                    <modelVersion>4.0.0</modelVersion>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
@@ -91,7 +91,7 @@ public class UpdateBomTest implements RewriteTest {
                         <dependency>
                           <groupId>io.jenkins.tools.bom</groupId>
                           <artifactId>bom-2.440.x</artifactId>
-                          <version>3435.v238d66a_043fb_</version>
+                          <version>4136.vca_c3202a_7fd1</version>
                           <type>pom</type>
                           <scope>import</scope>
                         </dependency>
@@ -124,12 +124,12 @@ public class UpdateBomTest implements RewriteTest {
                    <parent>
                      <groupId>org.jenkins-ci.plugins</groupId>
                      <artifactId>plugin</artifactId>
-                     <version>4.88</version>
+                     <version>4136.vca_c3202a_7fd1</version>
                      <relativePath />
                    </parent>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
@@ -140,7 +140,7 @@ public class UpdateBomTest implements RewriteTest {
                         <dependency>
                           <groupId>io.jenkins.tools.bom</groupId>
                           <artifactId>bom-2.440.x</artifactId>
-                          <version>2746.vb_79a_1d3e7b_c8</version>
+                          <version>4136.vca_c3202a_7fd1</version>
                           <type>pom</type>
                           <scope>import</scope>
                         </dependency>
@@ -161,12 +161,12 @@ public class UpdateBomTest implements RewriteTest {
                    <parent>
                      <groupId>org.jenkins-ci.plugins</groupId>
                      <artifactId>plugin</artifactId>
-                     <version>4.88</version>
+                     <version>4136.vca_c3202a_7fd1</version>
                      <relativePath />
                    </parent>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
@@ -177,7 +177,7 @@ public class UpdateBomTest implements RewriteTest {
                         <dependency>
                           <groupId>io.jenkins.tools.bom</groupId>
                           <artifactId>bom-2.440.x</artifactId>
-                          <version>3435.v238d66a_043fb_</version>
+                          <version>4136.vca_c3202a_7fd1</version>
                           <type>pom</type>
                           <scope>import</scope>
                         </dependency>
@@ -205,7 +205,7 @@ public class UpdateBomTest implements RewriteTest {
                    <modelVersion>4.0.0</modelVersion>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
@@ -216,7 +216,7 @@ public class UpdateBomTest implements RewriteTest {
                         <dependency>
                           <groupId>io.jenkins.tools.bom</groupId>
                           <artifactId>bom-2.452.x</artifactId>
-                          <version>3956.v1c544c9d8819</version>
+                          <version>4136.vca_c3202a_7fd1</version>
                           <type>pom</type>
                           <scope>import</scope>
                         </dependency>
@@ -236,7 +236,7 @@ public class UpdateBomTest implements RewriteTest {
                    <modelVersion>4.0.0</modelVersion>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>empty</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
@@ -247,7 +247,7 @@ public class UpdateBomTest implements RewriteTest {
                         <dependency>
                           <groupId>io.jenkins.tools.bom</groupId>
                           <artifactId>bom-2.452.x</artifactId>
-                          <version>3959.v187ce50819e9</version>
+                          <version>4136.vca_c3202a_7fd1</version>
                           <type>pom</type>
                           <scope>import</scope>
                         </dependency>
@@ -276,12 +276,12 @@ public class UpdateBomTest implements RewriteTest {
                    <parent>
                      <groupId>org.jvnet.hudson.plugins</groupId>
                      <artifactId>analysis-pom</artifactId>
-                     <version>10.0.0</version>
+                     <version>4136.vca_c3202a_7fd1</version>
                      <relativePath />
                    </parent>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>checks</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Checks Plugin</name>
                    <repositories>
@@ -306,7 +306,7 @@ public class UpdateBomTest implements RewriteTest {
                    <modelVersion>4.0.0</modelVersion>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>non-standard</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Checks Plugin</name>
                    <properties>
@@ -319,7 +319,7 @@ public class UpdateBomTest implements RewriteTest {
                        <dependency>
                          <groupId>io.jenkins.tools.bom</groupId>
                          <artifactId>${bom.artifactId}</artifactId>
-                         <version>${bom.version}</version>
+                         <version>4136.vca_c3202a_7fd1</version>
                          <type>pom</type>
                          <scope>import</scope>
                        </dependency>
@@ -339,7 +339,7 @@ public class UpdateBomTest implements RewriteTest {
                    <modelVersion>4.0.0</modelVersion>
                    <groupId>io.jenkins.plugins</groupId>
                    <artifactId>non-standard</artifactId>
-                   <version>1.0.0-SNAPSHOT</version>
+                   <version>4136.vca_c3202a_7fd1</version>
                    <packaging>hpi</packaging>
                    <name>Checks Plugin</name>
                    <properties>
@@ -352,7 +352,7 @@ public class UpdateBomTest implements RewriteTest {
                        <dependency>
                          <groupId>io.jenkins.tools.bom</groupId>
                          <artifactId>${bom.artifactId}</artifactId>
-                         <version>${bom.version}</version>
+                         <version>4136.vca_c3202a_7fd1</version>
                          <type>pom</type>
                          <scope>import</scope>
                        </dependency>


### PR DESCRIPTION



<Actions>
    <action id="bca6592877f982511ff78ab5eec3fd27b135734e0ba7bb11220aa68b6e231d57">
        <h3>Update io.jenkins.tools.bom:bom-2.452.x version in UpdateBomTest.java</h3>
        <details id="0ea5123971ff060e54d3ea552e977c73afb53490392fcebae82d6d87b961e044">
            <summary>Update io.jenkins.tools.bom:bom-2.452.x version in UpdateBomTest.java</summary>
            <p>1 file(s) updated with &#34;&lt;version&gt;4136.vca_c3202a_7fd1&lt;/version&gt;&#34;:&#xA;&#x9;* ./plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateBomTest.java&#xA;</p>
            <details>
                <summary>4136.vca_c3202a_7fd1</summary>
                <pre>&#xA;Release published on the 2025-02-08 12:24:08 +0000 UTC at the url https://github.com/jenkinsci/bom/releases/tag/4136.vca_c3202a_7fd1&#xA;&#xA;&lt;!-- Optional: add a release summary here --&gt;&#xA;## 🚀 New features and improvements&#xA;&#xA;* Add GitLab Logo to the managed set (#4376) @darinpope&#xA;* Add Safe Restart to the managed set (#4375) @darinpope&#xA;* Add Pipeline Multibranch build strategy extension to the managed set (#4358) @darinpope&#xA;* Add SCM Skip to the managed set (#4357) @darinpope&#xA;* Add Ignore Committer Strategy to the managed set (#4356) @darinpope&#xA;* Add Skip Notifications Trait to the managed set (#4355) @darinpope&#xA;* Add Naginator to the managed set (#4354) @darinpope&#xA;&#xA;## 👷 Changes for plugin developers&#xA;&#xA;* chore(deps): bump org.jenkins-ci.plugins:active-directory from 2.38 to 2.39 in /bom-weekly (#4426) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:pipeline-groovy-lib from 749.v70084559234a_ to 752.vdddedf804e72 in /bom-weekly (#4429) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:naginator from 1.489.v5808b_a_72e0fc to 1.496.v94260e77b_3f5 in /bom-weekly (#4425) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:pipeline-build-step from 551.v178956c49ef8 to 555.v589d5c24a_3d6 in /bom-weekly (#4428) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:copyartifact from 761.vea_2b_25523e84 to 763.v66351b_9c297f in /bom-weekly (#4423) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins.workflow:workflow-job from 1500.v29502eb_5182e to 1505.vea_4b_20a_4a_495 in /bom-weekly (#4427) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:apache-httpcomponents-client-4-api from 4.5.14-268.v37113894b_d72 to 4.5.14-269.vfa_2321039a_83 in /bom-weekly (#4422) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins.workflow:workflow-job from 1498.v33a_0c6f3a_4b_4 to 1500.v29502eb_5182e in /bom-weekly (#4418) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:github-checks from 589.v845136f916cd to 602.v264a_83610da_6 in /bom-weekly (#4419) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:junit-attachments from 239.v9e003a_c80a_8c to 275.v54db_1ed8e66f in /bom-weekly (#4414) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:customizable-header from 171.vd1b_e1cb_6cb_53 to 175.v07c36327359a_ in /bom-weekly (#4420) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins.workflow:workflow-cps from 4014.vcd7dc51d8b_30 to 4018.vf02e01888da_f in /bom-weekly (#4417) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:JiraTestResultReporter from 251.v8ee0248c418c to 252.v1b_e1698d2225 in /bom-weekly (#4421) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:msbuild from 1.35 to 1.36 in /bom-weekly (#4416) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:apache-httpcomponents-client-4-api from 4.5.14-208.v438351942757 to 4.5.14-268.v37113894b_d72 in /bom-weekly (#4413) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:junit from 1312.v1a_235a_b_94a_31 to 1314.vd966e9a_88895 in /bom-weekly (#4411) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:JiraTestResultReporter from 245.v5a_2d45c771c9 to 251.v8ee0248c418c in /bom-weekly (#4412) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:parameterized-scheduler from 277.v61a_4b_a_49a_c5c to 285.ve611986d4c48 in /bom-weekly (#4410) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:mercurial from 1308.v0e0888fdb_628 to 1309.v6802b_f0efb_b_9 in /bom-weekly (#4408) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:copyartifact from 761.vea_2b_25523e84 to 763.v66351b_9c297f in /bom-weekly (#4409) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:pipeline-groovy-lib from 749.v70084559234a_ to 751.v709f84f7d768 in /bom-weekly (#4407) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:gitlab-branch-source from 715.v4c830b_ca_ef95 to 718.v40b_5f0e67cd3 in /bom-weekly (#4406) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:cloudbees-bitbucket-branch-source from 934.4.1 to 934.4.2 in /bom-weekly (#4405) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.main:maven-plugin from 3.24 to 3.25 in /bom-weekly (#4402) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.modules:sshd from 3.330.vc866a_8389b_58 to 3.350.v1080103a_10fd in /bom-weekly (#4398) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:dashboard-view from 2.523.v673d549dfee5 to 2.528.v3470c02b_d7c9 in /bom-weekly (#4396) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:gitlab-oauth from 1.20 to 1.21 in /bom-weekly (#4397) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:ansicolor from 1.0.5 to 1.0.6 in /bom-weekly (#4392) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:subversion from 1283.vfc8b_92d49a_06 to 1287.vd2d507146906 in /bom-weekly (#4391) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins.workflow:workflow-support from 944.v5a_859593b_98a_ to 946.v2a_79d8a_4b_e14 in /bom-weekly (#4394) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:credentials from 1405.vb_cda_74a_f8974 to 1408.va_622a_b_f5b_1b_1 in /bom-weekly (#4395) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.6wind.jenkins:lockable-resources from 1342.v673282c325c0 to 1349.v8b_ccb_c5487f7 in /bom-weekly (#4393) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:ssh-slaves from 3.1021.va_cc11b_de26a_e to 3.1031.v72c6b_883b_869 in /bom-weekly (#4390) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump pipeline-stage-view-plugin.version from 2.34 to 2.35 in /bom-weekly (#4389) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:commons-math3-api from 3.6.1-18.v9d7081dffa_f5 to 3.6.1-38.vb_753c9382184 in /bom-weekly (#4387) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:pipeline-graph-view from 407.v7857c9611b_44 to 409.v98f212e980b_4 in /bom-weekly (#4388) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:artifactory-client-api from 2.19.0-76.v1826d97a_fef0 to 2.19.0-82.va_7314a_427046 in /bom-weekly (#4385) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:checks-api from 2.2.1 to 2.2.2 in /bom-weekly (#4384) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:token-macro from 442.v4f452dc3c7c0 to 444.v52de7e9c573d in /bom-weekly (#4383) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump configuration-as-code-plugin.version from 1929.v036b_5a_e1f123 to 1932.v75cb_b_f1b_698d in /bom-weekly (#4381) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:azure-vm-agents from 996.v523eb_feb_66ca_ to 1001.vf3448fe27897 in /bom-weekly (#4379) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:pipeline-graph-view from 406.v06871361eb_2d to 407.v7857c9611b_44 in /bom-weekly (#4380) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:saml from 4.519.v3927f2f0e020 to 4.525.v4f6a_7209447e in /bom-weekly (#4377) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:description-setter from 258.vcd25251271a_a_ to 264.v1957f215dcd5 in /bom-weekly (#4374) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:database-mysql from 63.va_0596d2b_1438 to 134.vb_98470b_d4d2d in /bom-weekly (#4373) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:mysql-api from 9.2.0-51.v555cd9442556 to 9.2.0-53.v708a_e33e6cb_6 in /bom-weekly (#4371) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.tools:git-parameter from 0.10.0 to 0.11.0 in /bom-weekly (#4372) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:gson-api from 2.11.0-109.v1ef91dd0829a_ to 2.12.1-113.v347686d6729f in /bom-weekly (#4369) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:joda-time-api from 2.13.0-93.v9934da_29b_a_e9 to 2.13.1-115.va_6b_5f8efb_1d8 in /bom-weekly (#4370) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:token-macro from 400.v35420b_922dcb_ to 442.v4f452dc3c7c0 in /bom-weekly (#4363) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:pipeline-graph-view from 402.va_9d108235846 to 406.v06871361eb_2d in /bom-weekly (#4367) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:flatpickr-api from 4.6.13-5.v534d8025a_a_59 to 4.6.13-15.vf6e534338831 in /bom-weekly (#4366) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:google-compute-engine from 4.680.v03300ceb_5e7e to 4.681.v9020cf2b_7453 in /bom-weekly (#4365) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:customizable-header from 169.v671208540e56 to 171.vd1b_e1cb_6cb_53 in /bom-weekly (#4364) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:mysql-api from 9.1.0-49.v012b_dfb_92c8a_ to 9.2.0-51.v555cd9442556 in /bom-weekly (#4362) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:flyway-api from 11.2.0-223.va_b_087b_80376b_ to 11.3.0-229.vc8f3594c89dc in /bom-weekly (#4361) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:design-library from 354.v87d9d5804b_c1 to 355.v0f007356e15d in /bom-weekly (#4360) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:prometheus from 801.v98e119d8eeda_ to 811.v1823c780b_e8e in /bom-weekly (#4359) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:ec2 from 1823.v828850f7f155 to 1856.vf40220e7a_75f in /bom-weekly (#4352) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:electricflow from 1.1.37 to 1.1.38 in /bom-weekly (#4350) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump io.jenkins.plugins:byte-buddy-api from 1.16.1-111.vc76cd8b_2dce5 to 1.17.0-117.v025ccb_c559d7 in /bom-weekly (#4349) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:cloudbees-bitbucket-branch-source from 934.4.0 to 934.4.1 in /bom-weekly (#4347) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps): bump org.jenkins-ci.plugins:ec2 from 1822.v87175d209b_b_5 to 1823.v828850f7f155 in /bom-weekly (#4348) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;&#xA;## ✍ Other changes&#xA;&#xA;* chore: update pipeline trigger time for 8 feb 2025 release #2 (#4415) @krisstern&#xA;* chore(release): update pipeline trigger time in jenkinsfile for 2025-02-07 (#4401) @krisstern&#xA;* chore(release): update pipeline trigger time in jenkinsfile for 2025-02-07 (#4400) @krisstern&#xA;* Use Jenkins 2.492.1 as bom-2.492.x base version (#4386) @jplayout&#xA;&#xA;## 📦 Dependency updates&#xA;&#xA;* Update dependency org.jenkins-ci.main:jenkins-war to v2.496 (#4382) @[renovate[bot]](https://github.com/apps/renovate)&#xA;* chore(deps): bump org.jenkins-ci.plugins:plugin from 5.6 to 5.7 in /sample-plugin (#4378) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* chore(deps-dev): bump io.jenkins.plugins:customizable-header from 169.v671208540e56 to 171.vd1b_e1cb_6cb_53 in /sample-plugin (#4368) @[dependabot[bot]](https://github.com/apps/dependabot)&#xA;* Update AWS Java SDK v2 (#4353) @basil&#xA;</pre>
            </details>
        </details>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

