### PR TITLE
chore: update rewrite-recipe-bom to 3.24.0 (#1574)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
       <dependency>
         <groupId>org.openrewrite.recipe</groupId>
         <artifactId>rewrite-recipe-bom</artifactId>
-        <version>${openrewrite.bom.version}</version>
+        <version>3.24.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
### Testing done
I have updated the `rewrite-recipe-bom` to version **3.24.0** in the `pom.xml`.
- I ran `mvn clean install` in the terminal.
- The build was a **SUCCESS** with the new version.

### Submitter checklist
- [x] I have updated the version to 3.24.0 as requested.
- [x] I have verified the local build.
- [x] Link to relevant issue: **Fixes #1574**