### PR TITLE
Fix string concatenation bug in validate_metadata.py

### DIFF
--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -48,7 +48,7 @@ schema = {
 
 # migration IDs
 valid_migration_ids = [
-    "io.jenkins.tools.pluginmodernizer.FetchMetadata,"
+    "io.jenkins.tools.pluginmodernizer.FetchMetadata",
     "io.jenkins.tools.pluginmodernizer.MergeGitIgnoreRecipe",
     "io.jenkins.tools.pluginmodernizer.UpdateScmUrl",
     "io.jenkins.tools.pluginmodernizer.SetupJenkinsfile",


### PR DESCRIPTION
## Problem

In `scripts/validate_metadata.py`, line 51, the `FetchMetadata` entry in the `valid_migration_ids` list had a trailing comma **inside** the closing quote:

```python
"io.jenkins.tools.pluginmodernizer.FetchMetadata,"
"io.jenkins.tools.pluginmodernizer.MergeGitIgnoreRecipe",
```

In Python, adjacent string literals without a comma separator are implicitly concatenated. This means these two lines produced a single string:

```
"io.jenkins.tools.pluginmodernizer.FetchMetadata,io.jenkins.tools.pluginmodernizer.MergeGitIgnoreRecipe"
```

This caused both `FetchMetadata` and `MergeGitIgnoreRecipe` to be missing as valid migration IDs, which could lead to false validation failures when checking metadata.

## Fix

Moved the comma from inside the quotes to outside, making both entries separate list items as intended.