### PR TITLE
Do not include Java 11 in UpgradeToRecommendCoreVersion title

### DIFF
--- a/plugin-modernizer-core/src/main/jte/pr-body-UpgradeToRecommendCoreVersion.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-UpgradeToRecommendCoreVersion.jte
@@ -29,7 +29,7 @@ This means your plugin POM was already using the `${plugin.getMetadata().getJenk
 For security reasons, the Jenkins infrastructure does not execute Jenkinsfiles proposed in pull requests.
 Instead, it builds the code using the Jenkinsfile from the default branch.
 
-In this case, the existing Jenkinsfile specifies Java 8, not Java 11, which is causing the check to fail.
+In this case, the existing Jenkinsfile specifies Java 8, not Java 17, which is causing the check to fail.
 To resolve this,
 a maintainer can replay the failed build
 by substituting the current Jenkinsfile content with our proposed changes using the "replay the build"

--- a/plugin-modernizer-core/src/main/jte/pr-title-UpgradeToRecommendCoreVersion.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-UpgradeToRecommendCoreVersion.jte
@@ -2,4 +2,4 @@
 @import io.jenkins.tools.pluginmodernizer.core.model.Recipe
 @param Plugin plugin
 @param Recipe recipe
-chore(pom): Use recommended core version ${plugin.getMetadata().getJenkinsVersion()}, and Java 11
+chore(pom): Use recommended core version ${plugin.getMetadata().getJenkinsVersion()}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -238,7 +238,7 @@ public class TemplateUtilsTest {
         String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
 
         // Assert
-        assertEquals("chore(pom): Use recommended core version 2.452.4, and Java 11", result);
+        assertEquals("chore(pom): Use recommended core version 2.452.4", result);
     }
 
     @Test


### PR DESCRIPTION
Do not include Java 11 in UpgradeToRecommendCoreVersion title

Better to not include the Java version in title.

It's more confusing when only changing the core version.

Also Java 11 is now incorrect for UpgradeToRecommendCoreVersion 

### Testing done

None, let CI do the job

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
