### PR TITLE
Fix metadata validation and update the repo org to jenkins-infra

### DIFF
--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -10,14 +10,14 @@ token = os.getenv('GH_TOKEN')
 if not token:
     raise EnvironmentError("GITHUB TOKEN is not found.")
 g = Github(token)
-repo = g.get_repo('Raunak80Madan/metadata-plugin-modernizer')
+repo = g.get_repo('jenkins-infra/metadata-plugin-modernizer')
 pr_number = os.getenv("PR_NUMBER")
 pr = repo.get_pull(int(pr_number))
 
 # JSON schema for metadata validation
 schema = {
     "type": "object",
-    "required": ["pluginName", "pluginRepository", "pluginVersion", "targetBaseline", "jenkinsVersion", "migrationName", "migrationDescription", "tags", "migrationId", "migrationStatus", "pullRequestUrl", "pullRequestStatus", "dryRun", "additions", "deletions", "changedFiles", "key", "path"],
+    "required": ["pluginName", "pluginRepository", "pluginVersion", "migrationName", "migrationDescription", "tags", "migrationId", "migrationStatus", "pullRequestUrl", "pullRequestStatus", "dryRun", "additions", "deletions", "changedFiles", "key", "path"],
     "properties": {
         "pluginName": {"type": "string", "pattern": "^[a-zA-Z0-9-]+$"},
         "pluginRepository": {"type": "string", "format": "uri", "pattern": "^https://github.com/[^/]+/.+\\.git$"},
@@ -41,7 +41,7 @@ schema = {
         "path": {"type": "string", "pattern": "^metadata-plugin-modernizer/[^/]+/modernization-metadata$"}
     },
     "anyOf": [
-        { "required": ["effectiveBaseline"] },
+        { "required": ["targetBaseline", "jenkinsVersion", "effectiveBaseline"] },
         { "required": ["rpuBaseline"] }
     ]
 }


### PR DESCRIPTION
- Fix metadata validation addressing `rpuBaseline` - We need to either make required `rpuBaseline` or (`targetBaseline`, `jenkinsVersion`, and `effectiveBaseline`) together.
- Update the repo org to `jenkins-infra` when getting the repo - I think this is also one of the issue that is causing the checks to fail.
Fixes failing [job](https://github.com/jenkins-infra/metadata-plugin-modernizer/actions/runs/17177478191/job/48735370839?pr=22)
### Testing done
Not required, will be tested after merged

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue