### PR TITLE
Add NPE check and anonymous classes override logic in MigrateAcegiSecurityToSpringSecurity

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateAcegiSecurityToSpringSecurity.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateAcegiSecurityToSpringSecurity.java
@@ -323,9 +323,7 @@ public class MigrateAcegiSecurityToSpringSecurity extends Recipe {
                                     type.getOverride().toString());
                             return super.visitMethodDeclaration(method, ctx);
                         }
-                        if (type != null) {
-                            type = type.withName("loadUserByUsername2");
-                        }
+                        type = type.withName("loadUserByUsername2");
                         method = method.withName(method.getName()
                                         .withSimpleName("loadUserByUsername2")
                                         .withType(type))


### PR DESCRIPTION
fix issue #1574 

Add NPE check and anonymous classes override logic in `MigrateAcegiSecurityToSpringSecurity.java`
- replace `Objects.requireNonNull()` with null check
- handle methods in anonymous classes without override information
- removed unused obj import

### Testing done

All test cases passed in [MigrateAcegiSecurityToSpringSecurityTest](https://github.com/jenkins-infra/plugin-modernizer-tool/blob/0b584b74b82644d81762c512d2a8201e76c91262/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/MigrateAcegiSecurityToSpringSecurityTest.java#L16) with `OpenRewrite BOM v3.24.0`

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
