### PR TITLE
Recipe to Replace Deprecated IOException2

### DIFF
--- a/plugin-modernizer-core/src/main/jte/pr-body-ReplaceIOException2WithIOException.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-ReplaceIOException2WithIOException.jte
@@ -1,0 +1,22 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+
+Hello `${plugin.getName()}` developers! :wave:
+
+This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool) tool. The tool has applied the following recipe to modernize the plugin:
+
+<details aria-label="Recipe details for ${recipe.getDisplayName()}">
+    <summary>${recipe.getDisplayName()}</summary>
+    <p><em>${recipe.getName()}</em></p>
+    <blockquote>${recipe.getDescription()}</blockquote>
+</details>
+
+## Remove usage of deprecated IOException2
+
+Removes usage of deprecated `hudson.util.IOException2` by replacing it with `java.io.IOException`.
+
+### Testing done
+
+None, rely on `ci.jenkins.io` to test it.

--- a/plugin-modernizer-core/src/main/jte/pr-title-ReplaceIOException2WithIOException.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-ReplaceIOException2WithIOException.jte
@@ -1,0 +1,5 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+Remove usage of deprecated IOException2

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -190,6 +190,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateAcegiSecurityToSpringSecurity
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
+  - io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
   - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
@@ -244,6 +245,16 @@ recipeList:
       propertyName: maven.compiler.source
   - io.jenkins.tools.pluginmodernizer.core.recipes.RemoveProperty: # Set by parent, ensure it's removed
       propertyName: maven.compiler.target
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
+displayName: Replace IOException2 With IOException
+tags: ['developer']
+description: Replace hudson.util.IOException2 With java.io.IOException.
+recipeList:
+    - org.openrewrite.java.ChangeType:
+        oldFullyQualifiedTypeName: hudson.util.IOException2
+        newFullyQualifiedTypeName: java.io.IOException
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.ReplaceLibrariesWithApiPlugin
@@ -459,6 +470,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
+  - io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
   - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -659,4 +659,42 @@ public class TemplateUtilsTest {
                 result.contains("This PR aims to migrate all tests to JUnit 5. Changes include:"),
                 "Missing This PR aims to migrate all tests to JUnit 5. Changes include: section");
     }
+
+    @Test
+    public void testFriendlyPrTitleReplaceIOException2WithIOException() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn("io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
+
+        // Assert
+        assertEquals("Remove usage of deprecated IOException2", result);
+    }
+
+    @Test
+    public void testFriendlyPrBodyReplaceIOException2WithIOException() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn("io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestBody(plugin, recipe);
+
+        // Just ensure it's using some key overall text
+        assertTrue(
+                result.contains("Remove usage of deprecated IOException2"),
+                "Remove usage of deprecated IOException2 section");
+    }
 }


### PR DESCRIPTION
#995 
- Created a standalone recipe named `ReplaceIOException2WithIOException`  which replace deprecated `hudson.util.IOException2` with `java.io.IOException`.
- Added the recipe in `UpgradeNextMajorParentVersion` and `UpgradeToRecommendCoreVersion`
- Added test coverage 
- Added pr title and pr body for it.
### Testing done
`mvn clean install`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
