### PR TITLE
Update recipe/migrate acegi security to spring security

### DIFF
--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -1865,8 +1865,21 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                 import org.acegisecurity.userdetails.UsernameNotFoundException;
                                 import jenkins.model.Jenkins;
                                 import jenkins.security.SecurityListener;
+                                import hudson.security.SecurityRealm;
 
-                                public class Foo {
+                                public class Foo extends SecurityRealm {
+                                    @Override
+                                    public UserDetails loadUserByUsername(String username) {
+                                       return null;
+                                    }
+                                    @Override
+                                    public SecurityComponents createSecurityComponents() {
+                                       new UserDetailsService() {
+                                          public UserDetails loadUserByUsername(String username) {
+                                             return null;
+                                          }
+                                       };
+                                    }
                                     public void foo() {
                                         StaplerRequest req = Stapler.getCurrentRequest();
                                         StaplerResponse response = Stapler.getCurrentResponse();
@@ -1881,7 +1894,6 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                 import org.kohsuke.stapler.StaplerResponse2;
                                 import org.springframework.security.core.Authentication;
                                 import org.springframework.security.core.GrantedAuthority;
-                                import org.springframework.security.authentication.AbstractAuthenticationToken;
                                 import org.springframework.security.core.context.SecurityContextHolder;
                                 import org.springframework.security.core.AuthenticationException;
                                 import org.springframework.security.core.userdetails.UserDetails;
@@ -1889,10 +1901,27 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                 import org.springframework.security.core.userdetails.UsernameNotFoundException;
                                 import jenkins.model.Jenkins;
                                 import jenkins.security.SecurityListener;
+                                import hudson.security.SecurityRealm;
+                                import org.springframework.security.core.authority.SimpleGrantedAuthority;
+                                import org.springframework.security.authentication.AbstractAuthenticationToken;
+                                import java.util.List;
+                                import java.util.Collection;
                                 import org.springframework.security.authentication.AuthenticationManager;
                                 import org.springframework.security.authentication.BadCredentialsException;
 
-                                public class Foo {
+                                public class Foo extends SecurityRealm {
+                                    @Override
+                                    public UserDetails loadUserByUsername2(String username) {
+                                       return null;
+                                    }
+                                    @Override
+                                    public SecurityComponents createSecurityComponents() {
+                                       new UserDetailsService() {
+                                          public UserDetails loadUserByUsername(String username) {
+                                             return null;
+                                          }
+                                       };
+                                    }
                                     public void foo() {
                                         StaplerRequest2 req = Stapler.getCurrentRequest2();
                                         StaplerResponse2 response = Stapler.getCurrentResponse2();


### PR DESCRIPTION
Issue https://github.com/jenkins-infra/plugin-modernizer-tool/issues/792
Part-2 for #808 
- Migrate `LoadUserByUsername` to `LoadUserByUsername2`
- Change Return type from `GrantedAuthority[]` to `Collection<GrantedAuthority>` of getAuthorities()
- GrantedAuthority[0] to List.of() in ternary expression.

### Testing done
Added unit test and declarative test.
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


