### PR TITLE
skip-metadata option to opt out for metadata feature 

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,9 @@ source <(plugin-modernizer generate-completion)
 - `--recipe` or `-r`: (required) Name of recipe to apply to the plugins.
 
 
+- `--skip-metadata` (optional) Skip collection and pushing the modernization metadata (i.e metadata after applying the recipes) to the metadata repository. Beneficial for testing or development purpose when we don't need to unnecessary add another step of collecting the metadata.
+
+
 - `--clean-forks` (optional) Remove forked repositories before and after the modernization process. Might cause data loss if you have other changes pushed on those forks. Forks with open pull request targeting original repo are not removed to prevent closing unmerged pull requests.
 
 

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
@@ -42,6 +42,14 @@ public class DryRunCommand implements ICommand {
     private Recipe recipe;
 
     /**
+     * Skip modernization metadata
+     */
+    @CommandLine.Option(
+            names = {"--skip-metadata"},
+            description = "Disable collection and pushing of modernization metadata")
+    private boolean skipMetadata;
+
+    /**
      * Environment options
      */
     @CommandLine.Mixin
@@ -68,7 +76,10 @@ public class DryRunCommand implements ICommand {
         pluginOptions.config(builder);
         githubOptions.config(builder);
         envOptions.config(builder);
-        return builder.withDryRun(true).withRecipe(recipe).build();
+        return builder.withDryRun(true)
+                .withRecipe(recipe)
+                .withSkipMetadata(skipMetadata)
+                .build();
     }
 
     @Override

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
@@ -53,6 +53,14 @@ public class RunCommand implements ICommand {
     public boolean removeForks;
 
     /**
+     * Skip modernization metadata
+     */
+    @CommandLine.Option(
+            names = {"--skip-metadata"},
+            description = "Disable collection and pushing of modernization metadata")
+    private boolean skipMetadata;
+
+    /**
      * Environment options
      */
     @CommandLine.Mixin
@@ -82,6 +90,7 @@ public class RunCommand implements ICommand {
         return builder.withRecipe(recipe)
                 .withDraft(draft)
                 .withRemoveForks(removeForks)
+                .withSkipMetadata(skipMetadata)
                 .build();
     }
 

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -25,6 +25,7 @@ public class Config {
     private final Path cachePath;
     private final Path mavenHome;
     private final Path mavenLocalRepo;
+    private final boolean skipMetadata;
     private final boolean dryRun;
     private final boolean draft;
     private final boolean removeForks;
@@ -51,6 +52,7 @@ public class Config {
             Path cachePath,
             Path mavenHome,
             Path mavenLocalRepo,
+            boolean skipMetadata,
             boolean dryRun,
             boolean draft,
             boolean removeForks) {
@@ -70,6 +72,7 @@ public class Config {
         this.cachePath = cachePath;
         this.mavenHome = mavenHome;
         this.mavenLocalRepo = mavenLocalRepo;
+        this.skipMetadata = skipMetadata;
         this.dryRun = dryRun;
         this.draft = draft;
         this.removeForks = removeForks;
@@ -161,6 +164,10 @@ public class Config {
         return mavenLocalRepo.toAbsolutePath();
     }
 
+    public boolean isSkipMetadata() {
+        return skipMetadata;
+    }
+
     public boolean isDryRun() {
         return dryRun;
     }
@@ -198,6 +205,7 @@ public class Config {
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
         private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
         private Path mavenLocalRepo = Settings.DEFAULT_MAVEN_LOCAL_REPO;
+        private boolean skipMetadata = false;
         private boolean dryRun = false;
         private boolean draft = false;
         public boolean removeForks = false;
@@ -298,6 +306,11 @@ public class Config {
             return this;
         }
 
+        public Builder withSkipMetadata(boolean skipMetadata) {
+            this.skipMetadata = skipMetadata;
+            return this;
+        }
+
         public Builder withDryRun(boolean dryRun) {
             this.dryRun = dryRun;
             return this;
@@ -331,6 +344,7 @@ public class Config {
                     cachePath,
                     mavenHome,
                     mavenLocalRepo,
+                    skipMetadata,
                     dryRun,
                     draft,
                     removeForks);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -401,6 +401,10 @@ public class GHService {
      * @param plugin The plugin to fork
      */
     public void forkMetadata(Plugin plugin) {
+        if (config.isDryRun()) {
+            LOG.info("Skipping forking metadata {} in dry-run mode", plugin);
+            return;
+        }
         if (plugin.isLocal()) {
             LOG.info("Plugin {} is local. Not forking metadata repo", plugin);
             return;
@@ -661,6 +665,10 @@ public class GHService {
      * @param plugin The plugin to sync
      */
     public void syncMetadata(Plugin plugin) {
+        if (config.isDryRun()) {
+            LOG.info("Skipping sync metadata {} in dry-run mode", plugin);
+            return;
+        }
         if (plugin.isLocal()) {
             LOG.info("Plugin {} is local. Not syncing metadata repo", plugin);
             return;
@@ -784,6 +792,10 @@ public class GHService {
      * @param plugin The plugin
      */
     public void fetchMetadata(Plugin plugin) {
+        if (config.isDryRun()) {
+            LOG.info("Skipping metadata fetch for plugin {} in dry-run mode", plugin);
+            return;
+        }
         if (plugin.isLocal()) {
             LOG.info("Skipping metadata fetch for plugin {} as its local", plugin);
             return;
@@ -1165,6 +1177,10 @@ public class GHService {
      * @param plugin The plugin to commit changes for
      */
     public void commitMetadataChanges(Plugin plugin) {
+        if (config.isDryRun()) {
+            LOG.info("Skipping commits changes for metadata {} in dry-run mode", plugin);
+            return;
+        }
         if (plugin.isLocal()) {
             LOG.info("Plugin {} is local. Not committing metadata changes", plugin);
             return;
@@ -1344,6 +1360,10 @@ public class GHService {
      * @param plugin The plugin that have been modernized
      */
     public void pushMetadataChanges(Plugin plugin) {
+        if (config.isDryRun()) {
+            LOG.info("Skipping push changes for metadata {} in dry-run mode", plugin);
+            return;
+        }
         if (config.isFetchMetadataOnly()) {
             LOG.info("Skipping push changes for modernization metadata {} in fetch-metadata-only mode", plugin);
             return;
@@ -1485,6 +1505,11 @@ public class GHService {
             // Render PR title and body
             LOG.debug("Pull request title: {}", prTitle);
             LOG.debug("Pull request body: {}", prBody);
+
+            if (config.isDryRun()) {
+                LOG.info("Skipping pull request changes for metadata {} in dry-run mode", plugin);
+                return;
+            }
 
             if (config.isFetchMetadataOnly()) {
                 LOG.info("Skipping pull request for modernization-metadata {} in fetch-metadata-only mode", plugin);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -379,20 +379,22 @@ public class PluginModernizer {
                 plugin.addError("Unexpected processing error. Check the logs at " + plugin.getLogFile(), e);
             }
         } finally {
-            try {
-                // collect the modernization metadata and push it to metadata repository if valid
-                collectModernizationMetadata(plugin);
-                validateModernizationMetadata(plugin);
-                plugin.fetchMetadata(ghService);
-                plugin.forkMetadata(ghService);
-                plugin.syncMetadata(ghService);
-                plugin.checkoutMetadataBranch(ghService);
-                plugin.copyMetadataToLocalMetadataRepo(cacheManager);
-                plugin.commitMetadata(ghService);
-                plugin.pushMetadata(ghService);
-                plugin.openMetadataPullRequest(ghService);
-            } catch (Exception e) {
-                plugin.addError("Failed to collect modernization metadata for plugin " + plugin.getName(), e);
+            if (!config.isSkipMetadata()) {
+                try {
+                    // collect the modernization metadata and push it to metadata repository if valid
+                    collectModernizationMetadata(plugin);
+                    validateModernizationMetadata(plugin);
+                    plugin.fetchMetadata(ghService);
+                    plugin.forkMetadata(ghService);
+                    plugin.syncMetadata(ghService);
+                    plugin.checkoutMetadataBranch(ghService);
+                    plugin.copyMetadataToLocalMetadataRepo(cacheManager);
+                    plugin.commitMetadata(ghService);
+                    plugin.pushMetadata(ghService);
+                    plugin.openMetadataPullRequest(ghService);
+                } catch (Exception e) {
+                    plugin.addError("Failed to collect modernization metadata for plugin " + plugin.getName(), e);
+                }
             }
         }
     }


### PR DESCRIPTION
- Add option `skip-metadata` with `dry run` and normal `run` commands.
- When skip-metadata is true, it disables collection and pushing it to the repo (both). 
- It is beneficial for testing or development purpose when we don't need to unnecessary add another step of collecting the metadata.
- Updated docs for the cli option
### Testing done
`mvn clean install` Also tested the option with `dry run` and normal `run`, and works as expected.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue