### PR TITLE
feat: Add wiremock version update configuration thanks to updatecli

### DIFF
--- a/updatecli/updatecli.d/wiremock.yaml
+++ b/updatecli/updatecli.d/wiremock.yaml
@@ -1,0 +1,47 @@
+name: Update wiremock version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  wiremockVersion:
+    kind: githubrelease
+    spec:
+      owner: "wiremock"
+      repository: "wiremock"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versioning:
+        kind: semver
+        pattern: "latest"
+
+targets:
+  updateWiremockVersion:
+    name: Update wiremock.version in versions.properties
+    kind: file
+    spec:
+      file: plugin-modernizer-core/src/main/resources/versions.properties
+      matchPattern: >-
+        wiremock\.version\s*=\s*.*
+      replacePattern: >-
+        wiremock.version = {{ source "wiremockVersion" }}
+
+
+actions:
+  createPullRequest:
+    kind: github/pullrequest
+    scmid: default
+    title: 'Update wiremock version to {{ source "wiremockVersion" }}'
+    spec:
+      labels:
+        - dependencies
+        - updatecli


### PR DESCRIPTION
This is a follow-up to #952 and #947.

I added wiremock version update configuration thanks to an updatecli manifest.

### Testing done

`updatecli diff --config ./updatecli/updatecli.d/wiremock.yaml --values ./updatecli/values.github-action.yaml --debug`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
