### PR TITLE
Limit the number of JDK in Jenkinsfile

### DIFF
--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -176,6 +176,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.SetupJenkinsfile
   - io.jenkins.tools.pluginmodernizer.core.recipes.UpdateJenkinsfileForJavaVersion:
       javaVersion: 25
+      totalJdk: 2
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
@@ -161,7 +161,6 @@ public class JDKTest {
         assertEquals(3, JDK.get("2.479.1").size());
         assertEquals(JDK.JAVA_17, JDK.get("2.479.1").get(0));
         assertEquals(JDK.JAVA_21, JDK.get("2.479.1").get(1));
-        assertEquals(JDK.JAVA_25, JDK.get("2.479.1").get(2));
 
         assertEquals(3, JDK.get("2.492.1").size());
         assertEquals(JDK.JAVA_17, JDK.get("2.492.1").get(0));

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateJenkinsfileForJavaVersionTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/UpdateJenkinsfileForJavaVersionTest.java
@@ -49,6 +49,37 @@ public class UpdateJenkinsfileForJavaVersionTest implements RewriteTest {
     }
 
     @Test
+    void shouldUpgradeLegacyConfigAndAddJava25LimitJDK() {
+        rewriteRun(
+                spec -> spec.recipe(new UpdateJenkinsfileForJavaVersion(25, 2)),
+                // language=groovy
+                groovy(
+                        """
+                        buildPlugin(
+                          dontRemoveMe: 'true',
+                          forkCount: '1C',
+                          jdkVersions: ['8', '11'],
+                          platforms: ['linux', 'windows']
+                        )
+                        """,
+                        """
+                        /*
+                         See the documentation for more options:
+                         https://github.com/jenkins-infra/pipeline-library/
+                        */
+                        buildPlugin(
+                          dontRemoveMe: 'true',
+                          forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+                          useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+                          configurations: [
+                            [platform: 'windows', jdk: 11],
+                            [platform: 'linux', jdk: 25],
+                        ])
+                        """,
+                        sourceSpecs -> sourceSpecs.path(ArchetypeCommonFile.JENKINSFILE.getPath())));
+    }
+
+    @Test
     void shouldAddJava25ToModernConfigurations() {
         rewriteRun(
                 spec -> spec.recipe(new UpdateJenkinsfileForJavaVersion(25)),
@@ -107,6 +138,37 @@ public class UpdateJenkinsfileForJavaVersionTest implements RewriteTest {
                             [platform: 'linux', jdk: 17],
                             [platform: 'windows', jdk: 17],
                             [platform: 'linux', jdk: 21],
+                        ])
+                        """,
+                        sourceSpecs -> sourceSpecs.path(ArchetypeCommonFile.JENKINSFILE.getPath())));
+    }
+
+    @Test
+    void shouldReplaceJava17To25InModernConfigurations() {
+        rewriteRun(
+                spec -> spec.recipe(new UpdateJenkinsfileForJavaVersion(25, 2)),
+                // language=groovy
+                groovy(
+                        """
+                        buildPlugin(
+                          useContainerAgent: true,
+                          configurations: [
+                            [platform: 'windows', jdk: 17],
+                            [platform: 'linux', jdk: 21],
+                          ]
+                        )
+                        """,
+                        """
+                        /*
+                         See the documentation for more options:
+                         https://github.com/jenkins-infra/pipeline-library/
+                        */
+                        buildPlugin(
+                          useContainerAgent: true,
+                          forkCount: '1C', // Set to `false` if you need to use Docker for containerized tests
+                          configurations: [
+                            [platform: 'windows', jdk: 21],
+                            [platform: 'linux', jdk: 25],
                         ])
                         """,
                         sourceSpecs -> sourceSpecs.path(ArchetypeCommonFile.JENKINSFILE.getPath())));


### PR DESCRIPTION
Limit the number of JDK in Jenkinsfile

### Testing done

Will use it to reapply the receipe on some plugin to remove the 17 from Jenkinsfile

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
