### PR TITLE
com.gargoylesoftware.htmlunit replaced to org.htmlunit in UpgradeNextMajorParentVersion

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -287,6 +287,11 @@
                   <artifactId>jenkins-core</artifactId>
                   <version>2.497</version>
                 </dependency>
+                <dependency>
+                  <groupId>net.sourceforge.htmlunit</groupId>
+                  <artifactId>htmlunit</artifactId>
+                  <version>2.70.0</version>
+                </dependency>
               </artifactItems>
             </configuration>
           </execution>

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -152,6 +152,10 @@ recipeList:
       minimumVersion: 2.479.3
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
       jenkinsVersion: 2.479.3
+  - org.openrewrite.java.ChangePackage:  #deprecating
+      oldPackageName: com.gargoylesoftware.htmlunit
+      newPackageName: org.htmlunit
+      recursive: true
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateAcegiSecurityToSpringSecurity
   - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -2082,6 +2082,9 @@ public class DeclarativeRecipesTest implements RewriteTest {
                         java(
                                 """
                                 import javax.servlet.ServletException;
+                                import com.gargoylesoftware.htmlunit.HttpMethod;
+                                import com.gargoylesoftware.htmlunit.WebRequest;
+                                import com.gargoylesoftware.htmlunit.html.HtmlPage;
                                 import org.kohsuke.stapler.Stapler;
                                 import org.kohsuke.stapler.StaplerRequest;
                                 import org.kohsuke.stapler.StaplerResponse;
@@ -2093,7 +2096,23 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                         StaplerResponse response = Stapler.getCurrentResponse();
                                     }
                                 }
-                                """)));
+                                """,
+                                """
+                                import javax.servlet.ServletException;
+                                import org.htmlunit.HttpMethod;
+                                import org.htmlunit.WebRequest;
+                                import org.htmlunit.html.HtmlPage;
+                                import org.kohsuke.stapler.Stapler;
+                                import org.kohsuke.stapler.StaplerRequest;
+                                import org.kohsuke.stapler.StaplerResponse;
+                                import hudson.util.ChartUtil;
+
+                                public class Foo {
+                                    public void foo() {
+                                        StaplerRequest req = Stapler.getCurrentRequest();
+                                        StaplerResponse response = Stapler.getCurrentResponse();
+                                    }
+                                }""")));
     }
 
     @Test


### PR DESCRIPTION
#861 
### Opearting System: Windows 10
I was not getting the same logs as mentioned in #861 rather was getting the below
```
COMPILATION ERROR :  
2025-03-21T21:41:31.800Z [INFO] [Thread=StreamPumper-systemOut] - i.j.t.p.core.impl.MavenInvoker # [INFO] ------------------------------------------------------------- 
2025-03-21T21:41:31.800Z [INFO] [Thread=StreamPumper-systemOut] - i.j.t.p.core.impl.MavenInvoker # [ERROR] /C:/Users/DELL PC/.cache/jenkins-plugin-modernizer-cli/statuspage-gating/sources/src/test/java/io/jenkins/plugins/statuspage_gating/JCascTest.java:[24,37] package com.gargoylesoftware.htmlunit does not exist 
2025-03-21T21:41:31.801Z [INFO] [Thread=StreamPumper-systemOut] - i.j.t.p.core.impl.MavenInvoker # [ERROR] /C:/Users/DELL PC/.cache/jenkins-plugin-modernizer-cli/statuspage-gating/sources/src/test/java/io/jenkins/plugins/statuspage_gating/JCascTest.java:[25,37] package com.gargoylesoftware.htmlunit does not exist
``` 
So the issue I encountered was the `com.gargoylesoftware.htmlunit` package was deprecated and replaced by `org.htmlunit` according to https://htmlunit.sourceforge.io/migration.html. There I updated the recipe and the recipe is working successfully. Here are the logs:
 ```
java -jar ./plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar dry-run --plugins statuspage-gating --recipe UpgradeNextMajorParentVersion
Run Plugin Modernizer in dry-run mode 
Fetching plugin code locally statuspage-gating... 
locking FileBasedConfig[C:\Users\DELL PC\.config\jgit\config] failed after 5 retries 
Fetched repository from https://github.com/jenkinsci/statuspage-gating-plugin.git to branch refs/heads/master 
Collecting metadata for plugin statuspage-gating... Please be patient 
Build failed 
Done
Failed to collect metadata for plugin statuspage-gating. Will retry after a first compile using lowest JDK
Quick build without tests statuspage-gating using with JDK 8 ... Please be patient
Done 
Collecting metadata for plugin statuspage-gating... Please be patient 
Done 
Plugin look outdated or without Jenkinsfile. Or fail it's parsing, falling back to jenkins.version 
Found jenkins version 2.190.3 from pom which support Java 8 
Need a first compile to generate classes due to Java 8 and lower
Quick build without tests statuspage-gating using with JDK 8 ... Please be patient
Done 
Collecting metadata for plugin statuspage-gating... Please be patient 
Done 
Running recipes io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion for plugin statuspage-gating... Please be patient 
Done 
No JDKs found in metadata for plugin statuspage-gating. Using same JDK as rewrite for verification
Skipping formatting for plugin statuspage-gating as it is not using Spotless 
Verifying plugin statuspage-gating with JDK 21... Please be patient
Build failed 
Done
Plugin statuspage-gating failed to verify with JDK 21
Plugin statuspage-gating verified successfully with JDK 21 
Collecting metadata for plugin statuspage-gating... Please be patient 
Done 
Skipping commits changes for plugin statuspage-gating in dry-run mode 
Skipping forking plugin statuspage-gating in dry-run mode
Skipping sync plugin statuspage-gating in dry-run mode
Skipping push changes for plugin statuspage-gating in dry-run mode
Skipping pull request changes for plugin statuspage-gating in dry-run mode 
*************
Plugin: statuspage-gating
Dry run mode. Changes were made on C:\Users\DELL PC\.cache\jenkins-plugin-modernizer-cli\statuspage-gating\sources but not commited
Modified file: src/test/java/io/jenkins/plugins/statuspage_gating/UiGlobalConfigTest.java
Modified file: src/main/resources/index.jelly
Modified file: pom.xml
Modified file: src/test/java/io/jenkins/plugins/statuspage_gating/JCascTest.java
*************
```
### Testing done

`mvn clean install` and the `UpgradeNextMajorParentVersion` working fine on `statuspage-gating`
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
