### PR TITLE
Handle invalid JSON files gracefully in consolidate and generate scripts

### DIFF
--- a/scripts/consolidate_metadata.py
+++ b/scripts/consolidate_metadata.py
@@ -24,8 +24,8 @@ for plugin_dir in os.listdir(root_dir):
                 try:
                     with open(os.path.join(metadata_dir, json_file) , "r") as f:
                         data = json.load(f)
-                except json.JSONDecodeError as e:
-                    print(f"[WARN] Skipping invalid JSON file: {os.path.join(metadata_dir, json_file)}, error: {e}")
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"[WARN] Skipping invalid file: {os.path.join(metadata_dir, json_file)}, error: {e}")
                     continue
                 data["timestamp"] = timestamp
                 migrations.append(data)

--- a/scripts/generate_reports.py
+++ b/scripts/generate_reports.py
@@ -35,8 +35,8 @@ for root, dirs, files in os.walk(json_dir):
                         if "migrationStatus" not in data:
                             data["migrationStatus"] = ""
                         data_list.append(data)
-                except json.JSONDecodeError as e:
-                    print(f"[WARN] Skipping invalid JSON file: {os.path.join(root, file)}, error: {e}")
+                except (json.JSONDecodeError, OSError) as e:
+                    print(f"[WARN] Skipping invalid file: {os.path.join(root, file)}, error: {e}")
                     continue
 
 # Create a DataFrame for analysis


### PR DESCRIPTION
## Summary

Both `consolidate_metadata.py` and `generate_reports.py` call `json.load()` with no error handling. A single corrupted or missing metadata file causes the entire script to crash, skipping all remaining plugins.

Added `try/except (json.JSONDecodeError, OSError)` around the load calls so bad files are logged as warnings and skipped instead, allowing processing to continue.

### Testing done

**Test 1 - Valid JSON files:**
```bash
$ python scripts/generate_reports.py
[INFO] Generated failed_migrations.csv for plugin 'test-plugin' at: ...
[INFO] Summary report generated at: ...
```

**Test 2 - Corrupted JSON file (simulated syntax error):**
Created a file with invalid JSON syntax:
```json
{ this is invalid json missing closing brace
  "pluginName": "corrupted-plugin"
```
Script logged warning and continued:
```bash
$ python scripts/generate_reports.py
[WARN] Skipping invalid file: ./test-plugin/modernization-metadata/corrupted.json, error: Expecting property name enclosed in double quotes: line 1 column 3 (char 2)
[INFO] Summary report generated at: ...
```

**Test 3 - Permission denied (OSError, addressed @CodexRaunak's feedback):**
Created a file with denied read permission (Windows: `icacls locked.json /deny Everyone:R`):
```bash
$ python scripts/generate_reports.py
[WARN] Skipping invalid file: ./oserror-test/modernization-metadata/locked.json, error [Errno 13] Permission denied: ...
[INFO] Summary report generated at: ...
```

After @CodexRaunak's suggestion, the code now catches both `json.JSONDecodeError` and `OSError` (file not found, permission denied):
```python
except (json.JSONDecodeError, OSError) as e:
    print(f"[WARN] Skipping invalid file: {path}, error: {e}")
```

Script processes remaining files instead of crashing on any file system error.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue