### PR TITLE
Store the opt out repositories and add option to override this behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,9 @@ source <(plugin-modernizer generate-completion)
 - `--skip-metadata` (optional) Skip collection and pushing the modernization metadata (i.e metadata after applying the recipes) to the [metadata repository](https://github.com/jenkins-infra/metadata-plugin-modernizer/). Beneficial for testing or development purpose when we don't need to unnecessary add another step of collecting the metadata.
 
 
+- `--override-opt-out-plugins` (optional) Override the default behavior to allow PRs to plugins marked as opt-out. This forces PR creation regardless of the plugin's opt-out status.
+
+
 - `--clean-forks` (optional) Remove forked repositories before and after the modernization process. Might cause data loss if you have other changes pushed on those forks. Forks with open pull request targeting original repo are not removed to prevent closing unmerged pull requests.
 
 
@@ -310,6 +313,8 @@ plugin-modernizer run --plugin-file path/to/plugin-file --recipe AddPluginsBom
 - `GH_METADATA_TARGET_ORGANISATION`: (optional) GitHub metadata target organization for the metadata repository. Defaults to `jenkins-infra`.
 
 - `JENKINS_UC`: (optional) Update Center URL. Can also be passed through the CLI option `--jenkins-update-center`.
+
+- `OPT_OUT_PLUGINS_URL`: (optional) Opt Out Plugins URL (.json file containing list of plugins that have opted out for receiving PRs). Can also be passed through the CLI option `--opt-out-plugins-url`. Defaults to this [url](https://raw.githubusercontent.com/jenkins-infra/metadata-plugin-modernizer/main/opt-out-plugins.json) .
 
 - `MAVEN_HOME` or `M2_HOME`: (required) Path to Maven home directory. Can also be passed through the CLI option `-m` or `--maven-home`.
 

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
@@ -61,6 +61,14 @@ public class RunCommand implements ICommand {
     private boolean skipMetadata;
 
     /**
+     * Override opt out plugins
+     */
+    @CommandLine.Option(
+            names = {"--override-opt-out-plugins"},
+            description = "Override the default behavior to allow PRs to plugins marked as opt-out")
+    private boolean overrideOptOutPlugins;
+
+    /**
      * Environment options
      */
     @CommandLine.Mixin
@@ -91,6 +99,7 @@ public class RunCommand implements ICommand {
                 .withDraft(draft)
                 .withRemoveForks(removeForks)
                 .withSkipMetadata(skipMetadata)
+                .withOverrideOptOutPlugins(overrideOptOutPlugins)
                 .build();
     }
 

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/EnvOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/EnvOptions.java
@@ -41,6 +41,12 @@ public class EnvOptions implements IOption {
     private URL jenkinsPluginsStatsInstallationsUrl = Settings.DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL;
 
     @CommandLine.Option(
+            names = {"--opt-out-plugins-url"},
+            description =
+                    "Sets the opt out plugins URL; will override OPT_OUT_PLUGINS_URL environment variable. If not set via CLI option or environment variable, will use default opt out plugins url.")
+    private URL optOutPluginsUrl = Settings.OPT_OUT_PLUGINS_URL;
+
+    @CommandLine.Option(
             names = {"--github-api-url"},
             description = "GitHub API URL. Default to https://api.github.com")
     private URL githubApiUrl = Settings.GITHUB_API_URL;
@@ -51,6 +57,7 @@ public class EnvOptions implements IOption {
                 .withJenkinsPluginVersions(jenkinsPluginVersions)
                 .withPluginHealthScore(pluginHealthScore)
                 .withPluginStatsInstallations(jenkinsPluginsStatsInstallationsUrl)
+                .withOptOutPlugins(optOutPluginsUrl)
                 .withGithubApiUrl(githubApiUrl);
     }
 }

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/options/EnvOptionsTest.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/options/EnvOptionsTest.java
@@ -36,6 +36,8 @@ public class EnvOptionsTest {
                 config.getPluginStatsInstallations(),
                 "Jenkins stats top plugins URL should be the default");
         assertEquals(Settings.GITHUB_API_URL, config.getGithubApiUrl(), "GitHub API URL should be the default");
+        assertEquals(
+                Settings.OPT_OUT_PLUGINS_URL, config.getOptOutPlugins(), "Opt out plugins URL should be the default");
     }
 
     @Test
@@ -86,6 +88,17 @@ public class EnvOptionsTest {
         githubApiField.set(
                 envOptions, URI.create("http://localhost:8080/github-api").toURL());
 
+        // Set opt out plugins URL
+        Field optOutPluginsField = ReflectionUtils.findFields(
+                        EnvOptions.class,
+                        f -> f.getName().equals("optOutPluginsUrl"),
+                        ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
+                .get(0);
+        optOutPluginsField.setAccessible(true);
+        optOutPluginsField.set(
+                envOptions,
+                URI.create("http://localhost:8080/opt-out-plugins.json").toURL());
+
         // Assertions
         envOptions.config(builder);
         Config config = builder.build();
@@ -105,5 +118,9 @@ public class EnvOptionsTest {
                 URI.create("http://localhost:8080/github-api").toURL(),
                 config.getGithubApiUrl(),
                 "Different GitHub API URL");
+        assertEquals(
+                URI.create("http://localhost:8080/opt-out-plugins.json").toURL(),
+                config.getOptOutPlugins(),
+                "Different Opt out plugins URL");
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -22,11 +22,13 @@ public class Config {
     private final URL jenkinsPluginVersions;
     private final URL pluginHealthScore;
     private final URL pluginStatsInstallations;
+    private final URL optOutPlugins;
     private final URL githubApiUrl;
     private final Path cachePath;
     private final Path mavenHome;
     private final Path mavenLocalRepo;
     private final boolean skipMetadata;
+    private final boolean overrideOptOutPlugins;
     private final boolean dryRun;
     private final boolean draft;
     private final boolean removeForks;
@@ -49,11 +51,13 @@ public class Config {
             URL jenkinsPluginVersions,
             URL pluginHealthScore,
             URL pluginStatsInstallations,
+            URL optOutPlugins,
             URL githubApiUrl,
             Path cachePath,
             Path mavenHome,
             Path mavenLocalRepo,
             boolean skipMetadata,
+            boolean overrideOptOutPlugins,
             boolean dryRun,
             boolean draft,
             boolean removeForks,
@@ -70,11 +74,13 @@ public class Config {
         this.jenkinsPluginVersions = jenkinsPluginVersions;
         this.pluginHealthScore = pluginHealthScore;
         this.pluginStatsInstallations = pluginStatsInstallations;
+        this.optOutPlugins = optOutPlugins;
         this.githubApiUrl = githubApiUrl;
         this.cachePath = cachePath;
         this.mavenHome = mavenHome;
         this.mavenLocalRepo = mavenLocalRepo;
         this.skipMetadata = skipMetadata;
+        this.overrideOptOutPlugins = overrideOptOutPlugins;
         this.dryRun = dryRun;
         this.draft = draft;
         this.removeForks = removeForks;
@@ -145,6 +151,10 @@ public class Config {
         return pluginStatsInstallations;
     }
 
+    public URL getOptOutPlugins() {
+        return optOutPlugins;
+    }
+
     public URL getGithubApiUrl() {
         return githubApiUrl;
     }
@@ -169,6 +179,10 @@ public class Config {
 
     public boolean isSkipMetadata() {
         return skipMetadata;
+    }
+
+    public boolean isOverrideOptOutPlugins() {
+        return overrideOptOutPlugins;
     }
 
     public boolean isDryRun() {
@@ -208,11 +222,13 @@ public class Config {
         private URL jenkinsPluginVersions = Settings.DEFAULT_PLUGIN_VERSIONS;
         private URL pluginStatsInstallations = Settings.DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL;
         private URL pluginHealthScore = Settings.DEFAULT_HEALTH_SCORE_URL;
+        private URL optOutPlugins = Settings.OPT_OUT_PLUGINS_URL;
         private URL githubApiUrl = Settings.GITHUB_API_URL;
         private Path cachePath = Settings.DEFAULT_CACHE_PATH;
         private Path mavenHome = Settings.DEFAULT_MAVEN_HOME;
         private Path mavenLocalRepo = Settings.DEFAULT_MAVEN_LOCAL_REPO;
         private boolean skipMetadata = false;
+        private boolean overrideOptOutPlugins = false;
         private boolean dryRun = false;
         private boolean draft = false;
         public boolean removeForks = false;
@@ -286,6 +302,13 @@ public class Config {
             return this;
         }
 
+        public Builder withOptOutPlugins(URL optOutPlugins) {
+            if (optOutPlugins != null) {
+                this.optOutPlugins = optOutPlugins;
+            }
+            return this;
+        }
+
         public Builder withGithubApiUrl(URL githubApiUrl) {
             if (githubApiUrl != null) {
                 this.githubApiUrl = githubApiUrl;
@@ -316,6 +339,11 @@ public class Config {
 
         public Builder withSkipMetadata(boolean skipMetadata) {
             this.skipMetadata = skipMetadata;
+            return this;
+        }
+
+        public Builder withOverrideOptOutPlugins(boolean overrideOptOutPlugins) {
+            this.overrideOptOutPlugins = overrideOptOutPlugins;
             return this;
         }
 
@@ -353,11 +381,13 @@ public class Config {
                     jenkinsPluginVersions,
                     pluginHealthScore,
                     pluginStatsInstallations,
+                    optOutPlugins,
                     githubApiUrl,
                     cachePath,
                     mavenHome,
                     mavenLocalRepo,
                     skipMetadata,
+                    overrideOptOutPlugins,
                     dryRun,
                     draft,
                     removeForks,

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Settings.java
@@ -35,6 +35,8 @@ public class Settings {
 
     public static final URL DEFAULT_HEALTH_SCORE_URL;
 
+    public static final URL OPT_OUT_PLUGINS_URL;
+
     public static final URL GITHUB_API_URL;
 
     public static final Path DEFAULT_CACHE_PATH;
@@ -123,6 +125,11 @@ public class Settings {
         }
         try {
             DEFAULT_PLUGINS_STATS_INSTALLATIONS_URL = getPluginsStatsInstallationsUrl();
+        } catch (MalformedURLException e) {
+            throw new ModernizerException("Invalid URL format", e);
+        }
+        try {
+            OPT_OUT_PLUGINS_URL = getOptOutPluginsUrl();
         } catch (MalformedURLException e) {
             throw new ModernizerException("Invalid URL format", e);
         }
@@ -310,6 +317,14 @@ public class Settings {
             return new URL(url);
         }
         return new URL(readProperty("plugin.stats.installations.plugin.url", "urls.properties"));
+    }
+
+    private static URL getOptOutPluginsUrl() throws MalformedURLException {
+        String url = System.getenv("OPT_OUT_PLUGINS_URL");
+        if (url != null) {
+            return new URL(url);
+        }
+        return new URL(readProperty("opt.out.plugins.url", "urls.properties"));
     }
 
     private static String getGithubToken() {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/CacheManager.java
@@ -23,6 +23,7 @@ public class CacheManager {
     public static final String INSTALLATION_STATS_KEY = "plugin-installation-stats.json";
     public static final String PLUGIN_METADATA_CACHE_KEY = "plugin-metadata.json";
     public static final String MODERNIZATION_METADATA_CACHE_KEY = "modernization-metadata.json";
+    public static final String OPT_OUT_PLUGINS_CACHE_KEY = "opt-out-plugins.json";
     private static final Logger LOG = LoggerFactory.getLogger(CacheManager.class);
 
     private final Path location;

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/OptOutPluginsData.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/OptOutPluginsData.java
@@ -1,0 +1,28 @@
+package io.jenkins.tools.pluginmodernizer.core.model;
+
+import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * List of plugins that have opted out of receiving PRs from plugin-modernizer-tool
+ */
+public class OptOutPluginsData extends CacheEntry<OptOutPluginsData> {
+
+    /**
+     * List of plugin names that have opted out
+     */
+    private List<String> opted_out_plugins;
+
+    public OptOutPluginsData(CacheManager cacheManager) {
+        super(cacheManager, OptOutPluginsData.class, CacheManager.OPT_OUT_PLUGINS_CACHE_KEY, Path.of("."));
+    }
+
+    /**
+     * Get the list of plugins that opted out
+     * @return list of plugin names
+     */
+    public List<String> getOptedOutPlugins() {
+        return opted_out_plugins;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginService.java
@@ -6,6 +6,7 @@ import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
 import io.jenkins.tools.pluginmodernizer.core.model.HealthScoreData;
 import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import io.jenkins.tools.pluginmodernizer.core.model.OptOutPluginsData;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.PluginInstallationStatsData;
 import io.jenkins.tools.pluginmodernizer.core.model.PluginVersionData;
@@ -152,7 +153,7 @@ public class PluginService {
     }
 
     /**
-     * Retrieve update center data from the given URL of from cache if it exists
+     * Retrieve update center data from the given URL or from cache if it exists
      * @return Update center data
      */
     public UpdateCenterData getUpdateCenterData() {
@@ -169,7 +170,7 @@ public class PluginService {
     }
 
     /**
-     * Retrieve health score data from the given URL of from cache if it exists
+     * Retrieve health score data from the given URL or from cache if it exists
      * @return Health score data
      */
     public HealthScoreData getHealthScoreData() {
@@ -186,6 +187,23 @@ public class PluginService {
     }
 
     /**
+     * Retrieve opt out plugins data from the given URL or from cache if it exists
+     * @return Opt out plugins data
+     */
+    public OptOutPluginsData getOptOutPluginsData() {
+        OptOutPluginsData optOutPluginsData =
+                cacheManager.get(cacheManager.root(), CacheManager.OPT_OUT_PLUGINS_CACHE_KEY, OptOutPluginsData.class);
+        // Download and update cache
+        if (optOutPluginsData == null) {
+            optOutPluginsData = downloadOptOutPluginsData();
+            optOutPluginsData.setKey(CacheManager.OPT_OUT_PLUGINS_CACHE_KEY);
+            optOutPluginsData.setPath(cacheManager.root());
+            cacheManager.put(optOutPluginsData);
+        }
+        return optOutPluginsData;
+    }
+
+    /**
      * Download refreshed update center data from the remote service
      * @return Update center data
      */
@@ -199,6 +217,14 @@ public class PluginService {
      */
     public HealthScoreData downloadHealthScoreData() {
         return JsonUtils.fromUrl(config.getPluginHealthScore(), HealthScoreData.class);
+    }
+
+    /**
+     * Download refreshed opt out plugins data from the metadata repository
+     * @return Opt out plugins data
+     */
+    public OptOutPluginsData downloadOptOutPluginsData() {
+        return JsonUtils.fromUrl(config.getOptOutPlugins(), OptOutPluginsData.class);
     }
 
     /**
@@ -270,7 +296,7 @@ public class PluginService {
     }
 
     /**
-     * Retrieve plugin version data from the given URL of from cache if it exists
+     * Retrieve plugin version data from the given URL or from cache if it exists
      * @return Plugin version data
      */
     public PluginVersionData getPluginVersionData() {
@@ -287,7 +313,7 @@ public class PluginService {
     }
 
     /**
-     * Retrieve plugin installation stats data from the given URL of from cache if it exists
+     * Retrieve plugin installation stats data from the given URL or from cache if it exists
      * @return Plugin installation stats data
      */
     public PluginInstallationStatsData getPluginInstallationStatsData() {

--- a/plugin-modernizer-core/src/main/resources/urls.properties
+++ b/plugin-modernizer-core/src/main/resources/urls.properties
@@ -2,3 +2,4 @@ update.center.url=https://updates.jenkins.io/current/update-center.actual.json
 plugin.versions.url=https://updates.jenkins.io/current/plugin-versions.json
 plugin.health.score.url=https://plugin-health.jenkins.io/api/scores
 plugin.stats.installations.plugin.url=https://stats.jenkins.io/jenkins-stats/svg/202505-plugins.csv
+opt.out.plugins.url=https://raw.githubusercontent.com/jenkins-infra/metadata-plugin-modernizer/main/opt-out-plugins.json


### PR DESCRIPTION
Fixes #1176 
- Create enum to store all the plugins that have been opted out, took reference from [here](https://github.com/jenkins-infra/plugin-modernizer-tool/issues/1176#issuecomment-3170701637)
- Add `--override-opt-out-plugins` option to allow making PRs for plugins marked as opt out
### Testing done
made this [PR](https://github.com/jenkinsci/safe-batch-environment-filter-plugin/pull/11) and closed instantly to test the override option

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue