### PR TITLE
fix: Ignore Local `file://` Repository URLs in Modernization Precondition Check

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/PreconditionError.java
@@ -130,7 +130,7 @@ public enum PreconditionError {
                     int nonHttpsCount = 0;
                     for (int i = 0; i < repositoryUrls.getLength(); i++) {
                         String url = repositoryUrls.item(i).getTextContent().trim();
-                        if (!url.startsWith("https") && !url.startsWith("${")) {
+                        if (!url.startsWith("https") && !url.startsWith("${") && !url.startsWith("file://")) {
                             nonHttpsCount++;
                         }
                     }


### PR DESCRIPTION
This fixes #1110 .

### Overview

This pull request updates the Maven repository URL precondition logic in `PreconditionError.java` to prevent false positives when local `file://` repositories are present in plugin POM files.

### Details

- The modernization tool previously flagged any repository URL not starting with `https` or `${` as a precondition error, including local `file://` URLs.
- This change updates the check to also ignore URLs starting with `file://`, ensuring only remote, insecure repository URLs are flagged.
- All debug output has been removed from the check for a clean codebase.

### Impact

- Plugins using local file-based repositories (e.g., `file:///${basedir}/src/repository`) will no longer be blocked from modernization.
- Only remote, non-HTTPS repository URLs will trigger the precondition error.

### Motivation

This resolves issues where plugins were incorrectly blocked from modernization due to the presence of local repository definitions, which do not pose a security risk for Maven builds.

---

### Testing done

` java -jar ./plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar run --plugins backup --recipe SetupJenkinsfile`
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
