### PR TITLE
Add MigrateToJava25 as a valid migration id

### DIFF
--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -51,6 +51,7 @@ valid_migration_ids = [
     "io.jenkins.tools.pluginmodernizer.SetupSecurityScan",
     "io.jenkins.tools.pluginmodernizer.AddPluginsBom",
     "io.jenkins.tools.pluginmodernizer.MigrateToJUnit5",
+    "io.jenkins.tools.pluginmodernizer.MigrateToJava25",
     "io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty",
     "io.jenkins.tools.pluginmodernizer.AddCodeOwner",
     "io.jenkins.tools.pluginmodernizer.UpgradeParentVersion",


### PR DESCRIPTION
Add `MigrateToJava25` as a valid migration id as we recently added this declarative recipe.
Eg:- Fixes failing validation for this [job](https://github.com/Raunak80Madan/metadata-plugin-modernizer/actions/runs/16849464160/job/47733542854?pr=731)

### Testing done
`mvn clean install`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue