### PR TITLE
Update openrewrite bom version from 3.8.0 to 3.8.1

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateAcegiSecurityToSpringSecurity.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateAcegiSecurityToSpringSecurity.java
@@ -4,6 +4,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.openrewrite.ExecutionContext;
@@ -306,9 +307,12 @@ public class MigrateAcegiSecurityToSpringSecurity extends Recipe {
                     if (methodMatcher.matches(method, enclosingClass)) {
                         JavaType.Method type = method.getMethodType();
 
-                        if (method.getMethodType().getOverride() != null) {
+                        if (!Objects.requireNonNull(method.getMethodType().getOverride())
+                                .toString()
+                                .equals(
+                                        "hudson.security.SecurityRealm{name=loadUserByUsername,return=org.acegisecurity.userdetails.UserDetails,parameters=[java.lang.String]}")) {
                             LOG.info(
-                                    "Don't migrate this one to loadUserByUsername2 {}",
+                                    "Don't migrate this one to loadUserByUsername2 as it doesn't override the method of SecurityRealm, instead overrides of: {}",
                                     method.getMethodType().getOverride().toString());
                             return super.visitMethodDeclaration(method, ctx);
                         }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -3519,12 +3519,6 @@ public class DeclarativeRecipesTest implements RewriteTest {
                     public void myTestMethodChild(JenkinsRule j) {
                         j.before();
                     }
-
-                    private static File newFile(File parent, String child) throws IOException {
-                        File result = new File(parent, child);
-                        result.createNewFile();
-                        return result;
-                    }
                 }
                 """));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 
     <!-- Version -->
     <jenkins.core.minimum.version>2.462.3</jenkins.core.minimum.version>
-    <openrewrite.bom.version>3.8.0</openrewrite.bom.version>
+    <openrewrite.bom.version>3.8.1</openrewrite.bom.version>
     <openrewrite.maven.plugin.version>6.9.0</openrewrite.maven.plugin.version>
     <micrometer.version>1.15.0</micrometer.version>
     <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
Manual fix for #1025

- bump `org.openrewrite.recipe:rewrite-recipe-bom` from `3.8.0` to `3.8.1`
- Update `MigrateAcegiSecurityToSpringSecurity` recipe and update `migrateToJUnit5` tests.

### Testing done
`mvn clean install`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
