### PR TITLE
Fix the hardcoded variable name 'j' of type JenkinsRule in the AnnotateWithJenkins recipe

### DIFF
--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/AnnotateWithJenkinsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/AnnotateWithJenkinsTest.java
@@ -34,16 +34,16 @@ public class AnnotateWithJenkinsTest implements RewriteTest {
 
                         public class MyTest {
                             @Rule
-                            public JenkinsRule j = new JenkinsRule();
+                            public JenkinsRule jr = new JenkinsRule();
 
                             @Test
                             public void myTestMethod() {
-                                j.before();
+                                jr.before();
                             }
 
                             @Test
                             public void myTestMethodWithParam(String str) {
-                                j.before();
+                                jr.before();
                             }
                         }
                         """,
@@ -57,13 +57,13 @@ public class AnnotateWithJenkinsTest implements RewriteTest {
                         public class MyTest {
 
                             @Test
-                            public void myTestMethod(JenkinsRule j) {
-                                j.before();
+                            public void myTestMethod(JenkinsRule jr) {
+                                jr.before();
                             }
 
                             @Test
-                            public void myTestMethodWithParam(String str, JenkinsRule j) {
-                                j.before();
+                            public void myTestMethodWithParam(String str, JenkinsRule jr) {
+                                jr.before();
                             }
                         }
                         """));


### PR DESCRIPTION
https://github.com/jenkins-infra/plugin-modernizer-tool/issues/996#issuecomment-2859406207
In the `AnnotateWithJenkins` recipe when we are passing `JenkinsRule j` as a `param` and removing it as a `class variable`, in the recipe we were only looking for the variable named `j`, as it was hardcoded in the recipe. So the recipe would successfully apply for the below case as we have the variable name as `j`. But in case the variable name of `JenkinsRule` is not `j`, it would not pass the `JenkinsRule` as params to the method which would give `cannot be resolved` err and prevents compilation.

### Works Fine When we have JenkinsRule j
Before:
```
public class MyTest {
     @Rule
      public JenkinsRule j = new JenkinsRule();
      @Test
      public void myTestMethod() {
      j.before();
      }
}
```
After:
```
@WithJenkins
class MyTest {
      @Test
      public void myTestMethod(JenkinsRule j) {
      j.before();
      }
}
```

### Error When we have JenkinsRule jr
Before:
```
public class MyTest {
      @Rule
      public JenkinsRule jr = new JenkinsRule();
      @Test
      public void myTestMethod() {
      jr.before();
      }
}
```
After:
```
@WithJenkins
class MyTest {
      @Test
      public void myTestMethod() {   //Not passed JenkinsRule jr as a parameter
      jr.before();   //cannot resolved
      }
}
```

### Testing done
`mvn clean install`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue