### PR TITLE
Update Recipe Migrate Acegi Security To Spring Security

### DIFF
--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateAcegiSecurityToSpringSecurityTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateAcegiSecurityToSpringSecurityTest.java
@@ -155,7 +155,10 @@ public class MigrateAcegiSecurityToSpringSecurityTest implements RewriteTest {
                 spec -> {
                     var parser = JavaParser.fromJavaVersion().logCompilationWarningsAndErrors(true);
                     collectRewriteTestDependencies().forEach(parser::addClasspathEntry);
-                    spec.recipe(new MigrateAcegiSecurityToSpringSecurity()).parser(parser);
+                    spec.recipe(new MigrateAcegiSecurityToSpringSecurity())
+                            .expectedCyclesThatMakeChanges(1)
+                            .cycles(1)
+                            .parser(parser);
                 },
                 java(
                         """
@@ -174,6 +177,9 @@ public class MigrateAcegiSecurityToSpringSecurityTest implements RewriteTest {
                          import jenkins.security.SecurityListener;
 
                          public class Bar extends AbstractAuthenticationToken {
+                             Bar() {
+                                 System.out.println("Bar");
+                             }
                              @Override
                              public GrantedAuthority[] getAuthorities() {
                                  return getName() != null? null : new GrantedAuthority[0];
@@ -213,6 +219,10 @@ public class MigrateAcegiSecurityToSpringSecurityTest implements RewriteTest {
                         import org.springframework.security.authentication.BadCredentialsException;
 
                         public class Bar extends AbstractAuthenticationToken {
+                            Bar() {
+                                super(null);
+                                System.out.println("Bar");
+                            }
                             @Override
                             public Collection<GrantedAuthority> getAuthorities() {
                                 return getName() != null? null : List.of();


### PR DESCRIPTION
Issue #792 
Previous PRs:
1st https://github.com/jenkins-infra/plugin-modernizer-tool/pull/808
2nd #836

- Add `super(null)` call to any class that is a sub class of `org.springframework.security.authentication.AbstractAuthenticationToken` to invoke its constructor.

### Testing done
Updated unit test 
Also verified that bitbucket-oauth plugin compiles and builds successfully.
`java -jar ./plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar dry-run --plugins bitbucket-oauth --recipe UpgradeNextMajorParentVersion`
![image](https://github.com/user-attachments/assets/a2a12c01-74c3-4de0-b1e1-3e527d8d424b)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
