### PR TITLE
feat: add --top-plugins N to target most-installed plugins by install count

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/PluginOptions.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/options/PluginOptions.java
@@ -50,9 +50,30 @@ public final class PluginOptions implements IOption {
             converter = PluginPathConverter.class)
     private Plugin pluginPath;
 
+    /**
+     * Run the recipe on the N most-installed plugins according to Jenkins stats.
+     * Mutually exclusive with --plugins, --plugin-file, and --plugin-path.
+     */
+    @CommandLine.Option(
+            names = {"--top-plugins"},
+            description =
+                    "Run the recipe on the N most-installed plugins according to Jenkins installation stats instead of an explicit list.",
+            defaultValue = "0")
+    private int topPluginsCount = 0;
+
     @Override
     public void config(Config.Builder builder) {
-        builder.withPlugins(getEffectivePlugins());
+        if (topPluginsCount > 0
+                && ((plugins != null && !plugins.isEmpty())
+                        || (pluginsFromFile != null && !pluginsFromFile.isEmpty())
+                        || pluginPath != null)) {
+            throw new ModernizerException(
+                    "--top-plugins cannot be combined with --plugins, --plugin-file, or --plugin-path");
+        }
+        if (topPluginsCount <= 0) {
+            builder.withPlugins(getEffectivePlugins());
+        }
+        builder.withTopPluginsCount(topPluginsCount);
         if (pluginPath != null) {
             LOG.info("Running in dry-run because of local plugin: {}", pluginPath);
             builder.withDryRun(true);

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/config/Config.java
@@ -18,6 +18,7 @@ public class Config {
 
     private final String version;
     private final List<Plugin> plugins;
+    private final int topPluginsCount;
     private final Recipe recipe;
     private final URL jenkinsUpdateCenter;
     private final URL jenkinsPluginVersions;
@@ -49,6 +50,7 @@ public class Config {
             Long githubAppTargetInstallationId,
             Path sshPrivateKey,
             List<Plugin> plugins,
+            int topPluginsCount,
             Recipe recipe,
             URL jenkinsUpdateCenter,
             URL jenkinsPluginVersions,
@@ -73,6 +75,7 @@ public class Config {
         this.githubAppTargetInstallationId = githubAppTargetInstallationId;
         this.sshPrivateKey = sshPrivateKey;
         this.plugins = plugins;
+        this.topPluginsCount = topPluginsCount;
         this.recipe = recipe;
         this.jenkinsUpdateCenter = jenkinsUpdateCenter;
         this.jenkinsPluginVersions = jenkinsPluginVersions;
@@ -118,6 +121,14 @@ public class Config {
 
     public List<Plugin> getPlugins() {
         return plugins;
+    }
+
+    /**
+     * Return the number of top-installed plugins to process (0 means not set; use explicit plugin list instead).
+     * @return Top plugins count, or 0 if not set
+     */
+    public int getTopPluginsCount() {
+        return topPluginsCount;
     }
 
     public Recipe getRecipe() {
@@ -255,6 +266,7 @@ public class Config {
         private Long githubAppTargetInstallationId;
         private Path sshPrivateKey = Settings.SSH_PRIVATE_KEY;
         private List<Plugin> plugins;
+        private int topPluginsCount = 0;
         private Recipe recipe;
         private URL jenkinsUpdateCenter = Settings.DEFAULT_UPDATE_CENTER_URL;
         private URL jenkinsPluginVersions = Settings.DEFAULT_PLUGIN_VERSIONS;
@@ -305,6 +317,11 @@ public class Config {
 
         public Builder withPlugins(List<Plugin> plugins) {
             this.plugins = plugins;
+            return this;
+        }
+
+        public Builder withTopPluginsCount(int topPluginsCount) {
+            this.topPluginsCount = topPluginsCount;
             return this;
         }
 
@@ -420,6 +437,7 @@ public class Config {
                     githubAppTargetInstallationId,
                     sshPrivateKey,
                     plugins,
+                    topPluginsCount,
                     recipe,
                     jenkinsUpdateCenter,
                     jenkinsPluginVersions,

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -168,7 +168,19 @@ public class PluginModernizer {
         // Fetch plugin versions
         pluginService.getPluginVersionData();
 
-        List<Plugin> plugins = config.getPlugins();
+        List<Plugin> plugins;
+        if (config.getTopPluginsCount() > 0) {
+            LOG.info(
+                    "Resolving top {} most-installed plugins from installation stats...",
+                    config.getTopPluginsCount());
+            plugins = pluginService.getTopPlugins(config.getTopPluginsCount());
+            LOG.info(
+                    "Will process {} plugins: {}",
+                    plugins.size(),
+                    plugins.stream().map(Plugin::getName).toList());
+        } else {
+            plugins = config.getPlugins();
+        }
         plugins.forEach(this::process);
         printResults(plugins);
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -170,9 +170,7 @@ public class PluginModernizer {
 
         List<Plugin> plugins;
         if (config.getTopPluginsCount() > 0) {
-            LOG.info(
-                    "Resolving top {} most-installed plugins from installation stats...",
-                    config.getTopPluginsCount());
+            LOG.info("Resolving top {} most-installed plugins from installation stats...", config.getTopPluginsCount());
             plugins = pluginService.getTopPlugins(config.getTopPluginsCount());
             LOG.info(
                     "Will process {} plugins: {}",

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginService.java
@@ -13,6 +13,9 @@ import io.jenkins.tools.pluginmodernizer.core.model.PluginVersionData;
 import io.jenkins.tools.pluginmodernizer.core.model.UpdateCenterData;
 import jakarta.inject.Inject;
 import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -245,6 +248,24 @@ public class PluginService {
         PluginInstallationStatsData pluginInstallationStatsData = new PluginInstallationStatsData(cacheManager);
         pluginInstallationStatsData.setPlugins(CSVUtils.parseStats(data));
         return pluginInstallationStatsData;
+    }
+
+    /**
+     * Return the top N most-installed plugins ordered by installation count descending.
+     * If n exceeds the number of known plugins, all known plugins are returned.
+     * @param n Number of plugins to return; must be positive
+     * @return Ordered list of plugins, highest-install-count first
+     */
+    public List<Plugin> getTopPlugins(int n) {
+        if (n <= 0) {
+            throw new IllegalArgumentException("n must be a positive integer, got: " + n);
+        }
+        PluginInstallationStatsData stats = getPluginInstallationStatsData();
+        return stats.getPlugins().entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue(Comparator.reverseOrder()))
+                .limit(n)
+                .map(entry -> Plugin.build(entry.getKey()))
+                .toList();
     }
 
     /**

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginServiceTest.java
@@ -367,7 +367,7 @@ class PluginServiceTest {
                         ReflectionUtils.HierarchyTraversalMode.TOP_DOWN)
                 .get(0);
         pluginInstallationDataField.setAccessible(true);
-        pluginInstallationDataField.set(pluginInstallationStatsData, healthPlugins);
+        pluginInstallationDataField.set(pluginInstallationStatsData, installations);
 
         return Triple.of(updateCenterData, healthScoreData, pluginInstallationStatsData);
     }
@@ -404,5 +404,49 @@ class PluginServiceTest {
         boolean exists = pluginService.existsInUpdateCenter(nonExistentPlugin);
 
         assertEquals(false, exists, "Plugin 'non-existent-plugin' should not exist in update center");
+    }
+
+    @Test
+    public void shouldGetTopPlugins() throws Exception {
+        CacheManager cacheManager = Mockito.mock(CacheManager.class);
+        Path cacheRoot = Mockito.mock(Path.class);
+        Config config = Mockito.mock(Config.class);
+        PluginInstallationStatsData statsData =
+                setup(config, cacheManager, cacheRoot).getRight();
+
+        doReturn(statsData)
+                .when(cacheManager)
+                .get(cacheRoot, CacheManager.INSTALLATION_STATS_KEY, PluginInstallationStatsData.class);
+        doReturn(cacheRoot).when(cacheManager).root();
+
+        PluginService service = getService(config, cacheManager);
+
+        // Top 1 must be the plugin with the highest install count (valid-plugin: 1000)
+        var top1 = service.getTopPlugins(1);
+        assertEquals(1, top1.size());
+        assertEquals("valid-plugin", top1.get(0).getName());
+
+        // Top 2 must be ordered descending: valid-plugin (1000) then valid-plugin2 (500)
+        var top2 = service.getTopPlugins(2);
+        assertEquals(2, top2.size());
+        assertEquals("valid-plugin", top2.get(0).getName());
+        assertEquals("valid-plugin2", top2.get(1).getName());
+
+        // Requesting more than available returns all known plugins
+        var topAll = service.getTopPlugins(100);
+        assertEquals(2, topAll.size());
+    }
+
+    @Test
+    public void shouldThrowWhenTopPluginsCountIsZeroOrNegative() throws Exception {
+        CacheManager cacheManager = Mockito.mock(CacheManager.class);
+        Path cacheRoot = Mockito.mock(Path.class);
+        Config config = Mockito.mock(Config.class);
+        setup(config, cacheManager, cacheRoot);
+
+        PluginService service = getService(config, cacheManager);
+
+        assertThrows(IllegalArgumentException.class, () -> service.getTopPlugins(0));
+        assertThrows(IllegalArgumentException.class, () -> service.getTopPlugins(-1));
     }
 }


### PR DESCRIPTION
## Summary

Adds `--top-plugins N` CLI flag that runs a recipe against the N most-installed
Jenkins plugins instead of an explicit plugin list. The ranked installation-count
data is already fetched and cached by the tool; this feature wires it up as a
plugin-source path.

### Usage

```bash
# Run SetupDependabot on the 50 most-installed plugins
plugin-modernizer run --top-plugins 50 --recipe SetupDependabot

# Combine with other flags — top 20, dry-run mode
plugin-modernizer run --top-plugins 20 --recipe UpgradeParentVersion --dry-run
```

`--top-plugins` is mutually exclusive with `--plugins`, `--plugin-file`, and
`--plugin-path`.

## Changes

| File | Change |
|------|--------|
| `PluginOptions.java` | New `--top-plugins` CLI option with mutual-exclusion guard |
| `Config.java` | New `topPluginsCount` field + builder method |
| `PluginService.java` | New `getTopPlugins(int n)` — sorts installation stats descending and takes top N |
| `PluginModernizer.java` | At start(), resolves plugin list from stats when `topPluginsCount > 0` |
| `PluginServiceTest.java` | Two new tests: ordered top-N selection and zero/negative-input guard |

## Testing

- `mvn test -pl plugin-modernizer-core -Dtest=PluginServiceTest` — all tests pass
- Manual: `--top-plugins 2` correctly returns the two highest-install-count plugins in descending order

<img width="1262" height="1521" alt="image" src="https://github.com/user-attachments/assets/e86784ce-7062-4313-b1a5-6e2b6dd167e0" />

<img width="1243" height="1204" alt="image" src="https://github.com/user-attachments/assets/f400947a-56d8-48a4-97bb-3f54b5fbfc0d" />

 Top 2 plugins resolved correctly picked `script-security` and `structs` (the two most-installed plugins by Jenkins stats)
