### PR TITLE
Add missing migration id for metadata validation

### DIFF
--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -91,6 +91,7 @@ valid_migration_ids = [
     "io.jenkins.tools.pluginmodernizer.conditions.IsUsingCoreVersionWithCommonsCompressRemoved",
     "io.jenkins.tools.pluginmodernizer.EnsureIndexJelly",
     "io.jenkins.tools.pluginmodernizer.MigrateTomakehurstToWiremock"
+    "io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText"
 ]
 
 def validate_metadata(file_path):


### PR DESCRIPTION
Fixes failing metadata validation on [#266](https://github.com/jenkins-infra/metadata-plugin-modernizer/pull/266), [#268](https://github.com/jenkins-infra/metadata-plugin-modernizer/pull/268)
- Add missing `io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText` in migration id 
 
### Testing done
Not required

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue