### PR TITLE
Update Openrewrite BOM and ReplaceLibrariesWithApiPluginTest

### DIFF
--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/ReplaceLibrariesWithApiPluginTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/ReplaceLibrariesWithApiPluginTest.java
@@ -116,7 +116,7 @@ public class ReplaceLibrariesWithApiPluginTest implements RewriteTest {
                       <dependency>
                         <groupId>io.jenkins.tools.bom</groupId>
                         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-                        <version>4051.v78dce3ce8b_d6</version>
+                        <version>4570.v1b_c718dd3b_1e</version>
                         <scope>import</scope>
                         <type>pom</type>
                       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
     <!-- Version -->
     <jenkins.core.minimum.version>2.516.3</jenkins.core.minimum.version>
-    <openrewrite.bom.version>3.22.0</openrewrite.bom.version>
+    <openrewrite.bom.version>3.24.0</openrewrite.bom.version>
     <openrewrite.maven.plugin.version>6.29.0</openrewrite.maven.plugin.version>
     <micrometer.version>1.16.3</micrometer.version>
     <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
fully fix issue #1574 

- update [ReplaceLibrariesWithApiPluginTest](https://github.com/jenkins-infra/plugin-modernizer-tool/blob/1d8041c935e76e9a1027bba068a8c55a657f3194/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/ReplaceLibrariesWithApiPluginTest.java#L119) version 

- update openrewrite recipe bom itself in PR to avoid noise. PR #1536 can be closed


### Testing done

mvn clean test

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
