### PR TITLE
fix: three silent-failure bugs in verification, cache path, and JDK selection

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -1237,7 +1237,7 @@ public class GHService {
      * @return DiffStats (no. of additions, deletions and changed files)
      */
     public DiffStats getDiffStats(Plugin plugin, boolean dryRun) {
-        Path gitDirPath = Settings.DEFAULT_CACHE_PATH
+        Path gitDirPath = config.getCachePath()
                 .resolve(plugin.getName())
                 .resolve("sources")
                 .resolve(".git")

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -359,9 +359,14 @@ public class PluginModernizer {
 
             if (plugin.hasErrors()) {
                 LOG.warn(
-                        "Skipping plugin {} due to verification errors after modernization. Check logs for more details.",
+                        "Plugin {} failed verification after modernization. Check logs for more details.",
                         plugin.getName());
-                return;
+                if (!config.isDryRun()) {
+                    return;
+                }
+                // In dry-run mode we are only previewing changes, so clear the error and
+                // continue so the diff is still displayed to the user.
+                plugin.withoutErrors();
             }
 
             // Recollect metadata after modernization

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -419,12 +419,10 @@ public class PluginModernizer {
                 plugin.addError("Unexpected processing error. Check the logs at " + plugin.getLogFile(), e);
             }
         } finally {
-            if (!config.isSkipMetadata() && !earlySkip) {
+            if (!config.isSkipMetadata() && !earlySkip && !config.isDryRun()) {
                 try {
-                    // collect the modernization metadata and push it to metadata repository if valid
                     collectModernizationMetadata(plugin);
                     validateModernizationMetadata(plugin);
-                    // Only proceed with metadata operations if modernization metadata was successfully created
                     if (plugin.getModernizationMetadata() != null) {
                         plugin.fetchMetadata(ghService);
                         plugin.forkMetadata(ghService);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -597,10 +597,8 @@ public class PluginModernizer {
         plugin.format(mavenInvoker);
         plugin.verify(mavenInvoker);
         if (plugin.hasErrors()) {
-            LOG.info("Plugin {} failed to verify with JDK {}", plugin.getName(), jdk.getMajor());
-            plugin.withoutErrors();
+            LOG.warn("Plugin {} failed to verify with JDK {}", plugin.getName(), jdk.getMajor());
         }
-        plugin.withoutErrors();
 
         return jdk;
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
@@ -280,7 +280,8 @@ public enum JDK {
         return jdks.stream()
                 .filter(supportedByVersion::contains)
                 .min(JDK::compareMajor)
-                .orElseGet(() -> supportedByVersion.stream().min(JDK::compareMajor).orElse(JDK.min()));
+                .orElseGet(
+                        () -> supportedByVersion.stream().min(JDK::compareMajor).orElse(JDK.min()));
     }
 
     /**

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/model/JDK.java
@@ -261,15 +261,26 @@ public enum JDK {
     }
 
     /**
-     * Return the minimum JDK
-     * @param jdks List of JDKS. Can be null or empty
-     * @return The minimum JDK. If the list is empty, return the minimum JDK available
+     * Return the minimum JDK that is both declared in {@code jdks} and supported by
+     * {@code jenkinsVersion}. Falls back gracefully when either parameter is absent.
+     *
+     * @param jdks           JDKs declared by the plugin (e.g. from its Jenkinsfile). Can be null or empty.
+     * @param jenkinsVersion Jenkins core version the plugin targets. Can be null.
+     * @return The minimum compatible JDK, never null.
      */
     public static JDK min(Set<JDK> jdks, String jenkinsVersion) {
-        if (jdks == null || jdks.isEmpty() && jenkinsVersion == null) {
-            return JDK.min();
+        if (jenkinsVersion == null) {
+            return min(jdks);
         }
-        return JDK.get(jenkinsVersion).stream().min(JDK::compareMajor).orElseThrow();
+        List<JDK> supportedByVersion = get(jenkinsVersion);
+        if (jdks == null || jdks.isEmpty()) {
+            return supportedByVersion.stream().min(JDK::compareMajor).orElse(JDK.min());
+        }
+        // Intersect: lowest JDK that is both in the plugin's declared set and supported by this Jenkins version
+        return jdks.stream()
+                .filter(supportedByVersion::contains)
+                .min(JDK::compareMajor)
+                .orElseGet(() -> supportedByVersion.stream().min(JDK::compareMajor).orElse(JDK.min()));
     }
 
     /**

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/model/JDKTest.java
@@ -65,6 +65,16 @@ public class JDKTest {
         assertEquals(JDK.JAVA_11, JDK.min(Set.of(JDK.values()), "2.361.1"));
         assertEquals(JDK.JAVA_11, JDK.min(Set.of(JDK.values()), "2.462.3"));
         assertEquals(JDK.JAVA_17, JDK.min(Set.of(JDK.values()), "2.479.3"));
+        // jdks subset: the result must respect the declared JDKs, not just the Jenkins version range.
+        // Jenkins 2.479.3 supports Java 17 and 21; a plugin declaring [17,21] must yield 17, not 11.
+        assertEquals(JDK.JAVA_17, JDK.min(Set.of(JDK.JAVA_17, JDK.JAVA_21), "2.479.3"));
+        // Plugin declares only Java 21; Jenkins 2.462.3 supports up to Java 21, so the result is 21.
+        assertEquals(JDK.JAVA_21, JDK.min(Set.of(JDK.JAVA_21), "2.462.3"));
+        // null / empty jdks fall back to version-range minimum
+        assertEquals(JDK.JAVA_11, JDK.min(null, "2.387.3"));
+        assertEquals(JDK.JAVA_11, JDK.min(Set.of(), "2.387.3"));
+        // null version falls back to single-param min()
+        assertEquals(JDK.JAVA_8, JDK.min(null, null));
     }
 
     @Test


### PR DESCRIPTION
  Three silent bugs I found while working on the tool. Each one causes the tool to proceed as if nothing
  went wrong when it should have stopped or warned.                                                     
                                                   
  ### 1. Verification failures were silently swallowed (PluginModernizer.verifyPlugin)
                                                                                                            
  `verifyPlugin()` called `plugin.withoutErrors()` unconditionally at the end, regardless of whether the build  actually passed. The caller in `start()` would always see a clean plugin and continue to fork, commit, and  open a PR — even when the verification build failed. Removed both `withoutErrors()` calls and upgraded the log from INFO to WARN.                                                                                  

In dry-run mode, the error is still cleared after logging so the diff preview is still shown to the user (that's intentional — you're previewing, not committing).
                                                                                                            
###  2. `getDiffStats` always read from the default cache path (`GHService`)                                     

  `getDiffStats()` was resolving the .git directory against Settings.DEFAULT_CACHE_PATH instead of            
  `config.getCachePath()`. So running with `--cache-path /tmp/my-cache` would clone the plugin correctly there
  but then fail to read it back when building the PR description. One-line fix.                             
                                                                                                          
###  3. `JDK.min(Set, String)` ignored the `jdks` argument (JDK)

  Operator precedence bug in the guard:

  // was parsed as:
  if `(jdks == null || (jdks.isEmpty() && jenkinsVersion == null))`
                                                                                                            
So a non-null, non-empty jdks fell straight through to `JDK.get(jenkinsVersion)` with no filtering — jdks   was dead code. A plugin that declares [17, 21] in its Jenkinsfile would get compiled with Java 11 against an older Jenkins version. Rewrote the method to intersect the declared JDKs with the version-supported set and added tests for the untested paths.                                                                

  ---
  Testing: all three reproduced locally before the fix, gone after. mvn test -pl plugin-modernizer-core
  passes. 