### PR TITLE
Recipe - Migrate from com.github.tomakehurst to org.wiremock

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -222,6 +222,14 @@ public class Settings {
         return readProperty("jenkins-test-harness.version", "versions.properties");
     }
 
+    /**
+     * Return the Wiremock version
+     * @return The Wiremock version
+     */
+    public static String getWiremockVersion() {
+        return readProperty("wiremock.version", "versions.properties");
+    }
+
     public static String getJenkinsMinimumBaseline() {
         String jenkinsVersion = getJenkinsMinimumVersion();
         if (JENKINS_VERSION_LTS_PATTERN.test(jenkinsVersion)) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateTomakehurstToWiremock.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateTomakehurstToWiremock.java
@@ -1,0 +1,76 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.maven.MavenIsoVisitor;
+import org.openrewrite.xml.ChangeTagValueVisitor;
+import org.openrewrite.xml.tree.Xml;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A recipe to upgrade WireMock coordinates to org.wiremock as of WireMock 3 release.
+ * Migrates groupId from com.github.tomakehurst to org.wiremock, updates artifactId to wiremock or wiremock-standalone,
+ * and sets the version to the latest release.
+ */
+public class MigrateTomakehurstToWiremock extends Recipe {
+
+    /**
+     * Logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(MigrateTomakehurstToWiremock.class);
+
+    @Override
+    public String getDisplayName() {
+        return "Migrate from com.github.tomakehurst to org.wiremock";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Migrates Maven dependencies from com.github.tomakehurst:wiremock, wiremock-jre8-standalone to the corresponding artifact under the org.wiremock group (wiremock or wiremock-standalone) with the latest version.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new MavenIsoVisitor<>() {
+            @Override
+            public Xml.Tag visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                String wiremockVersion = Settings.getWiremockVersion();
+                if (isDependencyTag()) {
+                    String groupId = tag.getChildValue("groupId").orElse("");
+                    String artifactId = tag.getChildValue("artifactId").orElse("");
+                    if (groupId.equals("com.github.tomakehurst")
+                            && (artifactId.equals("wiremock") || artifactId.equals("wiremock-jre8-standalone"))) {
+
+                        // Update groupId
+                        if (tag.getChild("groupId").isPresent()) {
+                            doAfterVisit(new ChangeTagValueVisitor<>(
+                                    tag.getChild("groupId").get(), "org.wiremock"));
+                        }
+
+                        // Update artifactId
+                        String newArtifactId = artifactId.equals("wiremock") ? "wiremock" : "wiremock-standalone";
+                        if (!artifactId.equals("wiremock")) {
+                            if (tag.getChild("artifactId").isPresent()) {
+                                doAfterVisit(new ChangeTagValueVisitor<>(
+                                        tag.getChild("artifactId").get(), newArtifactId));
+                            }
+                        }
+
+                        // Update version
+                        if (tag.getChild("version").isPresent()) {
+                            doAfterVisit(new ChangeTagValueVisitor<>(
+                                    tag.getChild("version").get(), wiremockVersion));
+                        }
+                        maybeUpdateModel();
+
+                        LOG.info("Migrated from com.github.tomakehurst to org.wiremock");
+                    }
+                }
+                return super.visitTag(tag, ctx);
+            }
+        };
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -189,6 +189,7 @@ recipeList:
       recursive: true
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateAcegiSecurityToSpringSecurity
+  - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
   - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
@@ -482,6 +483,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
+  - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
   - org.openrewrite.maven.UpgradeDependencyVersion: # Latest using Java 11 support
       groupId: org.jenkins-ci.test
       artifactId: docker-fixtures

--- a/plugin-modernizer-core/src/main/resources/versions.properties
+++ b/plugin-modernizer-core/src/main/resources/versions.properties
@@ -15,3 +15,4 @@ joda-time-api.version = 2.14.0-127.v7d9da_295a_d51
 json-api.version = 20250107-125.v28b_a_ffa_eb_f01
 json-path-api.version = 2.9.0-148.v22a_7ffe323ce
 jenkins-test-harness.version = 2429.v843718995d1d
+wiremock.version = 3.12.1

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateTomakehurstToWiremockTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateTomakehurstToWiremockTest.java
@@ -1,0 +1,106 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openrewrite.test.RewriteTest;
+
+/**
+ * Test for {@link MigrateTomakehurstToWiremock}.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class MigrateTomakehurstToWiremockTest implements RewriteTest {
+    @Test
+    void testMigrateWireMockJre8Standalone() {
+        rewriteRun(
+                spec -> spec.recipe(new MigrateTomakehurstToWiremock()),
+                // language=xml
+                pomXml(
+                        """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>empty</artifactId>
+                          <version>1.0.0-SNAPSHOT</version>
+                          <packaging>hpi</packaging>
+                          <name>Empty Plugin</name>
+                          <dependencies>
+                            <dependency>
+                              <groupId>com.github.tomakehurst</groupId>
+                              <artifactId>wiremock-jre8-standalone</artifactId>
+                              <version>2.35.2</version>
+                              <scope>test</scope>
+                            </dependency>
+                          </dependencies>
+                        </project>
+                        """,
+                        """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>empty</artifactId>
+                          <version>1.0.0-SNAPSHOT</version>
+                          <packaging>hpi</packaging>
+                          <name>Empty Plugin</name>
+                          <dependencies>
+                            <dependency>
+                              <groupId>org.wiremock</groupId>
+                              <artifactId>wiremock-standalone</artifactId>
+                              <version>3.12.1</version>
+                              <scope>test</scope>
+                            </dependency>
+                          </dependencies>
+                        </project>
+                        """));
+    }
+
+    @Test
+    void testMigrateWireMock() {
+        rewriteRun(
+                spec -> spec.recipe(new MigrateTomakehurstToWiremock()),
+                // language=xml
+                pomXml(
+                        """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>empty</artifactId>
+                          <version>1.0.0-SNAPSHOT</version>
+                          <packaging>hpi</packaging>
+                          <name>Empty Plugin</name>
+                          <dependencies>
+                            <dependency>
+                              <groupId>com.github.tomakehurst</groupId>
+                              <artifactId>wiremock</artifactId>
+                              <version>3.0.1</version>
+                              <scope>test</scope>
+                            </dependency>
+                          </dependencies>
+                        </project>
+                        """,
+                        """
+                        <?xml version="1.0" encoding="UTF-8"?>
+                        <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                          <modelVersion>4.0.0</modelVersion>
+                          <groupId>io.jenkins.plugins</groupId>
+                          <artifactId>empty</artifactId>
+                          <version>1.0.0-SNAPSHOT</version>
+                          <packaging>hpi</packaging>
+                          <name>Empty Plugin</name>
+                          <dependencies>
+                            <dependency>
+                              <groupId>org.wiremock</groupId>
+                              <artifactId>wiremock</artifactId>
+                              <version>3.12.1</version>
+                              <scope>test</scope>
+                            </dependency>
+                          </dependencies>
+                        </project>
+                        """));
+    }
+}


### PR DESCRIPTION
#947 
Changes made:
- `MigrateTomakehurstToWiremock` - This recipe Migrates Maven dependencies from `com.github.tomakehurst:wiremock`, `wiremock-jre8-standalone` to the corresponding artifact under the `org.wiremock` group (`wiremock` or `wiremock-standalone`) with the latest version.
- Add the unit tests for the recipe
- Add it under `UpgradeToLatestJava11CoreVersion` and `UpgradeNextMajorParentVersion`.

### Testing done
`mvn clean install`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue