### PR TITLE
feat: Enable Modernization of Deprecated Plugins via CLI Flag and User Guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ source <(plugin-modernizer generate-completion)
 
 - `--debug`: (optional) Enables debug mode. Defaults to false.
 
+- `--allow-deprecated-plugins`: (optional) **Allow modernization of deprecated plugins.**  
+  _Use with caution: This flag enables modernization and metadata collection for plugins that are marked as deprecated. Intended for new maintainers or development environments only. By default, deprecated plugins are blocked from modernization for safety._
 
 - `--cache-path`: (optional) Custom path to the cache directory. Defaults to `${user.home}/.cache/jenkins-plugin-modernizer-cli`.
 
@@ -296,6 +298,14 @@ plugin-modernizer run --plugin-file path/to/plugin-file --recipe AddPluginsBom
 plugin-modernizer run --plugins git,git-client,jobcacher --recipe AddPluginsBom
 ```
 The above command creates pull requests in the respective remote repositories after applying the changes.
+
+### modernizing a deprecated plugin (for new maintainers)
+
+```shell
+plugin-modernizer run --plugins bmc-change-manager-imstm --recipe AddPluginsBom --allow-deprecated-plugins
+```
+This command will allow modernization and metadata collection for the deprecated plugin `bmc-change-manager-imstm`.  
+**Warning:** Only use `--allow-deprecated-plugins` if you are a maintainer or have a valid reason to modernize a deprecated plugin.
 
 ### with dry-run
 

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/GlobalOptions.java
@@ -41,6 +41,11 @@ public class GlobalOptions implements IOption {
     private boolean debug;
 
     @CommandLine.Option(
+            names = {"--allow-deprecated-plugins"},
+            description = "Allow modernization of deprecated plugins (use with caution).")
+    private boolean allowDeprecatedPlugins = false;
+
+    @CommandLine.Option(
             names = {"--cache-path"},
             description = "Path to the cache directory.")
     private Path cachePath = Settings.DEFAULT_CACHE_PATH;
@@ -67,7 +72,8 @@ public class GlobalOptions implements IOption {
                                 ? cachePath.resolve(Settings.CACHE_SUBDIR)
                                 : cachePath)
                 .withMavenHome(mavenHome)
-                .withMavenLocalRepo(mavenLocalRepo);
+                .withMavenLocalRepo(mavenLocalRepo)
+                .withAllowDeprecatedPlugins(allowDeprecatedPlugins);
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -9,6 +9,7 @@ import java.util.List;
 public class Config {
 
     private static boolean DEBUG = false;
+    private final boolean allowDeprecatedPlugins;
 
     public static void setDebug(boolean debug) {
         DEBUG = debug;
@@ -55,7 +56,8 @@ public class Config {
             boolean skipMetadata,
             boolean dryRun,
             boolean draft,
-            boolean removeForks) {
+            boolean removeForks,
+            boolean allowDeprecatedPlugins) {
         this.version = version;
         this.githubOwner = githubOwner;
         this.githubAppId = githubAppId;
@@ -76,6 +78,7 @@ public class Config {
         this.dryRun = dryRun;
         this.draft = draft;
         this.removeForks = removeForks;
+        this.allowDeprecatedPlugins = allowDeprecatedPlugins;
     }
 
     public String getVersion() {
@@ -184,6 +187,10 @@ public class Config {
         return removeForks;
     }
 
+    public boolean isAllowDeprecatedPlugins() {
+        return allowDeprecatedPlugins;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -209,6 +216,7 @@ public class Config {
         private boolean dryRun = false;
         private boolean draft = false;
         public boolean removeForks = false;
+        private boolean allowDeprecatedPlugins = false;
 
         public Builder withVersion(String version) {
             this.version = version;
@@ -326,6 +334,11 @@ public class Config {
             return this;
         }
 
+        public Builder withAllowDeprecatedPlugins(boolean allowDeprecatedPlugins) {
+            this.allowDeprecatedPlugins = allowDeprecatedPlugins;
+            return this;
+        }
+
         public Config build() {
             return new Config(
                     version,
@@ -347,7 +360,8 @@ public class Config {
                     skipMetadata,
                     dryRun,
                     draft,
-                    removeForks);
+                    removeForks,
+                    allowDeprecatedPlugins);
         }
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -189,9 +189,14 @@ public class PluginModernizer {
             LOG.debug("Plugin {} health score: {}", plugin.getName(), pluginService.extractScore(plugin));
             LOG.debug("Plugin {} installations: {}", plugin.getName(), pluginService.extractInstallationStats(plugin));
             LOG.debug("Is API plugin {} : {}", plugin.getName(), plugin.isApiPlugin(pluginService));
-            if (plugin.isDeprecated(pluginService)) {
+            if (plugin.isDeprecated(pluginService) && !config.isAllowDeprecatedPlugins()) {
                 LOG.info("Plugin {} is deprecated. Skipping.", plugin.getName());
-                plugin.addError("Plugin is deprecated");
+                plugin.addError("Plugin is deprecated. Modernization is blocked by default for deprecated plugins.\n"
+                    + "If you are a maintainer or understand the risks, you can bypass this restriction by adding:\n"
+                    + "  --allow-deprecated-plugins\n"
+                    + "Example:\n"
+                    + "  java -jar ./plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar run --plugins=" + plugin.getName() + " --recipe=<your-recipe> --allow-deprecated-plugins"
+                );
                 return;
             }
             if (plugin.isArchived(ghService)) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -192,11 +192,11 @@ public class PluginModernizer {
             if (plugin.isDeprecated(pluginService) && !config.isAllowDeprecatedPlugins()) {
                 LOG.info("Plugin {} is deprecated. Skipping.", plugin.getName());
                 plugin.addError("Plugin is deprecated. Modernization is blocked by default for deprecated plugins.\n"
-                    + "If you are a maintainer or understand the risks, you can bypass this restriction by adding:\n"
-                    + "  --allow-deprecated-plugins\n"
-                    + "Example:\n"
-                    + "  java -jar ./plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar run --plugins=" + plugin.getName() + " --recipe=<your-recipe> --allow-deprecated-plugins"
-                );
+                        + "If you are a maintainer or understand the risks, you can bypass this restriction by adding:\n"
+                        + "  --allow-deprecated-plugins\n"
+                        + "Example:\n"
+                        + "  java -jar ./plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar run --plugins="
+                        + plugin.getName() + " --recipe=<your-recipe> --allow-deprecated-plugins");
                 return;
             }
             if (plugin.isArchived(ghService)) {


### PR DESCRIPTION
Fixes #1122.

## Summary

This pull request introduces a new CLI/configuration flag, `--allow-deprecated-plugins`, that enables maintainers to modernize and collect metadata for plugins marked as deprecated. By default, modernization of deprecated plugins remains blocked for safety, but maintainers can now explicitly opt in when needed.

## Key Changes

- **New CLI Flag:**  
  Added `--allow-deprecated-plugins` to the CLI and configuration. When set, this flag allows modernization and metadata collection for deprecated plugins.

- **User Guidance:**  
  When a user attempts to modernize a deprecated plugin without the flag, the tool now provides a clear message explaining the block and suggesting the use of `--allow-deprecated-plugins`, including an example command.

- **Documentation:**  
  Updated the README to document the new flag, its intended use, and example usage scenarios.

## Motivation

Previously, modernization was always blocked for deprecated plugins, preventing new maintainers from upgrading or maintaining them. This change provides a safe, explicit mechanism for maintainers to override the block when appropriate, while keeping the default behavior secure for general users.

## Impact

- **Default behavior is unchanged:** Deprecated plugins are still blocked from modernization unless the flag is set.
- **Improved UX:** Users are informed about the reason for the block and how to proceed if they are maintainers.
- **Documentation:** Maintainers and contributors can easily discover and use the new option.

## Example Usage

```shell
java -jar ./plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar run --plugins=bmc-change-manager-imstm --recipe=UpgradeNextMajorParentVersion --allow-deprecated-plugins
```

<!-- Please describe your pull request here. -->

### Testing done

`java -jar ./plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar run --plugins=bmc-change-manager-imstm --recipe=UpgradeNextMajorParentVersion --allow-deprecated-plugins`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
