### PR TITLE
Use 2.579.x for recommended jenkins version

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -156,7 +156,7 @@ recipeList:
   - org.openrewrite.jenkins.github.AddTeamToCodeowners
 ---
 type: specs.openrewrite.org/v1beta/recipe
-name: io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
+name: io.jenkins.tools.pluginmodernizer.UpgradeParent4Version
 displayName: Upgrade parent version to latest available in the 4.x line
 description: Upgrade the parent version to latest available in the 4.x line.
 tags: ['dependencies']
@@ -168,6 +168,18 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.UpgradeParent5Version
+displayName: Upgrade parent version to latest available in the 5.x line
+description: Upgrade the parent version to latest available in the 5.x line.
+tags: ['dependencies']
+recipeList:
+  - org.openrewrite.maven.UpgradeParentVersion:
+      groupId: org.jenkins-ci.plugins
+      artifactId: plugin
+      newVersion: 5.X
+  - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeNextMajorParentVersion
 displayName: Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17
 description: Upgrade to the next major parent version (5.X) requiring Jenkins 2.492 and Java 17.
@@ -176,10 +188,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.EnsureRelativePath
   - io.jenkins.tools.pluginmodernizer.EnsureIndexJelly
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpdateScmUrl
-  - org.openrewrite.maven.UpgradeParentVersion:
-      groupId: org.jenkins-ci.plugins
-      artifactId: plugin
-      newVersion: 5.X
+  - io.jenkins.tools.pluginmodernizer.UpgradeParent5Version
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: 2.492.3
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
@@ -462,19 +471,24 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.EnsureRelativePath
   - io.jenkins.tools.pluginmodernizer.EnsureIndexJelly
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpdateScmUrl
-  - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
+  - io.jenkins.tools.pluginmodernizer.UpgradeParent5Version
   - io.jenkins.tools.pluginmodernizer.AddPluginsBom
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: ${jenkins.core.minimum.version}
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsTestHarnessVersion:
       jenkinsVersion: ${jenkins.core.minimum.version}
+  - org.openrewrite.java.ChangePackage:  #deprecating
+      oldPackageName: com.gargoylesoftware.htmlunit
+      newPackageName: org.htmlunit
+      recursive: true
+  - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
+  - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateAcegiSecurityToSpringSecurity
+  - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
+  - io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
   - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
-  - io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
-  - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
-  - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
   - io.jenkins.tools.pluginmodernizer.SetupJenkinsfile
 ---
 type: specs.openrewrite.org/v1beta/recipe
@@ -486,7 +500,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.EnsureRelativePath
   - io.jenkins.tools.pluginmodernizer.EnsureIndexJelly
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpdateScmUrl
-  - io.jenkins.tools.pluginmodernizer.UpgradeParentVersion
+  - io.jenkins.tools.pluginmodernizer.UpgradeParent4Version
   - io.jenkins.tools.pluginmodernizer.AddPluginsBom
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
       minimumVersion: 2.462.3

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -62,23 +62,6 @@ public class DeclarativeRecipesTest implements RewriteTest {
             )""";
 
     @Language("groovy")
-    // For example 2.401 was not supporting yet officially Java 21
-    private static final String NO_JAVA_21_SUPPORT_JENKINSFILE =
-            """
-            /*
-            See the documentation for more options:
-            https://github.com/jenkins-infra/pipeline-library/
-            */
-            buildPlugin(
-                forkCount: '1C', // Run a JVM per core in tests
-                useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
-                configurations: [
-                    [platform: 'linux', jdk: 17],
-                    [platform: 'windows', jdk: 11]
-                ]
-            )""";
-
-    @Language("groovy")
     private static final String JAVA_8_JENKINS_FILE =
             """
             /*
@@ -203,7 +186,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
     void upgradeParentpom() {
         rewriteRun(
                 spec -> spec.recipeFromResource(
-                        "/META-INF/rewrite/recipes.yml", "io.jenkins.tools.pluginmodernizer.UpgradeParentVersion"),
+                        "/META-INF/rewrite/recipes.yml", "io.jenkins.tools.pluginmodernizer.UpgradeParent4Version"),
                 // language=xml
                 pomXml(
                         """
@@ -680,7 +663,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.87</version>
+                            <version>5.1</version>
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
                           <artifactId>empty</artifactId>
@@ -699,7 +682,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           </scm>
                           <properties>
                             <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
-                            <jenkins.version>2.440.3</jenkins.version>
+                            <jenkins.version>2.479.1</jenkins.version>
                           </properties>
                           <dependencies>
                             <dependency>
@@ -740,7 +723,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.88</version>
+                            <version>%s</version>
                             <relativePath/>
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
@@ -799,6 +782,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                         </project>
                         """
                                 .formatted(
+                                        Settings.getJenkinsParentVersion(),
                                         Settings.getJenkinsMinimumBaseline(),
                                         Settings.getJenkinsMinimumPatchVersion(),
                                         Settings.getRecommendedBomVersion(),
@@ -923,7 +907,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.88</version>
+                            <version>%s</version>
                             <relativePath />
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
@@ -952,7 +936,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           </pluginRepositories>
                         </project>
                         """
-                                .formatted(Settings.getJenkinsMinimumVersion())));
+                                .formatted(Settings.getJenkinsParentVersion(), Settings.getJenkinsMinimumVersion())));
     }
 
     @Test
@@ -1038,7 +1022,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                           <parent>
                             <groupId>org.jenkins-ci.plugins</groupId>
                             <artifactId>plugin</artifactId>
-                            <version>4.88</version>
+                            <version>%s</version>
                             <relativePath />
                           </parent>
                           <groupId>io.jenkins.plugins</groupId>
@@ -1084,6 +1068,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                         </project>
                         """
                                 .formatted(
+                                        Settings.getJenkinsParentVersion(),
                                         Settings.getJenkinsMinimumBaseline(),
                                         Settings.getJenkinsMinimumPatchVersion(),
                                         Settings.getRecommendedBomVersion())));
@@ -1106,7 +1091,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                 // language=groovy
                 groovy(
                         null,
-                        NO_JAVA_21_SUPPORT_JENKINSFILE,
+                        EXPECTED_MODERN_JENKINSFILE,
                         s -> s.path(ArchetypeCommonFile.JENKINSFILE.getPath().getFileName())),
                 // language=xml
                 pomXml(
@@ -1117,7 +1102,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <parent>
                         <groupId>org.jenkins-ci.plugins</groupId>
                         <artifactId>plugin</artifactId>
-                        <version>4.88</version>
+                        <version>5.1</version>
                         <relativePath />
                       </parent>
                       <artifactId>empty</artifactId>
@@ -1135,7 +1120,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                         <jenkins-test-harness.version>2.41.1</jenkins-test-harness.version>
                         <revision>2.17.0</revision>
                         <changelist>999999-SNAPSHOT</changelist>
-                        <jenkins.version>2.401.3</jenkins.version>
+                        <jenkins.version>2.479.1</jenkins.version>
                       </properties>
                       <repositories>
                         <repository>
@@ -1197,7 +1182,7 @@ public class DeclarativeRecipesTest implements RewriteTest {
                       <parent>
                         <groupId>org.jenkins-ci.plugins</groupId>
                         <artifactId>plugin</artifactId>
-                        <version>4.88</version>
+                        <version>5.17</version>
                         <relativePath />
                       </parent>
                       <artifactId>empty</artifactId>


### PR DESCRIPTION
Fix : https://github.com/jenkins-infra/plugin-modernizer-tool/issues/1059

Impartially fixed on https://github.com/jenkins-infra/plugin-modernizer-tool/pull/1090 since the parent was no updated to 5.x

### Testing done

mvn clean install

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
