### PR TITLE
Fix bug to not to add duplicate super call in Migrate Acegi Security To Spring Security recipe

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateAcegiSecurityToSpringSecurity.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateAcegiSecurityToSpringSecurity.java
@@ -337,7 +337,7 @@ public class MigrateAcegiSecurityToSpringSecurity extends Recipe {
                                             && body.getStatements()
                                                     .get(0)
                                                     .printTrimmed()
-                                                    .contains("super(new GrantedAuthority[] {})"))) {
+                                                    .contains("super("))) {
                                 method = addSuperCallTemplate.apply(
                                         updateCursor(method),
                                         body.getCoordinates().firstStatement());


### PR DESCRIPTION
OS: `Windows 10`
Issue: #826 
I am getting different error as mentioned in #826.
Err:
```
2025-04-10T20:05:10.321Z [INFO] [Thread=StreamPumper-systemOut] - i.j.t.p.core.impl.MavenInvoker # [ERROR] COMPILATION ERROR :  
2025-04-10T20:05:10.321Z [INFO] [Thread=StreamPumper-systemOut] - i.j.t.p.core.impl.MavenInvoker # [INFO] ------------------------------------------------------------- 
2025-04-10T20:05:10.321Z [INFO] [Thread=StreamPumper-systemOut] - i.j.t.p.core.impl.MavenInvoker # [ERROR] /C:/Users/DELL PC/.cache/jenkins-plugin-modernizer-cli/tuleap-oauth/sources/src/main/java/io/jenkins/plugins/tuleap_oauth/TuleapAuthenticationToken.java:[18,14] call to super must be first statement in constructor 
```
Fixed bug to not to add `duplicate` super call.
It produced the following [PR](https://github.com/jenkinsci/tuleap-oauth-plugin/pull/495)


### Testing done
`mvn clean install`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue