### PR TITLE
Track migrationStatus in metadata

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/ModernizationMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/ModernizationMetadata.java
@@ -61,6 +61,11 @@ public class ModernizationMetadata extends CacheEntry<ModernizationMetadata> {
     private String migrationId;
 
     /**
+     * Status of migration (success or fail)
+     */
+    private String migrationStatus;
+
+    /**
      * Number of deprecated APIs removed by the migration
      */
     private Integer removedDeprecatedApis;
@@ -153,6 +158,7 @@ public class ModernizationMetadata extends CacheEntry<ModernizationMetadata> {
         requiredFields.put("rpuBaseline", rpuBaseline);
         requiredFields.put("migrationName", migrationName);
         requiredFields.put("migrationDescription", migrationDescription);
+        requiredFields.put("migrationStatus", migrationStatus);
         requiredFields.put("tags", (tags != null && !tags.isEmpty()) ? tags : null);
         requiredFields.put("migrationId", migrationId);
         requiredFields.put("dryRun", dryRun);
@@ -227,6 +233,14 @@ public class ModernizationMetadata extends CacheEntry<ModernizationMetadata> {
 
     public void setMigrationId(String migrationId) {
         this.migrationId = migrationId;
+    }
+
+    public String getMigrationStatus() {
+        return migrationStatus;
+    }
+
+    public void setMigrationStatus(String migrationStatus) {
+        this.migrationStatus = migrationStatus;
     }
 
     public String getRpuBaseline() {


### PR DESCRIPTION
#1039 continue 
- Add `migrationStatus` field which computes `success` or `failure`  accordingly if the plugin has any `errors` or `precondition errors`.
- Move the metadata collection and pushing to the `finally` block.
- Make `migrationStatus` as a required field in validation
### Testing done
`mvn clean install` 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
