### PR TITLE
Push Metadata changes to a public repo 

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -51,7 +51,10 @@ public class Settings {
     public static final Path SSH_PRIVATE_KEY;
 
     public static final String GITHUB_OWNER;
+
     public static final Path GITHUB_APP_PRIVATE_KEY_FILE;
+
+    public static final String GITHUB_METADATA_REPOSITORY = "metadata-plugin-modernizer-tool";
 
     public static final String ORGANIZATION = getTargetOrganisation();
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -54,9 +54,11 @@ public class Settings {
 
     public static final Path GITHUB_APP_PRIVATE_KEY_FILE;
 
-    public static final String GITHUB_METADATA_REPOSITORY = "metadata-plugin-modernizer-tool";
+    public static final String GITHUB_METADATA_REPOSITORY = "metadata-plugin-modernizer";
 
     public static final String ORGANIZATION = getTargetOrganisation();
+
+    public static final String METADATA_ORGANISATION = "Raunak80Madan";
 
     public static final String RECIPE_DATA_YAML_PATH = "META-INF/rewrite/recipes.yml";
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -58,7 +58,7 @@ public class Settings {
 
     public static final String ORGANIZATION = getTargetOrganisation();
 
-    public static final String METADATA_ORGANISATION = "Raunak80Madan";
+    public static final String METADATA_ORGANISATION = getMetadataTargetOrganisation();
 
     public static final String RECIPE_DATA_YAML_PATH = "META-INF/rewrite/recipes.yml";
 
@@ -338,6 +338,10 @@ public class Settings {
             targetOrganisation = "jenkinsci";
         }
         return targetOrganisation;
+    }
+
+    private static String getMetadataTargetOrganisation() {
+        return "Raunak80Madan";
     }
 
     public static Path getDefaultSdkManJava(final String key) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -341,7 +341,11 @@ public class Settings {
     }
 
     private static String getMetadataTargetOrganisation() {
-        return "Raunak80Madan";
+        String metadataTargetOrganisation = System.getenv("GH_METADATA_TARGET_ORGANISATION");
+        if (metadataTargetOrganisation == null) {
+            metadataTargetOrganisation = "Raunak80Madan";
+        }
+        return metadataTargetOrganisation;
     }
 
     public static Path getDefaultSdkManJava(final String key) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/ModernizationMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/ModernizationMetadata.java
@@ -33,11 +33,31 @@ public class ModernizationMetadata extends CacheEntry<ModernizationMetadata> {
      */
     private String rpuBaseline;
 
+    /**
+     * Name of the migration
+     */
     private String migrationName;
+
+    /**
+     * Description of the migration
+     */
     private String migrationDescription;
+
+    /**
+     * Tags for the migration
+     */
     private Set<String> tags;
+
+    /**
+     * Unique identifier for the migration
+     */
     private String migrationId;
+
+    /**
+     * Number of deprecated APIs removed by the migration
+     */
     private Integer removedDeprecatedApis;
+
     /**
      * Create a new modernization metadata
      * Store the metadata in the relative target directory of current folder

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -1469,7 +1469,7 @@ public class GHService {
                 return;
             }
             // Check if existing PR exists
-            GHRepository repository = getMetadataRepository(plugin);
+            GHRepository repository = plugin.getRemoteMetadataRepository(this);
             Optional<GHPullRequest> existingPR = checkIfMetadataPullRequestExists(plugin);
             if (existingPR.isPresent()) {
                 LOG.info("Pull request already exists: {}", existingPR.get().getHtmlUrl());
@@ -1579,7 +1579,7 @@ public class GHService {
      * @return The pull request if it exists
      */
     private Optional<GHPullRequest> checkIfMetadataPullRequestExists(Plugin plugin) {
-        GHRepository repository = getMetadataRepository(plugin);
+        GHRepository repository = plugin.getRemoteMetadataRepository(this);
         String branchName = plugin.getName() + "-" + "modernization-metadata";
         try {
             List<GHPullRequest> pullRequests = repository

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -760,9 +760,14 @@ public class GHService {
     /**
      * Fetch a metadata repository code from the original repo
      *
-     * @param plugin The plugin to fork
+     * @param plugin The plugin
      */
     public void fetchMetadata(Plugin plugin) {
+        if (config.isDryRun() || plugin.isLocal()) {
+            LOG.info("Skipping metadata fetch for plugin {} in dry-run or local mode", plugin);
+            return;
+        }
+
         // We always fetch from original repo to avoid forking when not necessary
         GHRepository repository = getMetadataRepository(plugin);
 
@@ -1027,6 +1032,10 @@ public class GHService {
      * @param plugin The plugin to checkout branch for
      */
     public void checkoutMetadataBranch(Plugin plugin) {
+        if (plugin.isLocal()) {
+            LOG.info("Plugin {} is local. Not checking out metadata branch", plugin);
+            return;
+        }
         String branchName = plugin.getName() + "-" + "modernization-metadata";
         try (Git git = Git.open(plugin.getLocalMetadataRepository().toFile())) {
             try {
@@ -1135,6 +1144,10 @@ public class GHService {
      * @param plugin The plugin to commit changes for
      */
     public void commitMetadataChanges(Plugin plugin) {
+        if (plugin.isLocal()) {
+            LOG.info("Plugin {} is local. Not committing metadata changes", plugin);
+            return;
+        }
         try (Git git = Git.open(plugin.getLocalMetadataRepository().toFile())) {
             // change the remote origin back to fork
             setRemoteURL(git, "https://github.com/" + getGithubOwner() + "/" + Settings.GITHUB_METADATA_REPOSITORY);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -267,7 +267,7 @@ public class GHService {
      */
     public void addFilesToStaging(Git git, String filePattern) throws GitAPIException {
         git.add().addFilepattern(filePattern).call();
-        LOG.info("Added files to staging area: {}", filePattern);
+        LOG.debug("Added files to staging area: {}", filePattern);
     }
 
     /**
@@ -1138,7 +1138,6 @@ public class GHService {
         try (Git git = Git.open(plugin.getLocalMetadataRepository().toFile())) {
             // change the remote origin back to fork
             setRemoteURL(git, "https://github.com/" + getGithubOwner() + "/" + Settings.GITHUB_METADATA_REPOSITORY);
-            checkoutMetadataBranch(plugin);
             addFilesToStaging(git, ".");
             Status status = git.status().call();
             // don't commit empty changes

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
@@ -22,7 +22,7 @@ public class CacheManager {
     public static final String HEALTH_SCORE_KEY = "health-score";
     public static final String INSTALLATION_STATS_KEY = "plugin-installation-stats";
     public static final String PLUGIN_METADATA_CACHE_KEY = "plugin-metadata";
-    public static final String MODERNIZATION_METADATA_CACHE_KEY = "modernization-metadata";
+    public static final String MODERNIZATION_METADATA_CACHE_KEY = "modernization-metadata.json";
     private static final Logger LOG = LoggerFactory.getLogger(CacheManager.class);
 
     private final Path location;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -321,6 +321,7 @@ public class PluginModernizer {
                 plugin.fetchMetadata(ghService);
                 plugin.forkMetadata(ghService);
                 plugin.syncMetadata(ghService);
+                plugin.checkoutMetadataBranch(ghService);
                 plugin.copyMetadataToLocalMetadataRepo(cacheManager);
                 plugin.commitMetadata(ghService);
                 plugin.pushMetadata(ghService);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -318,7 +318,10 @@ public class PluginModernizer {
             // collect the modernziation metadata and push it to metadata repository
             if (!config.isFetchMetadataOnly()) {
                 collectModernizationMetadata(plugin);
-                plugin.initializePluginDirectory(ghService);
+                plugin.fetchMetadata(ghService);
+                plugin.forkMetadata(ghService);
+                plugin.syncMetadata(ghService);
+                plugin.copyMetadataToLocalMetadataRepo(cacheManager);
                 plugin.commitMetadata(ghService);
                 plugin.pushMetadata(ghService);
                 plugin.openMetadataPullRequest(ghService);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -816,6 +816,14 @@ public class Plugin {
     }
 
     /**
+     * Return if the metadata is forked
+     * @param service The GitHub service
+     */
+    public boolean isForkedMetadata(GHService service) {
+        return service.isForkedMetadata(this);
+    }
+
+    /**
      * Return if this plugin is archived
      * @param service The GitHub service
      * @return True if the plugin is archived
@@ -872,6 +880,14 @@ public class Plugin {
      */
     public void checkoutBranch(GHService service) {
         service.checkoutBranch(this);
+    }
+
+    /**
+     * Checkout the metadata branch
+     * @param service The GitHub service
+     */
+    public void checkoutMetadataBranch(GHService service) {
+        service.checkoutMetadataBranch(this);
     }
 
     /**
@@ -963,6 +979,15 @@ public class Plugin {
      */
     public GHRepository getRemoteForkRepository(GHService service) {
         return service.getRepositoryFork(this);
+    }
+
+    /**
+     * Get the associated fork repository for the metadata
+     * @param service The GitHub service
+     * @return The repository object
+     */
+    public GHRepository getRemoteMetadataForkRepository(GHService service) {
+        return service.getMetadataRepositoryFork(this);
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/Plugin.java
@@ -96,6 +96,21 @@ public class Plugin {
     private boolean hasPullRequest;
 
     /**
+     * Flag to indicate if the modernization-metadata has any commits to be pushed
+     */
+    private boolean hasMetadataCommits;
+
+    /**
+     * Flag to indicate if the modernization-metadata has any changes pushed and ready to be merged
+     */
+    private boolean hasMetadataChangesPushed;
+
+    /**
+     * Flag to indicate if the modernization-metadata has any pull request open
+     */
+    private boolean hasMetadataPullRequest;
+
+    /**
      * Return if the plugin has any error
      */
     private final List<PluginProcessingException> errors = new LinkedList<>();
@@ -267,6 +282,84 @@ public class Plugin {
      */
     public boolean hasPullRequest() {
         return hasPullRequest;
+    }
+
+    /**
+     * Indicate that the plugin has metadata commits to be pushed
+     * @return Plugin object
+     */
+    public Plugin withMetadataCommits() {
+        this.hasMetadataCommits = true;
+        return this;
+    }
+
+    /**
+     * Indicate that the plugin has no metadata commits to be pushed
+     * @return Plugin object
+     */
+    public Plugin withoutMetadataCommits() {
+        this.hasMetadataCommits = false;
+        return this;
+    }
+
+    /**
+     * Indicate that the plugin has metadata changes pushed and ready to be merged
+     * @return Plugin object
+     */
+    public Plugin withMetadataChangesPushed() {
+        this.hasMetadataChangesPushed = true;
+        return this;
+    }
+
+    /**
+     * Indicate that the plugin has no metadata changes pushed and ready to be merged
+     * @return Plugin object
+     */
+    public Plugin withoutMetadataChangesPushed() {
+        this.hasMetadataChangesPushed = false;
+        return this;
+    }
+
+    /**
+     * Indicate that the plugin has a metadata pull request open
+     * @return Plugin object
+     */
+    public Plugin withMetadataPullRequest() {
+        this.hasMetadataPullRequest = true;
+        return this;
+    }
+
+    /**
+     * Indicate that the plugin has no metadata pull request open
+     * @return Plugin object
+     */
+    public Plugin withoutMetadataPullRequest() {
+        this.hasMetadataPullRequest = false;
+        return this;
+    }
+
+    /**
+     * Return if the plugin has any metadata commits
+     * @return True if the plugin has commits
+     */
+    public boolean hasMetadataCommits() {
+        return hasMetadataCommits;
+    }
+
+    /**
+     * Return if the plugin has any metadata changes pushed and ready to be merged
+     * @return True if the plugin has changes pushed
+     */
+    public boolean hasMetadataChangesPushed() {
+        return hasMetadataChangesPushed;
+    }
+
+    /**
+     * Return if the plugin has any metadata changes pushed and ready to be merged
+     * @return True if the plugin has changes pushed
+     */
+    public boolean hasMetadataPullRequest() {
+        return hasMetadataPullRequest;
     }
 
     /**
@@ -467,6 +560,14 @@ public class Plugin {
      */
     public URI getGitRepositoryURI(String organization) {
         return URI.create("https://github.com/" + organization + "/" + repositoryName + ".git");
+    }
+
+    /**
+     * Initialize the plugin directory on the given service
+     * @param service The GitHub service
+     */
+    public void initializePluginDirectory(GHService service) {
+        service.initializePluginDirectory(this);
     }
 
     /**
@@ -754,6 +855,14 @@ public class Plugin {
     }
 
     /**
+     * Commit the metadata changes to the metadata repository
+     * @param service The GitHub service
+     */
+    public void commitMetadata(GHService service) {
+        service.commitMetadataChanges(this);
+    }
+
+    /**
      * Push the changes to the plugin repository
      * @param service The GitHub service
      */
@@ -762,11 +871,27 @@ public class Plugin {
     }
 
     /**
+     * Push the metadata changes to the metadata repository
+     * @param service The GitHub service
+     */
+    public void pushMetadata(GHService service) {
+        service.pushMetadataChanges(this);
+    }
+
+    /**
      * Open a pull request for the plugin
      * @param service The GitHub service
      */
     public void openPullRequest(GHService service) {
         service.openPullRequest(this);
+    }
+
+    /**
+     * Open a pull request for the metadata changes
+     * @param service The GitHub service
+     */
+    public void openMetadataPullRequest(GHService service) {
+        service.openMetadataPullRequest(this);
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtils.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/JsonUtils.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
 import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import java.io.IOException;
@@ -136,7 +139,8 @@ public class JsonUtils {
     public static void toJsonFile(Object object, Path path) {
         try {
             LOG.debug("Writing JSON file to {}", path);
-            FileUtils.writeStringToFile(path.toFile(), gson.toJson(object), StandardCharsets.UTF_8);
+            String prettyJson = JsonUtils.prettyPrint(gson.toJson(object));
+            FileUtils.writeStringToFile(path.toFile(), prettyJson, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new ModernizerException("Unable to write JSON file due to IO error", e);
         }
@@ -253,5 +257,11 @@ public class JsonUtils {
         array1.forEach(set1::add);
         array2.forEach(set2::add);
         return set1.equals(set2);
+    }
+
+    private static String prettyPrint(String uglyJson) {
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        JsonElement jsonElement = JsonParser.parseString(uglyJson);
+        return gson.toJson(jsonElement);
     }
 }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/github/GHServiceTest.java
@@ -115,6 +115,20 @@ public class GHServiceTest {
     }
 
     @Test
+    public void shouldGetMetadataRepository() throws Exception {
+
+        // Mock
+        GHRepository mock = Mockito.mock(GHRepository.class);
+        doReturn(mock).when(github).getRepository(eq("Raunak80Madan/metadata-plugin-modernizer"));
+
+        // Test
+        GHRepository repository = service.getMetadataRepository(plugin);
+
+        // Verify
+        assertSame(mock, repository);
+    }
+
+    @Test
     public void shouldFailToGetRepository() throws Exception {
 
         // Mock
@@ -124,6 +138,18 @@ public class GHServiceTest {
         // Test
         assertThrows(PluginProcessingException.class, () -> {
             service.getRepository(plugin);
+        });
+    }
+
+    @Test
+    public void shouldFailToGetMetadataRepository() throws Exception {
+
+        // Mock
+        doThrow(new IOException()).when(github).getRepository(eq("Raunak80Madan/metadata-plugin-modernizer"));
+
+        // Test
+        assertThrows(PluginProcessingException.class, () -> {
+            service.getMetadataRepository(plugin);
         });
     }
 
@@ -143,6 +169,20 @@ public class GHServiceTest {
         assertSame(mock, repository);
     }
 
+    public void shouldGetMetadataRepositoryFork() throws Exception {
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        GHRepository mock = Mockito.mock(GHRepository.class);
+        doReturn(mock).when(github).getRepository(eq("fake-owner/metadata-plugin-modernizer"));
+
+        // Test
+        GHRepository repository = service.getMetadataRepositoryFork(plugin);
+
+        // Verify
+        assertSame(mock, repository);
+    }
+
     @Test
     public void shouldFailToGetForkRepository() throws Exception {
 
@@ -154,6 +194,19 @@ public class GHServiceTest {
         // Test
         assertThrows(PluginProcessingException.class, () -> {
             service.getRepositoryFork(plugin);
+        });
+    }
+
+    @Test
+    public void shouldFailToGetForkMetadataRepository() throws Exception {
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        doThrow(new IOException()).when(github).getRepository(eq("fake-owner/metadata-plugin-modernizer"));
+
+        // Test
+        assertThrows(PluginProcessingException.class, () -> {
+            service.getMetadataRepositoryFork(plugin);
         });
     }
 
@@ -202,6 +255,22 @@ public class GHServiceTest {
     }
 
     @Test
+    public void isForkedMetadataTest() throws Exception {
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        doReturn(null).when(config).getGithubAppId();
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHMyself myself = Mockito.mock(GHMyself.class);
+
+        doReturn(myself).when(github).getMyself();
+        doReturn(fork).when(myself).getRepository(eq("metadata-plugin-modernizer"));
+
+        // Test and verify
+        assertTrue(service.isForkedMetadata(plugin));
+    }
+
+    @Test
     public void isNotForkedTest() throws Exception {
 
         // Mock
@@ -218,6 +287,21 @@ public class GHServiceTest {
     }
 
     @Test
+    public void isNotForkedMetadataTest() throws Exception {
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        doReturn(null).when(config).getGithubAppId();
+        GHMyself myself = Mockito.mock(GHMyself.class);
+
+        doReturn(myself).when(github).getMyself();
+        doReturn(null).when(myself).getRepository(eq("metadata-plugin-modernizer"));
+
+        // Test and verify
+        assertFalse(service.isForkedMetadata(plugin));
+    }
+
+    @Test
     public void isForkedToOrganisation() throws Exception {
 
         // Mock
@@ -231,6 +315,21 @@ public class GHServiceTest {
 
         // Test and verify
         assertTrue(service.isForked(plugin));
+    }
+
+    @Test
+    public void isForkedMetadataToOrganisation() throws Exception {
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHOrganization org = Mockito.mock(GHOrganization.class);
+
+        doReturn(org).when(github).getOrganization(eq("fake-owner"));
+        doReturn(fork).when(org).getRepository(eq("metadata-plugin-modernizer"));
+
+        // Test and verify
+        assertTrue(service.isForkedMetadata(plugin));
     }
 
     @Test
@@ -289,6 +388,34 @@ public class GHServiceTest {
     }
 
     @Test
+    public void shouldForkMetadataRepoToMyself() throws Exception {
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHMyself myself = Mockito.mock(GHMyself.class);
+        GHRepositoryForkBuilder builder = Mockito.mock(GHRepositoryForkBuilder.class);
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        doReturn(null).when(config).getGithubAppId();
+        doReturn("metadata-plugin-modernizer").when(repository).getName();
+        doReturn(Mockito.mock(URL.class)).when(fork).getHtmlUrl();
+        doReturn(repository).when(plugin).getRemoteMetadataRepository(eq(service));
+        doReturn(myself).when(github).getMyself();
+        doReturn(builder).when(repository).createFork();
+        doReturn(fork).when(builder).create();
+
+        // Not yet forked
+        doReturn(null).when(myself).getRepository(eq("metadata-plugin-modernizer"));
+
+        // Test
+        service.forkMetadata(plugin);
+
+        // Verify
+        verify(repository, times(1)).createFork();
+    }
+
+    @Test
     public void shouldReturnForkWhenAlreadyForkedToMyself() throws Exception {
 
         GHRepository repository = Mockito.mock(GHRepository.class);
@@ -320,6 +447,34 @@ public class GHServiceTest {
     }
 
     @Test
+    public void shouldReturnMetadataForkWhenAlreadyForkedToMyself() throws Exception {
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHMyself myself = Mockito.mock(GHMyself.class);
+        GHRepositoryForkBuilder builder = Mockito.mock(GHRepositoryForkBuilder.class);
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        doReturn(null).when(config).getGithubAppId();
+        doReturn(repository).when(fork).getParent();
+        doReturn("metadata-plugin-modernizer").when(repository).getName();
+        doReturn(Mockito.mock(URL.class)).when(fork).getHtmlUrl();
+        doReturn(repository).when(plugin).getRemoteMetadataRepository(eq(service));
+        doReturn(myself).when(github).getMyself();
+
+        // Already forked
+        doReturn(fork).when(myself).getRepository(eq("metadata-plugin-modernizer"));
+
+        // Test
+        service.forkMetadata(plugin);
+
+        // Verify
+        verify(repository, times(0)).createFork();
+        verify(myself, times(2)).getRepository(eq("metadata-plugin-modernizer"));
+    }
+
+    @Test
     public void shouldFailToGetForkWhenAlreadyForkedFromOtherSource() throws Exception {
 
         GHRepository repository = Mockito.mock(GHRepository.class);
@@ -340,6 +495,30 @@ public class GHServiceTest {
 
         assertThrows(PluginProcessingException.class, () -> {
             service.fork(plugin);
+        });
+    }
+
+    @Test
+    public void shouldFailToGetMetadataForkWhenAlreadyForkedFromOtherSource() throws Exception {
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHRepository other = Mockito.mock(GHRepository.class);
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHMyself myself = Mockito.mock(GHMyself.class);
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        doReturn(null).when(config).getGithubAppId();
+        doReturn(other).when(fork).getParent();
+        doReturn("metadata-plugin-modernizer").when(repository).getName();
+        doReturn(repository).when(plugin).getRemoteMetadataRepository(eq(service));
+        doReturn(myself).when(github).getMyself();
+
+        // Already forked
+        doReturn(fork).when(myself).getRepository(eq("metadata-plugin-modernizer"));
+
+        assertThrows(PluginProcessingException.class, () -> {
+            service.forkMetadata(plugin);
         });
     }
 
@@ -375,6 +554,34 @@ public class GHServiceTest {
     }
 
     @Test
+    public void shouldForkMetadataRepoToOrganisation() throws Exception {
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHOrganization org = Mockito.mock(GHOrganization.class);
+        GHRepositoryForkBuilder builder = Mockito.mock(GHRepositoryForkBuilder.class);
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        doReturn("metadata-plugin-modernizer").when(repository).getName();
+        doReturn(Mockito.mock(URL.class)).when(fork).getHtmlUrl();
+        doReturn(repository).when(plugin).getRemoteMetadataRepository(eq(service));
+        doReturn(org).when(github).getOrganization("fake-owner");
+        doReturn(builder).when(repository).createFork();
+        doReturn(builder).when(builder).organization(eq(org));
+        doReturn(fork).when(builder).create();
+
+        // Not yet forked
+        doReturn(null).when(org).getRepository(eq("metadata-plugin-modernizer"));
+
+        // Test
+        service.forkMetadata(plugin);
+
+        // Verify
+        verify(repository, times(1)).createFork();
+    }
+
+    @Test
     public void shouldReturnForkWhenAlreadyForkedToOrganisation() throws Exception {
 
         GHRepository repository = Mockito.mock(GHRepository.class);
@@ -404,6 +611,32 @@ public class GHServiceTest {
     }
 
     @Test
+    public void shouldReturnMetadataForkWhenAlreadyForkedToOrganisation() throws Exception {
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHOrganization org = Mockito.mock(GHOrganization.class);
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        doReturn(repository).when(fork).getParent();
+        doReturn("metadata-plugin-modernizer").when(repository).getName();
+        doReturn(Mockito.mock(URL.class)).when(fork).getHtmlUrl();
+        doReturn(repository).when(plugin).getRemoteMetadataRepository(eq(service));
+        doReturn(org).when(github).getOrganization("fake-owner");
+
+        // Already forked to org
+        doReturn(fork).when(org).getRepository(eq("metadata-plugin-modernizer"));
+
+        // Test
+        service.forkMetadata(plugin);
+
+        // Verify
+        verify(repository, times(0)).createFork();
+        verify(org, times(2)).getRepository(eq("metadata-plugin-modernizer"));
+    }
+
+    @Test
     public void shouldFailtToGetForkWhenAlreadyForkedToOrganisationOfOtherSource() throws Exception {
 
         GHRepository repository = Mockito.mock(GHRepository.class);
@@ -424,6 +657,30 @@ public class GHServiceTest {
         // Test
         assertThrows(PluginProcessingException.class, () -> {
             service.fork(plugin);
+        });
+    }
+
+    @Test
+    public void shouldFailtToGetMetadataForkWhenAlreadyForkedToOrganisationOfOtherSource() throws Exception {
+
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHRepository other = Mockito.mock(GHRepository.class);
+        GHRepository fork = Mockito.mock(GHRepository.class);
+        GHOrganization org = Mockito.mock(GHOrganization.class);
+
+        // Mock
+        doReturn("fake-owner").when(config).getGithubOwner();
+        doReturn(other).when(fork).getParent();
+        doReturn("metadata-plugin-modernizer").when(repository).getName();
+        doReturn(repository).when(plugin).getRemoteMetadataRepository(eq(service));
+        doReturn(org).when(github).getOrganization("fake-owner");
+
+        // Already forked to org
+        doReturn(fork).when(org).getRepository(eq("metadata-plugin-modernizer"));
+
+        // Test
+        assertThrows(PluginProcessingException.class, () -> {
+            service.forkMetadata(plugin);
         });
     }
 
@@ -652,6 +909,43 @@ public class GHServiceTest {
     }
 
     @Test
+    public void shouldSshFetchOriginalMetadataRepoInDryRunModeToNewFolder() throws Exception {
+
+        // Mock
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        Git git = Mockito.mock(Git.class);
+        CloneCommand cloneCommand = Mockito.mock(CloneCommand.class);
+
+        // Use SSH key auth
+        Field field = ReflectionUtils.findFields(
+                        GHService.class,
+                        f -> f.getName().equals("sshKeyAuth"),
+                        ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
+                .get(0);
+        field.setAccessible(true);
+        field.set(service, true);
+
+        doReturn(repository).when(github).getRepository(eq("Raunak80Madan/metadata-plugin-modernizer"));
+        doReturn(git).when(cloneCommand).call();
+        doReturn("fake-url").when(repository).getSshUrl();
+        doReturn(cloneCommand).when(cloneCommand).setRemote(eq("origin"));
+        doReturn(cloneCommand).when(cloneCommand).setURI(eq("ssh:///fake-url"));
+        doReturn(cloneCommand).when(cloneCommand).setCredentialsProvider(any(CredentialsProvider.class));
+        doReturn(cloneCommand).when(cloneCommand).setDirectory(any(File.class));
+
+        // Directory doesn't exists
+        doReturn(Path.of("not-existing-dir")).when(plugin).getLocalMetadataRepository();
+
+        // Test
+        try (MockedStatic<Git> mockStaticGit = mockStatic(Git.class)) {
+            mockStaticGit.when(Git::cloneRepository).thenReturn(cloneCommand);
+            service.fetchMetadata(plugin);
+            verify(cloneCommand, times(1)).call();
+            verifyNoMoreInteractions(cloneCommand);
+        }
+    }
+
+    @Test
     public void shouldHttpFetchOriginalRepoInDryRunModeToNewFolder() throws Exception {
 
         // Mock
@@ -675,6 +969,34 @@ public class GHServiceTest {
         try (MockedStatic<Git> mockStaticGit = mockStatic(Git.class)) {
             mockStaticGit.when(Git::cloneRepository).thenReturn(cloneCommand);
             service.fetch(plugin);
+            verify(cloneCommand, times(1)).call();
+            verifyNoMoreInteractions(cloneCommand);
+        }
+    }
+
+    @Test
+    public void shouldHttpFetchOriginalMetadataRepoInDryRunModeToNewFolder() throws Exception {
+
+        // Mock
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        Git git = Mockito.mock(Git.class);
+        CloneCommand cloneCommand = Mockito.mock(CloneCommand.class);
+
+        doReturn(repository).when(github).getRepository(eq("Raunak80Madan/metadata-plugin-modernizer"));
+        doReturn(git).when(cloneCommand).call();
+        doReturn("fake-url").when(repository).getHttpTransportUrl();
+        doReturn(cloneCommand).when(cloneCommand).setRemote(eq("origin"));
+        doReturn(cloneCommand).when(cloneCommand).setURI(eq("fake-url"));
+        doReturn(cloneCommand).when(cloneCommand).setCredentialsProvider(any(CredentialsProvider.class));
+        doReturn(cloneCommand).when(cloneCommand).setDirectory(any(File.class));
+
+        // Directory doesn't exists
+        doReturn(Path.of("not-existing-dir")).when(plugin).getLocalMetadataRepository();
+
+        // Test
+        try (MockedStatic<Git> mockStaticGit = mockStatic(Git.class)) {
+            mockStaticGit.when(Git::cloneRepository).thenReturn(cloneCommand);
+            service.fetchMetadata(plugin);
             verify(cloneCommand, times(1)).call();
             verifyNoMoreInteractions(cloneCommand);
         }
@@ -794,6 +1116,34 @@ public class GHServiceTest {
     }
 
     @Test
+    public void shouldOpenMetadataPullRequest() throws Exception {
+
+        // Mocks
+        Recipe recipe = Mockito.mock(Recipe.class);
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHPullRequest pr = Mockito.mock(GHPullRequest.class);
+        GHPullRequestQueryBuilder prQuery = Mockito.mock(GHPullRequestQueryBuilder.class);
+        PagedIterable<?> prQueryList = Mockito.mock(PagedIterable.class);
+
+        doReturn("test").when(config).getGithubOwner();
+        doReturn("example").when(plugin).getName();
+        doReturn(null).when(config).getGithubAppTargetInstallationId();
+        doReturn(true).when(plugin).hasMetadataChangesPushed();
+        doReturn(repository).when(plugin).getRemoteMetadataRepository(eq(service));
+
+        // Return just one PR to deleete
+        doReturn(prQuery).when(repository).queryPullRequests();
+        doReturn(prQuery).when(prQuery).state(eq(GHIssueState.OPEN));
+        doReturn(prQueryList).when(prQuery).list();
+
+        doReturn(pr).when(repository).createPullRequest(anyString(), anyString(), isNull(), anyString(), eq(true));
+
+        // Test
+        service.openMetadataPullRequest(plugin);
+        verify(repository).createPullRequest(anyString(), anyString(), isNull(), anyString(), eq(true));
+    }
+
+    @Test
     public void shouldUpdatePullRequest() throws Exception {
 
         // Mocks
@@ -838,6 +1188,43 @@ public class GHServiceTest {
         // We don't open a PR
         verify(repository, never())
                 .createPullRequest(anyString(), anyString(), isNull(), anyString(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    public void shouldUpdateMetadataPullRequest() throws Exception {
+
+        // Mocks
+        Recipe recipe = Mockito.mock(Recipe.class);
+        GHRepository repository = Mockito.mock(GHRepository.class);
+        GHPullRequest existingPr = Mockito.mock(GHPullRequest.class);
+        GHPullRequest toDeletePr = Mockito.mock(GHPullRequest.class);
+        GHPullRequestQueryBuilder prQuery = Mockito.mock(GHPullRequestQueryBuilder.class);
+        PagedIterable<?> prQueryList = Mockito.mock(PagedIterable.class);
+        GHCommitPointer head = Mockito.mock(GHCommitPointer.class);
+        GHCommitPointer toDeleteHead = Mockito.mock(GHCommitPointer.class);
+
+        doReturn(null).when(config).getGithubAppTargetInstallationId();
+        doReturn("example").when(plugin).getName();
+        doReturn(true).when(plugin).hasMetadataChangesPushed();
+        doReturn(repository).when(plugin).getRemoteMetadataRepository(eq(service));
+        doReturn("example-modernization-metadata").when(head).getRef();
+        doReturn(head).when(existingPr).getHead();
+
+        // Return one open PR that match the branch name
+        doReturn(prQuery).when(repository).queryPullRequests();
+        doReturn(prQuery).when(prQuery).state(eq(GHIssueState.OPEN));
+        doReturn(prQueryList).when(prQuery).list();
+        doReturn(List.of(existingPr, toDeletePr)).when(prQueryList).toList();
+
+        // Test
+        service.openMetadataPullRequest(plugin);
+
+        // We update a PR
+        verify(existingPr, times(1)).setTitle(anyString());
+        verify(existingPr, times(1)).setBody(anyString());
+
+        // We don't open a PR
+        verify(repository, never()).createPullRequest(anyString(), anyString(), isNull(), anyString(), anyBoolean());
     }
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/PluginTest.java
@@ -93,6 +93,16 @@ public class PluginTest {
     }
 
     @Test
+    public void testHasMetadataCommits() {
+        Plugin plugin = Plugin.build("example");
+        assertFalse(plugin.hasMetadataCommits());
+        plugin.withMetadataCommits();
+        assertTrue(plugin.hasMetadataCommits());
+        plugin.withoutMetadataCommits();
+        assertFalse(plugin.hasMetadataCommits());
+    }
+
+    @Test
     public void testClean() {
         Plugin plugin = Plugin.build("example");
         plugin.clean(mavenInvoker);
@@ -175,6 +185,16 @@ public class PluginTest {
     }
 
     @Test
+    public void testForkMetadata() {
+        Plugin plugin = Plugin.build("example");
+        plugin.withConfig(config);
+        doReturn(false).when(config).isFetchMetadataOnly();
+        plugin.forkMetadata(ghService);
+        verify(ghService).forkMetadata(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
     public void shouldNotForkInFetchMetadataMode() {
         Plugin plugin = Plugin.build("example");
         plugin.withConfig(config);
@@ -194,6 +214,16 @@ public class PluginTest {
     }
 
     @Test
+    public void testSyncMetadata() {
+        Plugin plugin = Plugin.build("example");
+        plugin.withConfig(config);
+        doReturn(false).when(config).isFetchMetadataOnly();
+        plugin.syncMetadata(ghService);
+        verify(ghService).syncMetadata(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
     public void shouldNotSyncInFetchMetadataMode() {
         Plugin plugin = Plugin.build("example");
         plugin.withConfig(config);
@@ -207,6 +237,14 @@ public class PluginTest {
         Plugin plugin = Plugin.build("example");
         plugin.isForked(ghService);
         verify(ghService).isForked(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testIsMetadataFork() {
+        Plugin plugin = Plugin.build("example");
+        plugin.isForkedMetadata(ghService);
+        verify(ghService).isForkedMetadata(plugin);
         verifyNoMoreInteractions(ghService);
     }
 
@@ -235,10 +273,26 @@ public class PluginTest {
     }
 
     @Test
+    public void testMetadataCheckoutBranch() {
+        Plugin plugin = Plugin.build("example");
+        plugin.checkoutMetadataBranch(ghService);
+        verify(ghService).checkoutMetadataBranch(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
     public void testCommit() {
         Plugin plugin = Plugin.build("example");
         plugin.commit(ghService);
         verify(ghService).commitChanges(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testMetadataCommit() {
+        Plugin plugin = Plugin.build("example");
+        plugin.commitMetadata(ghService);
+        verify(ghService).commitMetadataChanges(plugin);
         verifyNoMoreInteractions(ghService);
     }
 
@@ -251,10 +305,26 @@ public class PluginTest {
     }
 
     @Test
+    public void testMetadataPush() {
+        Plugin plugin = Plugin.build("example");
+        plugin.pushMetadata(ghService);
+        verify(ghService).pushMetadataChanges(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
     public void testOpenPullRequest() {
         Plugin plugin = Plugin.build("example");
         plugin.openPullRequest(ghService);
         verify(ghService).openPullRequest(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
+    public void testOpenMetadataPullRequest() {
+        Plugin plugin = Plugin.build("example");
+        plugin.openMetadataPullRequest(ghService);
+        verify(ghService).openMetadataPullRequest(plugin);
         verifyNoMoreInteractions(ghService);
     }
 
@@ -267,6 +337,14 @@ public class PluginTest {
     }
 
     @Test
+    public void testFetchMetadata() {
+        Plugin plugin = Plugin.build("example");
+        plugin.fetchMetadata(ghService);
+        verify(ghService).fetchMetadata(plugin);
+        verifyNoMoreInteractions(ghService);
+    }
+
+    @Test
     public void testGetRemoteRepository() {
         Plugin plugin = Plugin.build("example");
         plugin.withRepositoryName("repo-name");
@@ -275,11 +353,25 @@ public class PluginTest {
     }
 
     @Test
+    public void testGetRemoteMetadataRepository() {
+        Plugin plugin = Plugin.build("example");
+        plugin.getRemoteMetadataRepository(ghService);
+        verify(ghService).getMetadataRepository(plugin);
+    }
+
+    @Test
     public void testGetRemoteForkRepository() {
         Plugin plugin = Plugin.build("example");
         plugin.withRepositoryName("repo-name");
         plugin.getRemoteForkRepository(ghService);
         verify(ghService).getRepositoryFork(plugin);
+    }
+
+    @Test
+    public void testGetRemoteMetadataForkRepository() {
+        Plugin plugin = Plugin.build("example");
+        plugin.getRemoteMetadataForkRepository(ghService);
+        verify(ghService).getMetadataRepositoryFork(plugin);
     }
 
     @Test


### PR DESCRIPTION
#1046 
Current workings after the changes:
- Initialize git with the local plugin directory where all the metadata is stored locally.
- After running the recipe, collect the modernization metadata and push it. Currently for testing I am pushing it to https://github.com/CodexRaunak/metadata-plugin-modernizer-tool.
- Make a PR with title and body to the repo.

Current Problems:
- It's also committing and pushing empty changes.
- We are not forking the repo, rather just checking out branch and make a PR to the original.
I am working on these 2 issues.

Also when the metadata is pushed, it is not formated and looks like:
![image](https://github.com/user-attachments/assets/d6cbea46-68cf-44d2-b4c8-7ea8663c8e68)

After these changes now we have separate methods for interacting with git in `GHService` class, one to interact with the plugin and one to interact with the `metadata repo`. For example like `openPullRequest()` for plugin and `openMetadataPullRequest()` for `metadata repo`.
This may cause some duplicity, but we can see as we progress to keep it separate or use a single method for both by passing some params.
For now maybe keep it separate and see where this thing can go to make changes easily.

Any feedbacks or suggestions are welcomed
Thank You 

### Testing done
Able to open PR at https://github.com/CodexRaunak/metadata-plugin-modernizer-tool. 
Need to add test coverage in the tool.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
