### PR TITLE
Recipe to migrate JSR305 annotations

### DIFF
--- a/plugin-modernizer-core/pom.xml
+++ b/plugin-modernizer-core/pom.xml
@@ -311,6 +311,17 @@
                   <artifactId>hamcrest</artifactId>
                   <version>3.0</version>
                 </dependency>
+                <!-- JSR305 annotations -->
+                <dependency>
+                  <groupId>javax.annotation</groupId>
+                  <artifactId>javax.annotation-api</artifactId>
+                  <version>1.3.2</version>
+                </dependency>
+                <dependency>
+                  <groupId>com.google.code.findbugs</groupId>
+                  <artifactId>jsr305</artifactId>
+                  <version>3.0.2</version>
+                </dependency>
               </artifactItems>
             </configuration>
           </execution>

--- a/plugin-modernizer-core/src/main/jte/pr-title-JavaxAnnotationsToSpotbugs.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-JavaxAnnotationsToSpotbugs.jte
@@ -1,0 +1,6 @@
+
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+Migrate `javax.annotations` to SpotBugs annotations

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -573,6 +573,7 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateAcegiSecurityToSpringSecurity
   - io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText
+  - io.jenkins.tools.pluginmodernizer.JavaxAnnotationsToSpotbugs
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
   - io.jenkins.tools.pluginmodernizer.ReplaceIOException2WithIOException
   - io.jenkins.tools.pluginmodernizer.RemoveDevelopersTag
@@ -732,3 +733,18 @@ description: This PR migrates the groupId and artifactId to the new artifact and
 tags: ['chore']
 recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateTomakehurstToWiremock
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.JavaxAnnotationsToSpotbugs
+displayName: Migrate `javax.annotations` to SpotBugs annotations.
+description: SpotBugs is the [preferred replacement](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) of JSR-305 annotations for Jenkins plugins.
+tags: ['chore']
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: javax.annotation.Nonnull
+      newFullyQualifiedTypeName: edu.umd.cs.findbugs.annotations.NonNull
+      ignoreDefinition: true
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: javax.annotation
+      newPackageName: edu.umd.cs.findbugs.annotations
+      recursive: false

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -783,8 +783,21 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                 import hudson.util.IOException2;
                                 import java.io.File;
                                 import java.io.IOException;
+                                import javax.annotation.CheckForNull;
+                                import javax.annotation.Nonnull;
 
                                 public class Foo {
+
+                                    @CheckForNull
+                                    public String getSomething() {
+                                       return "something";
+                                    }
+
+                                    @Nonnull
+                                    public String getOther() {
+                                       return "something";
+                                    }
+
                                     public static void main(String[] args) {
                                         try {
                                             parseFile(new File("invalid.xml"));
@@ -802,10 +815,23 @@ public class DeclarativeRecipesTest implements RewriteTest {
                                     }
                                 }
                                 """, """
+                                import edu.umd.cs.findbugs.annotations.NonNull;
                                 import java.io.File;
                                 import java.io.IOException;
+                                import edu.umd.cs.findbugs.annotations.CheckForNull;
 
                                 public class Foo {
+
+                                    @CheckForNull
+                                    public String getSomething() {
+                                       return "something";
+                                    }
+
+                                    @NonNull
+                                    public String getOther() {
+                                       return "something";
+                                    }
+
                                     public static void main(String[] args) {
                                         try {
                                             parseFile(new File("invalid.xml"));

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -811,4 +811,22 @@ public class TemplateUtilsTest {
                 result.contains("This pull request upgrades `Apache Commons Lang 2` to `Apache Commons Lang 3`"),
                 "Description");
     }
+
+    @Test
+    public void testFriendlyPrTitleMigrateJavaxAnnotationsToSpotbugs() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn("io.jenkins.tools.pluginmodernizer.JavaxAnnotationsToSpotbugs")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
+
+        // Assert
+        assertEquals("Migrate `javax.annotations` to SpotBugs annotations", result);
+    }
 }

--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -95,7 +95,8 @@ valid_migration_ids = [
     "io.jenkins.tools.pluginmodernizer.MigrateTomakehurstToWiremock",
     "io.jenkins.tools.pluginmodernizer.MigrateCommonsLang2ToLang3AndCommonText",
     "io.jenkins.tools.pluginmodernizer.RemoveOldJavaVersionForModernJenkins",
-    "io.jenkins.tools.pluginmodernizer.SwitchToRenovate"
+    "io.jenkins.tools.pluginmodernizer.SwitchToRenovate",
+    "io.jenkins.tools.pluginmodernizer.JavaxAnnotationsToSpotbugs"
 ]
 
 def validate_metadata(file_path):


### PR DESCRIPTION
Was totally forgotten.

Now javax.* is gone on newer Jenkins

### Testing done

Updated automated test and test 2 annotation migration

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
