### PR TITLE
Jammy to Noble

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG VERSION=999999-SNAPSHOT
 
 # Create the image using Maven and Eclipse Temurin JDK 21
-FROM maven:3.9.11-eclipse-temurin-21-jammy AS result-image
+FROM maven:3.9.11-eclipse-temurin-21-noble AS result-image
 
 LABEL org.opencontainers.image.description="Using OpenRewrite Recipes for Plugin Modernization or Automation Plugin Build Metadata Updates"
 

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -56,7 +56,7 @@ targets:
         keyword: "FROM" # The Dockerfile instruction to target.
         matcher: "maven" # The specific Docker image to update with the new Maven version.
     transformers:
-      - addsuffix: "-eclipse-temurin-21-jammy" # Add the suffix to the Maven version.
+      - addsuffix: "-eclipse-temurin-21-noble" # Add the suffix to the Maven version.
     scmid: default # Use the default SCM configuration.
 
 # Define the actions to take after the targets are updated.


### PR DESCRIPTION
Maven 3.9.11 is in any case not available with jammy.

Seen here https://github.com/jenkins-infra/plugin-modernizer-tool/actions/runs/17292038302/job/49082028783

### Testing done

None in particular

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
