### PR TITLE
Add recipe to add 'throws Exception' where assertThrows is invoked

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/AddThrowsExceptionWhereAssertThrows.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/AddThrowsExceptionWhereAssertThrows.java
@@ -1,0 +1,122 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.NameTree;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AddThrowsExceptionWhereAssertThrows extends Recipe {
+
+    /**
+     * Logger
+     */
+    private static final Logger LOG = LoggerFactory.getLogger(AddThrowsExceptionWhereAssertThrows.class);
+
+    @Override
+    public String getDisplayName() {
+        return "Add throws exception to methods using assertThrows";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Adds 'throws Exception' to test methods that contain assertThrows calls.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new JavaIsoVisitor<>() {
+            // find the test method using assertThrows
+            // firstly check if assertThrows is imported, if not skip that file
+            @Override
+            public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                // Check for relevant imports
+                boolean hasAssertThrowsImport = cu.getImports().stream()
+                        .anyMatch(imp -> imp.getPackageName().equals("org.junit.jupiter.api")
+                                && (imp.getClassName().equals("Assertions")
+                                        || imp.getClassName().equals("*")));
+                if (!hasAssertThrowsImport) {
+                    return cu; // Skip files without relevant imports
+                }
+
+                return super.visitCompilationUnit(cu, ctx);
+            }
+
+            @Override
+            public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+                method = super.visitMethodDeclaration(method, ctx);
+                // Check if method is a test method (has @Test annotation)
+                if (method.getLeadingAnnotations().stream()
+                        .anyMatch(annotation -> annotation.getType() != null
+                                && annotation.getSimpleName().equals("Test"))) {
+                    // Check if method contains assertThrows
+                    if (containsAssertThrows(method)) {
+                        LOG.info(
+                                "Found assertThrows for method {} in class {}",
+                                method.getSimpleName(),
+                                method.getMethodType().getDeclaringType().getFullyQualifiedName());
+                        // Check if 'throws Exception' is already present
+                        if (method.getThrows() == null
+                                || method.getThrows().stream()
+                                        .noneMatch(t -> t.getType() != null
+                                                && t.getType().toString().equals("java.lang.Exception"))) {
+                            // Add 'throws Exception'
+                            List<NameTree> newThrows = new ArrayList<>();
+                            newThrows.add(new JRightPadded<>(
+                                            new J.Identifier(
+                                                    Tree.randomId(),
+                                                    Space.SINGLE_SPACE,
+                                                    Markers.EMPTY,
+                                                    "Exception",
+                                                    JavaType.buildType("java.lang.Exception"),
+                                                    null),
+                                            Space.SINGLE_SPACE,
+                                            Markers.EMPTY)
+                                    .getElement());
+                            J.MethodDeclaration withThrows = method.withThrows(newThrows);
+                            LOG.info(
+                                    "Added 'throws Exception' to method {} in class {}",
+                                    method.getSimpleName(),
+                                    method.getMethodType().getDeclaringType().getFullyQualifiedName());
+                            return withThrows;
+                        }
+                    }
+                }
+                return method;
+            }
+
+            private boolean containsAssertThrows(J.MethodDeclaration method) {
+                AtomicBoolean found = new AtomicBoolean(false);
+                new JavaIsoVisitor<AtomicBoolean>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(
+                            J.MethodInvocation methodInvocation, AtomicBoolean found) {
+                        if (found.get()) return methodInvocation; // Short-circuit if already found
+                        if ("assertThrows".equals(methodInvocation.getSimpleName())) {
+                            if (methodInvocation.getSelect() == null
+                                    || (methodInvocation.getSelect() instanceof J.Identifier
+                                            && "Assertions"
+                                                    .equals(((J.Identifier) methodInvocation.getSelect())
+                                                            .getSimpleName()))) {
+                                found.set(true);
+                            }
+                        }
+                        return super.visitMethodInvocation(methodInvocation, found);
+                    }
+                }.visit(method.getBody(), found);
+                return found.get();
+            }
+        };
+    }
+}

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -135,6 +135,7 @@ recipeList:
       methodPattern: org.junit.jupiter.api.Assertions *(..)
   - org.openrewrite.java.testing.junit5.AddMissingTestBeforeAfterAnnotations
   - org.openrewrite.java.testing.cleanup.TestsShouldNotBePublic
+  - io.jenkins.tools.pluginmodernizer.core.recipes.AddThrowsExceptionWhereAssertThrows
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/AddThrowsExceptionWhereAssertThrowsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/AddThrowsExceptionWhereAssertThrowsTest.java
@@ -1,0 +1,158 @@
+package io.jenkins.tools.pluginmodernizer.core.recipes;
+
+import static org.openrewrite.java.Assertions.java;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.openrewrite.test.RewriteTest;
+
+/**
+ * Test for {@link AddThrowsExceptionWhereAssertThrows}.
+ */
+@Execution(ExecutionMode.CONCURRENT)
+public class AddThrowsExceptionWhereAssertThrowsTest implements RewriteTest {
+
+    @Test
+    void shouldAddThrowsExceptionToTestMethodWhenUsingAssertThrows() {
+        rewriteRun(
+                spec -> spec.recipe(new AddThrowsExceptionWhereAssertThrows()),
+                // language=java
+                java(
+                        """
+                    import static org.junit.jupiter.api.Assertions.assertThrows;
+                    import org.junit.jupiter.api.Test;
+
+                    public class MyTest {
+                        @Test
+                        public void testSomething() {
+                            assertThrows(Exception.class, () -> {
+                                //someMethod()
+                             });
+                        }
+                    }
+                    """,
+                        """
+                    import static org.junit.jupiter.api.Assertions.assertThrows;
+                    import org.junit.jupiter.api.Test;
+
+                    public class MyTest {
+                        @Test
+                        public void testSomething()throws Exception {
+                            assertThrows(Exception.class, () -> {
+                                //someMethod()
+                             });
+                        }
+                    }
+                    """));
+    }
+
+    @Test
+    void shouldAddThrowsExceptionForQualifiedAssertThrows() {
+        rewriteRun(
+                spec -> spec.recipe(new AddThrowsExceptionWhereAssertThrows()),
+                // language=java
+                java(
+                        """
+                        import org.junit.jupiter.api.Assertions;
+                        import org.junit.jupiter.api.Test;
+
+                        public class MyTest {
+                            @Test
+                            public void testSomething() {
+                                Assertions.assertThrows(Exception.class, () -> {
+                                  //someMethod();
+                                });
+                            }
+                        }
+                        """,
+                        """
+                        import org.junit.jupiter.api.Assertions;
+                        import org.junit.jupiter.api.Test;
+
+                        public class MyTest {
+                            @Test
+                            public void testSomething()throws Exception {
+                                Assertions.assertThrows(Exception.class, () -> {
+                                  //someMethod();
+                                });
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void shouldNotAddThrowsExceptionIfAlreadyPresent() {
+        rewriteRun(
+                spec -> spec.recipe(new AddThrowsExceptionWhereAssertThrows()),
+                // language=java
+                java(
+                        """
+                        import static org.junit.jupiter.api.Assertions.assertThrows;
+                        import org.junit.jupiter.api.Test;
+
+                        public class MyTest {
+                            @Test
+                            public void testSomething() throws Exception {
+                                assertThrows(Exception.class, () -> {
+                                  //someMethod();
+                                });
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void shouldNotAddThrowsExceptionIfNoAssertThrows() {
+        rewriteRun(
+                spec -> spec.recipe(new AddThrowsExceptionWhereAssertThrows()),
+                // language=java
+                java(
+                        """
+                        import org.junit.jupiter.api.Test;
+
+                        public class MyTest {
+                            @Test
+                            public void testSomething() {
+                                // No assertThrows
+                            }
+                        }
+                        """));
+    }
+
+    @Test
+    void shouldAddThrowsExceptionAlongWithExistingThrowsByReplacingIt() {
+        rewriteRun(
+                spec -> spec.recipe(new AddThrowsExceptionWhereAssertThrows()),
+                // language=java
+                java(
+                        """
+                        import static org.junit.jupiter.api.Assertions.assertThrows;
+                        import org.junit.jupiter.api.Test;
+                        import java.io.IOException;
+
+                        public class MyTest {
+                            @Test
+                            public void testSomething() throws IOException {
+                                assertThrows(Exception.class, () -> {
+                                  //someMethod();
+                                });
+                            }
+                        }
+                        """,
+                        """
+                        import static org.junit.jupiter.api.Assertions.assertThrows;
+                        import org.junit.jupiter.api.Test;
+                        import java.io.IOException;
+
+                        public class MyTest {
+                            @Test
+                            public void testSomething() throws Exception {
+                                assertThrows(Exception.class, () -> {
+                                  //someMethod();
+                                });
+                            }
+                        }
+                        """));
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -3474,7 +3474,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                     }
 
                     @Test
-                    void testException() {
+                    void testException()throws Exception {
                         assertThrows(IllegalArgumentException.class, () -> {
                             throw new IllegalArgumentException("Expected");
                         });


### PR DESCRIPTION
#996 
- Created recipe `AddThrowsExceptionWhereAssertThrows` - It adds `throws Exception` to the method declaration wherever `assertThrows` is called.
- Rather than checking all files we are filtering the files by firstly checking the imports of `assertThrows`, if not just skip that file.
- Added the recipe under `migrateToJUnit5` and updated its test coverage.
### Testing done
`mvn clean install` 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue