### PR TITLE
Ignore the URL to check for http when a placeholder is used 

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 /**
  * Enum to represent the precondition errors preventing any modernization process
@@ -121,11 +122,19 @@ public enum PreconditionError {
                     return false;
                 }
                 try {
-                    Double nonHttpsRepositories = (Double) xpath.evaluate(
-                            "count(//*[local-name()='project']/*[local-name()='repositories']/*[local-name()='repository']/*[local-name()='url' and not(starts-with(., 'https'))])",
+                    NodeList repositoryUrls = (NodeList) xpath.evaluate(
+                            "//*[local-name()='project']/*[local-name()='repositories']/*[local-name()='repository']/*[local-name()='url']",
                             document,
-                            XPathConstants.NUMBER);
-                    return nonHttpsRepositories != null && !nonHttpsRepositories.equals(0.0);
+                            XPathConstants.NODESET);
+
+                    int nonHttpsCount = 0;
+                    for (int i = 0; i < repositoryUrls.getLength(); i++) {
+                        String url = repositoryUrls.item(i).getTextContent().trim();
+                        if (!url.startsWith("https") && !url.startsWith("${")) {
+                            nonHttpsCount++;
+                        }
+                    }
+                    return nonHttpsCount > 0;
                 } catch (Exception e) {
                     return false;
                 }


### PR DESCRIPTION
#1072 

The issue initially happening was even after remediation of the plugin from `http` to `https` it still returns precondition error.
Upon printing the logs I found 
```
Non-HTTPS repositories count: 1.0
Non-HTTPS repository URL found: ${repoReleaseArtifactoryUrl}
```
In the [pom.xml](https://github.com/jenkinsci/blackduck-security-scan-plugin/blob/main/pom.xml#L157-L160) we have
```
<repository>
      <id>bds-artifactory</id>
      <url>${repoReleaseArtifactoryUrl}</url>
</repository>

```
This was being count as a `non https url` in the logic of `isApplicable` for `MAVEN_REPOSITORIES_HTTP`.

I just modified it to ignore when a placeholder is being used like `${}`.

### Testing done
`mvn clean install`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue