### PR TITLE
Add recipe Migrate Commons Lang2 To Lang3 And CommonText

### DIFF
--- a/plugin-modernizer-core/src/main/jte/pr-body-MigrateCommonsLang2ToLang3AndCommonText.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-MigrateCommonsLang2ToLang3AndCommonText.jte
@@ -1,0 +1,23 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+Hello `${plugin.getName()}` developers! :wave:
+
+This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool) tool. The tool has applied the following recipes to modernize the plugin:
+<details aria-label="Recipe details for ${recipe.getDisplayName()}">
+    <summary>${recipe.getDisplayName()}</summary>
+    <p><em>${recipe.getName()}</em></p>
+    <blockquote>${recipe.getDescription()}</blockquote>
+</details>
+
+This pull request upgrades `Apache Commons Lang 2` to `Apache Commons Lang 3` and migrates HTML escaping functionality from `Apache Commons Lang` to `Apache Commons Text`, as
+`Apache Commons` community recommends using `Apache Commons Text` for string escaping operations, as it provides a more focused and feature-rich API for text processing.
+
+## What's Changed?
+
+- Migrate from deprecated/EOL `Apache Commons Lang 2` to `Commons Lang 3`.
+- Migrate from deprecated/EOL Apache Commons Lang `StringEscapeUtils` to `Commons Text`.
+
+
+

--- a/plugin-modernizer-core/src/main/jte/pr-title-MigrateCommonsLang2ToLang3AndCommonText.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-MigrateCommonsLang2ToLang3AndCommonText.jte
@@ -1,0 +1,5 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+Migrate Commons Lang from 2 to 3 and StringEscapeUtils to Commons Text

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -253,6 +253,7 @@ recipeList:
       recursive: true
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateAcegiSecurityToSpringSecurity
+  - io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
   - io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
   - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
@@ -537,6 +538,7 @@ recipeList:
       recursive: true
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateAcegiSecurityToSpringSecurity
+  - io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
   - io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
   - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
@@ -564,6 +566,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.RemoveDependencyVersionOverride
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
+  - io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText
   - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
@@ -599,6 +602,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.code.ReplaceRemovedSSHLauncherConstructor
   - io.jenkins.tools.pluginmodernizer.RemoveExtraMavenProperties
   - io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
+  - io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText
   - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
   - io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
   - org.openrewrite.java.RemoveUnusedImports

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -157,6 +157,41 @@ recipeList:
       javaVersion: 25
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText
+displayName: Migrate Commons Lang from 2 to 3 and StringEscapeUtils to Commons Text
+description: Migrate Commons Lang from 2 to 3 and StringEscapeUtils to Commons Text.
+tags: ['dependencies', 'migration']
+recipeList:
+  # upgrade Commons Lang from 2 to 3
+  - org.openrewrite.maven.AddDependency:
+      groupId: io.jenkins.plugins
+      artifactId: commons-lang3-api
+      version: LATEST
+      onlyIfUsing: org.apache.commons.lang.*
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.commons.lang
+      newPackageName: org.apache.commons.lang3
+      recursive: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.commons.lang3.exception.ExceptionUtils getFullStackTrace(..)
+      newMethodName: getStackTrace
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.commons.lang3.NullArgumentException
+      newFullyQualifiedTypeName: java.lang.NullPointerException
+  # migrate StringEscapeUtils to Commons Text
+  - org.openrewrite.maven.AddDependency:
+        groupId: io.jenkins.plugins
+        artifactId: commons-text-api
+        version: LATEST
+        onlyIfUsing: org.apache.commons.lang.StringEscapeUtils
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.commons.lang3.StringEscapeUtils
+      newFullyQualifiedTypeName: org.apache.commons.text.StringEscapeUtils
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "*..StringEscapeUtils escapeHtml(java.lang.String)"
+      newMethodName: escapeHtml4
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.MigrateToJenkinsBaseLineProperty
 displayName: Migrate pom to using jenkins.baseline property if bom is present
 description: Migrate pom to using jenkins.baseline property if bom is present.

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -3352,6 +3352,66 @@ public class DeclarativeRecipesTest implements RewriteTest {
     }
 
     @Test
+    void migrateCommonsLang2ToLang3AndCommonText() {
+        rewriteRun(
+                spec -> spec.recipeFromResource(
+                        "/META-INF/rewrite/recipes.yml",
+                        "io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText"),
+                // language=java
+                java(
+                        """
+                package org.apache.commons.lang;
+                public class StringEscapeUtils {
+                    public static String escapeHtml(String input) {
+                        return input;
+                    }
+                }
+                """,
+                        """
+                package org.apache.commons.text;
+                public class StringEscapeUtils {
+                    public static String escapeHtml4(String input) {
+                        return input;
+                    }
+                }
+                """),
+                // language=java
+                java(
+                        """
+                package org.apache.commons.lang;
+                public class StringUtils {}
+                """,
+                        """
+                package org.apache.commons.lang3;
+                public class StringUtils {}
+                """),
+                // language=java
+                java(
+                        """
+                import org.apache.commons.lang.StringEscapeUtils;
+                import org.apache.commons.lang.StringUtils;
+
+                class MyComponent {
+                    public String getHtml() {
+                        String unsafeInput = "<script>alert('xss')</script>";
+                        return StringEscapeUtils.escapeHtml(unsafeInput);
+                    }
+                }
+                """,
+                        """
+                import org.apache.commons.lang3.StringUtils;
+                import org.apache.commons.text.StringEscapeUtils;
+
+                class MyComponent {
+                    public String getHtml() {
+                        String unsafeInput = "<script>alert('xss')</script>";
+                        return StringEscapeUtils.escapeHtml4(unsafeInput);
+                    }
+                }
+                """));
+    }
+
+    @Test
     void migrateToJUnit5() {
         rewriteRun(
                 spec -> {

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -2617,7 +2617,60 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                 .formatted(
                                         Settings.getJenkinsParentVersion(),
                                         Settings.getJenkinsTestHarnessVersion(),
-                                        Settings.getBomVersion())));
+                                        Settings.getBomVersion())),
+
+                // language=java
+                java(
+                        """
+                package org.apache.commons.lang;
+                public class StringEscapeUtils {
+                    public static String escapeHtml(String input) {
+                        return input;
+                    }
+                }
+                """,
+                        """
+                package org.apache.commons.text;
+                public class StringEscapeUtils {
+                    public static String escapeHtml4(String input) {
+                        return input;
+                    }
+                }
+                """),
+                // language=java
+                java(
+                        """
+                package org.apache.commons.lang;
+                public class StringUtils {}
+                """,
+                        """
+                package org.apache.commons.lang3;
+                public class StringUtils {}
+                """),
+                // language=java
+                java(
+                        """
+                import org.apache.commons.lang.StringEscapeUtils;
+                import org.apache.commons.lang.StringUtils;
+
+                class MyComponent {
+                    public String getHtml() {
+                        String unsafeInput = "<script>alert('xss')</script>";
+                        return StringEscapeUtils.escapeHtml(unsafeInput);
+                    }
+                }
+                """,
+                        """
+                import org.apache.commons.lang3.StringUtils;
+                import org.apache.commons.text.StringEscapeUtils;
+
+                class MyComponent {
+                    public String getHtml() {
+                        String unsafeInput = "<script>alert('xss')</script>";
+                        return StringEscapeUtils.escapeHtml4(unsafeInput);
+                    }
+                }
+                """));
     }
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -735,4 +735,43 @@ public class TemplateUtilsTest {
                 result.contains("We have introduced changes to improve the plugin's compatibility with `Java 25`"),
                 "What's Changed section");
     }
+
+    @Test
+    public void testFriendlyPrTitleMigrateCommonsLang2ToLang3AndCommonText() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn("io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
+
+        // Assert
+        assertEquals("Migrate Commons Lang from 2 to 3 and StringEscapeUtils to Commons Text", result);
+    }
+
+    @Test
+    public void testFriendlyPrBodyMigrateCommonsLang2ToLang3AndCommonText() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn("io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestBody(plugin, recipe);
+
+        // Just ensure it's using some key overall text
+        assertTrue(
+                result.contains(
+                        "This pull request upgrades `Apache Commons Lang 2` to `Apache Commons Lang 3` and migrates HTML escaping functionality from `Apache Commons Lang` to `Apache Commons Text"),
+                "Description");
+    }
 }


### PR DESCRIPTION
Fixes #1168 
- This recipe first upgrades from common lang 2 to 3 (took reference from [openrewrite](https://docs.openrewrite.org/recipes/apache/commons/lang/upgradeapachecommonslang_2_3))
- Then we also migrate `StringEscapeUtils` to Apache Commons Text and migrated method to `escapeHtml4`
### Testing done
`mvn clean install` 

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue