### PR TITLE
Increase recommended to 2.479.3

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -156,14 +156,14 @@ recipeList:
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
-displayName: Upgrade parent version to latest available in the 4.x line
-description: Upgrade the parent version to latest available in the 4.x line.
+displayName: Upgrade parent version to latest available in the 5.x line
+description: Upgrade the parent version to latest available in the 5.x line.
 tags: ['dependencies']
 recipeList:
   - org.openrewrite.maven.UpgradeParentVersion:
       groupId: org.jenkins-ci.plugins
       artifactId: plugin
-      newVersion: 4.X
+      newVersion: 5.X
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
 ---
 type: specs.openrewrite.org/v1beta/recipe

--- a/plugin-modernizer-core/src/main/resources/versions.properties
+++ b/plugin-modernizer-core/src/main/resources/versions.properties
@@ -1,7 +1,7 @@
 openrewrite.maven.plugin.version = ${openrewrite.maven.plugin.version}
 jenkins.parent.version = 5.10
 bom.version = 4583.v0a_f4df179fa_b_
-bom.recommended.version = 4228.v0a_71308d905b_
+bom.recommended.version = 4583.v0a_f4df179fa_b_
 remediation.jenkins.plugin.parent.version = 2.37
 jenkins.core.minimum.version = ${jenkins.core.minimum.version}
 asm-api.version = 9.8-135.vb_2239d08ee90

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -215,7 +215,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.87</version>
+                            <version>5.1</version>
                             <relativePath />
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
@@ -224,7 +224,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
                           <properties>
-                            <jenkins.version>2.440.3</jenkins.version>
+                            <jenkins.version>2.479.3</jenkins.version>
                           </properties>
                           <repositories>
                             <repository>
@@ -247,7 +247,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.88</version>
+                            <version>%s</version>
                             <relativePath />
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
@@ -256,7 +256,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
                           <properties>
-                            <jenkins.version>2.440.3</jenkins.version>
+                            <jenkins.version>2.479.3</jenkins.version>
                           </properties>
                           <repositories>
                             <repository>
@@ -271,7 +271,8 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             </pluginRepository>
                           </pluginRepositories>
                         </project>
-                        """));
+                        """
+                                .formatted(Settings.getJenkinsParentVersion())));
     }
 
     @Test
@@ -677,7 +678,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.87</version>
+                            <version>5.1</version>
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
                           <artifactId>empty</artifactId>
@@ -696,7 +697,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           </scm>
                           <properties>
                             <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
-                            <jenkins.version>2.440.3</jenkins.version>
+                            <jenkins.version>2.479.3</jenkins.version>
                           </properties>
                           <dependencies>
                             <dependency>
@@ -731,7 +732,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.88</version>
+                            <version>%s</version>
                             <relativePath/>
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
@@ -743,10 +744,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             <connection>scm:git:https://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
                           <properties>
-                            <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+                            <jenkins-test-harness.version>%s</jenkins-test-harness.version>
                             <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                            <jenkins.baseline>%s</jenkins.baseline>
-                            <jenkins.version>${jenkins.baseline}.%s</jenkins.version>
+                            <jenkins.baseline>2.479</jenkins.baseline>
+                            <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -784,8 +785,8 @@ public class DeclarativeRecipesTest implements RewriteTest {
                         </project>
                         """
                                 .formatted(
-                                        Settings.getJenkinsMinimumBaseline(),
-                                        Settings.getJenkinsMinimumPatchVersion(),
+                                        Settings.getJenkinsParentVersion(),
+                                        Settings.getJenkinsTestHarnessVersion(),
                                         Settings.getRecommendedBomVersion())));
     }
 
@@ -859,7 +860,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.88</version>
+                            <version>%s</version>
                             <relativePath />
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
@@ -871,8 +872,8 @@ public class DeclarativeRecipesTest implements RewriteTest {
                             <connection>scm:git:https://github.com/jenkinsci/empty-plugin.git</connection>
                           </scm>
                           <properties>
-                            <jenkins.version>%s</jenkins.version>
-                            <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+                            <jenkins.version>2.479.3</jenkins.version>
+                            <jenkins-test-harness.version>%s</jenkins-test-harness.version>
                           </properties>
                           <repositories>
                             <repository>
@@ -888,7 +889,8 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           </pluginRepositories>
                         </project>
                         """
-                                .formatted(Settings.getJenkinsMinimumVersion())));
+                                .formatted(
+                                        Settings.getJenkinsParentVersion(), Settings.getJenkinsTestHarnessVersion())));
     }
 
     @Test
@@ -974,7 +976,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.88</version>
+                            <version>%s</version>
                             <relativePath />
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
@@ -983,10 +985,10 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <packaging>hpi</packaging>
                           <name>Empty Plugin</name>
                           <properties>
-                            <jenkins-test-harness.version>2225.v04fa_3929c9b_5</jenkins-test-harness.version>
+                            <jenkins-test-harness.version>%s</jenkins-test-harness.version>
                             <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-                            <jenkins.baseline>%s</jenkins.baseline>
-                            <jenkins.version>${jenkins.baseline}.%s</jenkins.version>
+                            <jenkins.baseline>2.479</jenkins.baseline>
+                            <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                           </properties>
                           <dependencyManagement>
                             <dependencies>
@@ -1020,8 +1022,8 @@ public class DeclarativeRecipesTest implements RewriteTest {
                         </project>
                         """
                                 .formatted(
-                                        Settings.getJenkinsMinimumBaseline(),
-                                        Settings.getJenkinsMinimumPatchVersion(),
+                                        Settings.getJenkinsParentVersion(),
+                                        Settings.getJenkinsTestHarnessVersion(),
                                         Settings.getRecommendedBomVersion())));
     }
 
@@ -2493,6 +2495,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
     void replaceLibrariesByApiPluginsSimple() throws IOException {
 
         // Read API plugin version
+        String asmApiVersion = getApiPluginVersion("asm-api");
         String jsonApiVersion = getApiPluginVersion("json-api");
         String jsonPathApiVersion = getApiPluginVersion("json-path-api");
         String gsonApiVersion = getApiPluginVersion("gson-api");
@@ -2515,7 +2518,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   <parent>
                     <groupId>org.jenkins-ci.plugins</groupId>
                     <artifactId>plugin</artifactId>
-                    <version>4.88</version>
+                    <version>5.10</version>
                     <relativePath />
                   </parent>
                   <groupId>io.jenkins.plugins</groupId>
@@ -2524,7 +2527,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                    <jenkins.version>2.462.3</jenkins.version>
+                    <jenkins.version>2.479.3</jenkins.version>
                   </properties>
                   <dependencies>
                     <dependency>
@@ -2541,11 +2544,6 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <groupId>net.bytebuddy</groupId>
                       <artifactId>byte-buddy</artifactId>
                       <version>1.15.11</version>
-                    </dependency>
-                    <dependency>
-                      <groupId>org.apache.commons</groupId>
-                      <artifactId>commons-compress</artifactId>
-                      <version>1.26.1</version>
                     </dependency>
                     <dependency>
                       <groupId>org.jsoup</groupId>
@@ -2572,11 +2570,6 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <artifactId>json-path</artifactId>
                       <version>2.9.0</version>
                     </dependency>
-                    <dependency>
-                      <groupId>org.ow2.asm</groupId>
-                      <artifactId>asm</artifactId>
-                      <version>9.7.1</version>
-                    </dependency>
                   </dependencies>
                   <repositories>
                     <repository>
@@ -2599,7 +2592,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   <parent>
                     <groupId>org.jenkins-ci.plugins</groupId>
                     <artifactId>plugin</artifactId>
-                    <version>4.88</version>
+                    <version>5.10</version>
                     <relativePath />
                   </parent>
                   <groupId>io.jenkins.plugins</groupId>
@@ -2608,9 +2601,14 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                    <jenkins.version>2.462.3</jenkins.version>
+                    <jenkins.version>2.479.3</jenkins.version>
                   </properties>
                   <dependencies>
+                    <dependency>
+                      <groupId>io.jenkins.plugins</groupId>
+                      <artifactId>asm-api</artifactId>
+                      <version>%s</version>
+                    </dependency>
                     <dependency>
                       <groupId>io.jenkins.plugins</groupId>
                       <artifactId>byte-buddy-api</artifactId>
@@ -2637,11 +2635,6 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <version>%s</version>
                     </dependency>
                     <dependency>
-                      <groupId>org.apache.commons</groupId>
-                      <artifactId>commons-compress</artifactId>
-                      <version>1.26.1</version>
-                    </dependency>
-                    <dependency>
                       <groupId>org.jenkins-ci.plugins</groupId>
                       <artifactId>jsoup</artifactId>
                       <version>%s</version>
@@ -2655,11 +2648,6 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <groupId>io.jenkins.plugins</groupId>
                       <artifactId>json-path-api</artifactId>
                       <version>%s</version>
-                    </dependency>
-                    <dependency>
-                      <groupId>org.ow2.asm</groupId>
-                      <artifactId>asm</artifactId>
-                      <version>9.7.1</version>
                     </dependency>
                   </dependencies>
                   <repositories>
@@ -2677,6 +2665,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                 </project>
                 """
                                 .formatted(
+                                        asmApiVersion,
                                         byteBuddyApiVersion,
                                         commonsLang3ApiVersion,
                                         commonTextApiVersion,
@@ -2702,7 +2691,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   <parent>
                     <groupId>org.jenkins-ci.plugins</groupId>
                     <artifactId>plugin</artifactId>
-                    <version>4.88</version>
+                    <version>5.1</version>
                     <relativePath />
                   </parent>
                   <artifactId>antexec</artifactId>
@@ -2760,7 +2749,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   <parent>
                     <groupId>org.jenkins-ci.plugins</groupId>
                     <artifactId>plugin</artifactId>
-                    <version>4.88</version>
+                    <version>5.1</version>
                     <relativePath />
                   </parent>
                   <artifactId>antexec</artifactId>
@@ -2791,10 +2780,6 @@ public class DeclarativeRecipesTest implements RewriteTest {
                     <dependency>
                       <groupId>io.jenkins.plugins</groupId>
                       <artifactId>asm-api</artifactId>
-                    </dependency>
-                    <dependency>
-                      <groupId>io.jenkins.plugins</groupId>
-                      <artifactId>json-path-api</artifactId>
                     </dependency>
                     <dependency>
                       <groupId>org.jenkins-ci.plugins</groupId>

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsVersionTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpgradeJenkinsVersionTest.java
@@ -174,7 +174,7 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
     @Test
     void testPerformUpgradeWithoutBaselineWithBomAndUpgradeBomIfDoesntExistsForNewJenkinsVersion() {
         rewriteRun(
-                spec -> spec.recipe(new UpgradeJenkinsVersion(Settings.getJenkinsMinimumVersion())),
+                spec -> spec.recipe(new UpgradeJenkinsVersion("2.492.3")),
                 // language=xml
                 pomXml(
                         """
@@ -184,7 +184,7 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                   <parent>
                     <groupId>org.jenkins-ci.plugins</groupId>
                     <artifactId>plugin</artifactId>
-                    <version>4.87</version>
+                    <version>5.1</version>
                     <relativePath />
                   </parent>
                   <groupId>io.jenkins.plugins</groupId>
@@ -193,7 +193,7 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                    <jenkins.version>2.440.3</jenkins.version>
+                    <jenkins.version>2.479.1</jenkins.version>
                   </properties>
                   <dependencyManagement>
                     <dependencies>
@@ -227,7 +227,7 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                    <parent>
                      <groupId>org.jenkins-ci.plugins</groupId>
                      <artifactId>plugin</artifactId>
-                     <version>4.87</version>
+                     <version>5.1</version>
                      <relativePath />
                    </parent>
                    <groupId>io.jenkins.plugins</groupId>
@@ -236,13 +236,13 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
-                     <jenkins.version>%s</jenkins.version>
+                     <jenkins.version>2.492.3</jenkins.version>
                    </properties>
                    <dependencyManagement>
                      <dependencies>
                        <dependency>
                          <groupId>io.jenkins.tools.bom</groupId>
-                         <artifactId>%s</artifactId>
+                         <artifactId>bom-2.492.x</artifactId>
                          <version>%s</version>
                          <type>pom</type>
                          <scope>import</scope>
@@ -263,16 +263,13 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                    </pluginRepositories>
                  </project>
                  """
-                                .formatted(
-                                        Settings.getJenkinsMinimumVersion(),
-                                        Settings.getBomArtifactId(),
-                                        Settings.getRecommendedBomVersion())));
+                                .formatted(Settings.getRecommendedBomVersion())));
     }
 
     @Test
     void testPerformUpgradeWithBaselineWithBomAndUpgradeBomIfDoesntExistsForNewJenkinsVersion() {
         rewriteRun(
-                spec -> spec.recipe(new UpgradeJenkinsVersion(Settings.getJenkinsMinimumVersion())),
+                spec -> spec.recipe(new UpgradeJenkinsVersion("2.492.3")),
                 // language=xml
                 pomXml(
                         """
@@ -282,7 +279,7 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                   <parent>
                     <groupId>org.jenkins-ci.plugins</groupId>
                     <artifactId>plugin</artifactId>
-                    <version>4.87</version>
+                    <version>5.1</version>
                     <relativePath />
                   </parent>
                   <groupId>io.jenkins.plugins</groupId>
@@ -291,15 +288,15 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                   <packaging>hpi</packaging>
                   <name>Empty Plugin</name>
                   <properties>
-                    <jenkins.baseline>2.440</jenkins.baseline>
+                    <jenkins.baseline>2.479</jenkins.baseline>
                     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                   </properties>
                   <dependencyManagement>
                     <dependencies>
                       <dependency>
                         <groupId>io.jenkins.tools.bom</groupId>
-                        <artifactId>bom-2.440.x</artifactId>
-                        <version>3435.v238d66a_043fb_</version>
+                        <artifactId>bom-2.479.x</artifactId>
+                        <version>4570.v1b_c718dd3b_1e</version>
                         <type>pom</type>
                         <scope>import</scope>
                       </dependency>
@@ -326,7 +323,7 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                    <parent>
                      <groupId>org.jenkins-ci.plugins</groupId>
                      <artifactId>plugin</artifactId>
-                     <version>4.87</version>
+                     <version>5.1</version>
                      <relativePath />
                    </parent>
                    <groupId>io.jenkins.plugins</groupId>
@@ -335,8 +332,8 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                    <packaging>hpi</packaging>
                    <name>Empty Plugin</name>
                    <properties>
-                     <jenkins.baseline>%s</jenkins.baseline>
-                     <jenkins.version>${jenkins.baseline}.%s</jenkins.version>
+                     <jenkins.baseline>2.492</jenkins.baseline>
+                     <jenkins.version>${jenkins.baseline}.3</jenkins.version>
                    </properties>
                    <dependencyManagement>
                      <dependencies>
@@ -363,9 +360,6 @@ public class UpgradeJenkinsVersionTest implements RewriteTest {
                    </pluginRepositories>
                  </project>
                  """
-                                .formatted(
-                                        Settings.getJenkinsMinimumBaseline(),
-                                        Settings.getJenkinsMinimumPatchVersion(),
-                                        Settings.getRecommendedBomVersion())));
+                                .formatted(Settings.getRecommendedBomVersion())));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,8 @@
     <spotless.check.skip>false</spotless.check.skip>
 
     <!-- Version -->
-    <jenkins.core.minimum.version>2.462.3</jenkins.core.minimum.version>
-    <openrewrite.bom.version>3.5.0</openrewrite.bom.version>
+    <jenkins.core.minimum.version>2.479.3</jenkins.core.minimum.version>
+    <openrewrite.bom.version>3.6.1</openrewrite.bom.version>
     <openrewrite.maven.plugin.version>6.6.1</openrewrite.maven.plugin.version>
     <micrometer.version>1.14.5</micrometer.version>
     <slf4j.version>2.0.17</slf4j.version>

--- a/updatecli/updatecli.d/jenkins-bom.yaml
+++ b/updatecli/updatecli.d/jenkins-bom.yaml
@@ -25,12 +25,21 @@ sources:
         pattern: "latest"
 
 targets:
-  updateVersionsProperties:
+  updateBomVersionProperties:
     name: "Update jenkins-bom version in recipes.yml"
     kind: file
     spec:
       file: ./plugin-modernizer-core/src/main/resources/versions.properties
       matchPattern: "(?m)^(bom.version =) (.*)"
+      replacePattern: '$1 {{ source "latestBomVersion" }}'
+    sourceid: latestBomVersion
+    scmid: default
+  updateRecommendedBomVersionProperties:
+    name: "Update recommended jenkins-bom version in recipes.yml"
+    kind: file
+    spec:
+      file: ./plugin-modernizer-core/src/main/resources/versions.properties
+      matchPattern: "(?m)^(bom.recommended.version =) (.*)"
       replacePattern: '$1 {{ source "latestBomVersion" }}'
     sourceid: latestBomVersion
     scmid: default


### PR DESCRIPTION
Some tests are failing. Not sure why this PR suddendly cause this

```
[ERROR]   DeclarativeRecipesTest.upgradeToRecommendCoreVersionTestWithMultipleBom:1032 Failed to run recipe at Cursor{Tag->Tag->Tag->Tag->Document->root}
[ERROR]   DeclarativeRecipesTest.upgradeToUpgradeToLatestJava11CoreVersion:1201 Failed to run recipe at Cursor{Tag->Tag->Tag->Tag->Document->root}
```

```
Caused by: java.net.URISyntaxException: Illegal character in path at index 63: file:///home/valentin/.m2/repository/io/jenkins/tools/bom/bom-${jenkins.baseline}.x/maven-metadata-local.xml
        at java.base/java.net.URI$Parser.fail(URI.java:2995)
        at java.base/java.net.URI$Parser.checkChars(URI.java:3166
```

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
