### PR TITLE
Fix get-jdk-versions.sh to work with version like 25-tem

### DIFF
--- a/updatecli/scripts/get-jdk-versions.sh
+++ b/updatecli/scripts/get-jdk-versions.sh
@@ -36,7 +36,7 @@ cd "$current_dir" || exit
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 
 # Find and output the Temurin JDK version identifier for the given major version
-identifier=$(PAGER=cat sdk list java | grep -E " $major_version\\.0.*-tem" | awk -v ver="$major_version" '$0 ~ " " ver "\\.0.*-tem" {print $NF}' | head -n 1)
+identifier=$(PAGER=cat sdk list java | grep -E " $major_version(\.[0-9]+)*-tem" | awk -v ver="$major_version" '$0 ~ " " ver "(\\.[0-9]+)*-tem" {print $NF}' | head -n 1)
 
 if [ -n "$identifier" ]; then
     echo "$identifier"


### PR DESCRIPTION
Fix get-jdk-versions.sh to work with version like 25-tem

### Testing done

```
bash updatecli/scripts/get-jdk-versions.sh 8
bash updatecli/scripts/get-jdk-versions.sh 11
bash updatecli/scripts/get-jdk-versions.sh 17
bash updatecli/scripts/get-jdk-versions.sh 21
bash updatecli/scripts/get-jdk-versions.sh 25
```

Which output

```
8.0.462-tem
11.0.28-tem
17.0.17-tem
21.0.8-tem
25-tem
```

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
