### PR TITLE
Add precondition to not apply the MigrateToJUnit5 recipe on files using JenkinsSessionRule field type.

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -110,6 +110,9 @@ name: io.jenkins.tools.pluginmodernizer.MigrateToJUnit5
 displayName: Migrate to JUnit 5
 description: Migrate tests to JUnit5.
 tags: ['migration', 'testing']
+preconditions:
+  - org.openrewrite.java.search.DoesNotUseType:
+      fullyQualifiedTypeName: org.jvnet.hudson.test.JenkinsSessionRule
 recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.AnnotateWithJenkins  
   - org.openrewrite.java.testing.junit5.UpdateTestAnnotation


### PR DESCRIPTION
Add precondition to not apply the `MigrateToJUnit5` recipe on files using `JenkinsSessionRule` field type. 
This is a `JUnit 4 construct` that’s incompatible with `JUnit 5’s test runner`, leading to the `NullPointerException` in `JenkinsRule.apply()` (as Description is null in JUnit 5) in #914 

We can revisit it later with a proper migration.

### Testing done
`mvn clean install`
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue