### PR TITLE
feat: add campaign mode for multi-stage plugin modernization

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/Main.java
@@ -1,6 +1,7 @@
 package io.jenkins.tools.pluginmodernizer.cli;
 
 import io.jenkins.tools.pluginmodernizer.cli.command.BuildMetadataCommand;
+import io.jenkins.tools.pluginmodernizer.cli.command.CampaignCommand;
 import io.jenkins.tools.pluginmodernizer.cli.command.CleanupCommand;
 import io.jenkins.tools.pluginmodernizer.cli.command.DryRunCommand;
 import io.jenkins.tools.pluginmodernizer.cli.command.ListRecipesCommand;
@@ -22,6 +23,7 @@ import picocli.CommandLine.Command;
             ValidateCommand.class,
             ListRecipesCommand.class,
             BuildMetadataCommand.class,
+            CampaignCommand.class,
             DryRunCommand.class,
             RunCommand.class,
             CleanupCommand.class,

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CampaignCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CampaignCommand.java
@@ -19,8 +19,7 @@ import picocli.CommandLine;
  */
 @CommandLine.Command(
         name = "campaign",
-        description =
-                "Run a multi-stage modernization campaign in dry-run mode and emit a structured JSON report")
+        description = "Run a multi-stage modernization campaign in dry-run mode and emit a structured JSON report")
 public class CampaignCommand implements ICommand {
 
     private static final Logger LOG = LoggerFactory.getLogger(CampaignCommand.class);
@@ -51,8 +50,8 @@ public class CampaignCommand implements ICommand {
     @Override
     public Integer call() {
         try {
-            CampaignService campaignService =
-                    Guice.createInjector(new GuiceModule(setup(Config.builder()))).getInstance(CampaignService.class);
+            CampaignService campaignService = Guice.createInjector(new GuiceModule(setup(Config.builder())))
+                    .getInstance(CampaignService.class);
             CampaignReport report = campaignService.run(file);
             LOG.info(
                     "Campaign finished. Plugins: {} success / {} failed. Report: {}",

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CampaignCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CampaignCommand.java
@@ -1,0 +1,73 @@
+package io.jenkins.tools.pluginmodernizer.cli.command;
+
+import com.google.inject.Guice;
+import io.jenkins.tools.pluginmodernizer.cli.options.EnvOptions;
+import io.jenkins.tools.pluginmodernizer.cli.options.GitHubOptions;
+import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
+import io.jenkins.tools.pluginmodernizer.core.GuiceModule;
+import io.jenkins.tools.pluginmodernizer.core.campaign.CampaignReport;
+import io.jenkins.tools.pluginmodernizer.core.campaign.CampaignService;
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+/**
+ * Campaign command.
+ */
+@CommandLine.Command(
+        name = "campaign",
+        description =
+                "Run a multi-stage modernization campaign in dry-run mode and emit a structured JSON report")
+public class CampaignCommand implements ICommand {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CampaignCommand.class);
+
+    @CommandLine.Option(
+            names = {"--file"},
+            required = true,
+            description = "Path to the campaign YAML file.")
+    private Path file;
+
+    @CommandLine.Mixin
+    private EnvOptions envOptions;
+
+    @CommandLine.Mixin
+    private GlobalOptions options = GlobalOptions.getInstance();
+
+    @CommandLine.Mixin
+    private GitHubOptions githubOptions;
+
+    @Override
+    public Config setup(Config.Builder builder) {
+        options.config(builder);
+        envOptions.config(builder);
+        githubOptions.config(builder);
+        return builder.withDryRun(true).build();
+    }
+
+    @Override
+    public Integer call() {
+        try {
+            CampaignService campaignService =
+                    Guice.createInjector(new GuiceModule(setup(Config.builder()))).getInstance(CampaignService.class);
+            CampaignReport report = campaignService.run(file);
+            LOG.info(
+                    "Campaign finished. Plugins: {} success / {} failed. Report: {}",
+                    report.getSuccessfulPlugins(),
+                    report.getFailedPlugins(),
+                    report.getReportJson());
+            return report.getFailedStages() > 0 ? 1 : 0;
+        } catch (ModernizerException e) {
+            LOG.error("Campaign validation error");
+            LOG.error(e.getMessage());
+            return 1;
+        } catch (RuntimeException e) {
+            LOG.error("Campaign execution failed");
+            LOG.error(e.getMessage() != null ? e.getMessage() : e.getClass().getName());
+            return 1;
+        }
+    }
+}

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/converter/PluginPathConverter.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/converter/PluginPathConverter.java
@@ -1,97 +1,17 @@
 package io.jenkins.tools.pluginmodernizer.cli.converter;
 
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
-import io.jenkins.tools.pluginmodernizer.core.utils.StaticPomParser;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.stream.Stream;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import io.jenkins.tools.pluginmodernizer.core.utils.PluginPathResolver;
 import picocli.CommandLine;
 
 /**
  * Custom converter to get a list of plugin from a local folder
  */
 public class PluginPathConverter implements CommandLine.ITypeConverter<Plugin> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(PluginPathConverter.class);
+    private final PluginPathResolver pluginPathResolver = new PluginPathResolver();
 
     @Override
     public Plugin convert(String value) throws Exception {
-        Path path = Path.of(value);
-        if (!Files.isDirectory(path)) {
-            throw new IllegalArgumentException("Path is not a directory: " + path);
-        }
-
-        Path pom = path.resolve("pom.xml");
-        if (!Files.exists(pom)) {
-            throw new IllegalArgumentException("Path does not contain a pom.xml: " + path);
-        }
-
-        StaticPomParser rootPomParser = new StaticPomParser(pom.toString());
-        String packaging = rootPomParser.getPackaging();
-
-        // Check if this is a single-module Jenkins plugin
-        if ("hpi".equals(packaging)) {
-            String artifactId = rootPomParser.getArtifactId();
-            if (artifactId == null) {
-                throw new IllegalArgumentException("Path does not contain a valid Jenkins plugin: " + path);
-            }
-            LOG.info("Found single-module plugin '{}' at root level", artifactId);
-            return Plugin.build(artifactId, path);
-        }
-
-        // Check if this is a multi-module project (packaging = pom)
-        if ("pom".equals(packaging) || packaging == null || packaging.isEmpty()) {
-            LOG.info("Detected multi-module project, searching for Jenkins plugin module...");
-            Path pluginPath = findJenkinsPluginModule(path);
-            if (pluginPath != null) {
-                StaticPomParser pluginPomParser =
-                        new StaticPomParser(pluginPath.resolve("pom.xml").toString());
-                String artifactId = pluginPomParser.getArtifactId();
-                if (artifactId == null) {
-                    throw new IllegalArgumentException(
-                            "Plugin module does not contain valid artifactId: " + pluginPath);
-                }
-                LOG.info("Found Jenkins plugin module '{}' at: {}", artifactId, pluginPath);
-                return Plugin.build(artifactId, pluginPath);
-            }
-            throw new IllegalArgumentException(
-                    "Multi-module project detected but no module with packaging 'hpi' found" + path);
-        }
-
-        throw new IllegalArgumentException(
-                "Path does not contain a Jenkins plugin (packaging must be 'hpi' or a multi-module project with an hpi module): "
-                        + path);
-    }
-
-    /**
-     * Find the Jenkins plugin module in a multi-module project.
-     * Searches all subdirectories for a pom.xml with packaging 'hpi'.
-     *
-     * @param rootPath The root path of the multi-module project
-     * @return The path to the plugin module, or null if not found
-     * @throws IOException if an I/O error occurs
-     */
-    private Path findJenkinsPluginModule(Path rootPath) throws IOException {
-        try (Stream<Path> paths = Files.walk(rootPath, 2)) { // Search up to 2 levels deep
-            return paths.filter(Files::isDirectory)
-                    .filter(dir -> !dir.equals(rootPath)) // Skip root directory
-                    .filter(dir -> Files.exists(dir.resolve("pom.xml")))
-                    .filter(dir -> {
-                        try {
-                            StaticPomParser parser =
-                                    new StaticPomParser(dir.resolve("pom.xml").toString());
-                            String packaging = parser.getPackaging();
-                            return "hpi".equals(packaging);
-                        } catch (Exception e) {
-                            LOG.debug("Failed to parse pom.xml in {}: {}", dir, e.getMessage());
-                            return false;
-                        }
-                    })
-                    .findFirst()
-                    .orElse(null);
-        }
+        return pluginPathResolver.resolve(value);
     }
 }

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/converter/RecipeConverter.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/converter/RecipeConverter.java
@@ -1,7 +1,7 @@
 package io.jenkins.tools.pluginmodernizer.cli.converter;
 
-import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
+import io.jenkins.tools.pluginmodernizer.core.utils.RecipeResolver;
 import java.util.Iterator;
 import picocli.CommandLine;
 
@@ -9,22 +9,15 @@ import picocli.CommandLine;
  * Custom converter for Recipe interface.
  */
 public final class RecipeConverter implements CommandLine.ITypeConverter<Recipe>, Iterable<String> {
+    private final RecipeResolver recipeResolver = new RecipeResolver();
+
     @Override
     public Recipe convert(String value) {
-        return Settings.AVAILABLE_RECIPES.stream()
-                // Compare without and without the FQDN prefix
-                .filter(recipe -> recipe.getName().equals(value)
-                        || recipe.getName()
-                                .replace(Settings.RECIPE_FQDN_PREFIX + ".", "")
-                                .equals(value))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Invalid recipe name: " + value));
+        return recipeResolver.resolve(value);
     }
 
     @Override
     public Iterator<String> iterator() {
-        return Settings.AVAILABLE_RECIPES.stream()
-                .map(r -> r.getName().replace(Settings.RECIPE_FQDN_PREFIX + ".", ""))
-                .iterator();
+        return recipeResolver.candidates().iterator();
     }
 }

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import io.jenkins.tools.pluginmodernizer.cli.utils.GitHubServerContainer;
 import io.jenkins.tools.pluginmodernizer.cli.utils.ModernizerTestWatcher;
+import io.jenkins.tools.pluginmodernizer.core.campaign.CampaignReport;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
 import io.jenkins.tools.pluginmodernizer.core.extractor.ArchetypeCommonFile;
 import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
@@ -553,6 +554,93 @@ public class CommandLineITCase {
             assertTrue(
                     Files.exists(targetPath.resolve(ArchetypeCommonFile.WORKFLOW_SECURITY.getPath())),
                     "Workflow security file was not created");
+        }
+    }
+
+    @Test
+    @Tag("Slow")
+    public void testCampaignOnLocalPlugin(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+
+        Path logFile = setupLogs("testCampaignOnLocalPlugin");
+
+        final String plugin = "empty";
+        final Path pluginPath = Path.of("src/test/resources").resolve(plugin);
+        Path targetPath = cachePath
+                .resolve("jenkins-plugin-modernizer-cli")
+                .resolve(plugin)
+                .resolve("sources");
+        FileUtils.copyDirectory(pluginPath.toFile(), targetPath.toFile());
+        Git.init().setDirectory(targetPath.toFile()).call().close();
+
+        Path campaignFile = cachePath.resolve("campaign.yaml");
+        Files.writeString(
+                campaignFile,
+                """
+                plugins:
+                  localPaths:
+                    - %s
+                stages:
+                  - recipe: SetupDependabot
+                  - recipe: SetupSecurityScan
+                execution:
+                  concurrency: 1
+                  continueOnFailure: false
+                  skipMetadata: true
+                output:
+                  reportJson: reports/campaign.json
+                """
+                        .formatted(targetPath.toAbsolutePath()));
+
+        try (GitHubServerContainer gitRemote = new GitHubServerContainer(wmRuntimeInfo, keysPath, plugin, "main")) {
+
+            gitRemote.start();
+
+            System.out.printf("[[ATTACHMENT|%s]]%n", getMavenInvokerLog(plugin));
+            System.out.printf("[[ATTACHMENT|%s]]%n", logFile.toAbsolutePath());
+
+            Invoker invoker = buildInvoker();
+            InvocationRequest request = buildRequest(
+                    """
+                    campaign --file %s
+                    --debug
+                    --maven-home %s
+                    --ssh-private-key %s
+                    --cache-path %s
+                    --github-api-url %s
+                    --jenkins-update-center %s
+                    --jenkins-plugin-info %s
+                    --plugin-health-score %s
+                    --jenkins-plugins-stats-installations-url %s
+                    """
+                            .formatted(
+                                    campaignFile.toAbsolutePath(),
+                                    getModernizerMavenHome(),
+                                    keysPath.resolve(plugin),
+                                    cachePath,
+                                    wmRuntimeInfo.getHttpBaseUrl() + "/api",
+                                    wmRuntimeInfo.getHttpBaseUrl() + "/update-center.json",
+                                    wmRuntimeInfo.getHttpBaseUrl() + "/plugin-versions.json",
+                                    wmRuntimeInfo.getHttpBaseUrl() + "/scores",
+                                    wmRuntimeInfo.getHttpBaseUrl() + "/jenkins-stats/svg/202406-plugins.csv")
+                            .replaceAll("\\s+", " "),
+                    logFile);
+            InvocationResult result = invoker.execute(request);
+
+            Path reportPath = cachePath.resolve("reports").resolve("campaign.json");
+            CampaignReport report = JsonUtils.fromJson(reportPath, CampaignReport.class);
+
+            assertAll(
+                    () -> assertEquals(0, result.getExitCode()),
+                    () -> assertTrue(Files.readAllLines(logFile).stream()
+                            .anyMatch(line -> line.matches("(.*)Campaign finished. Plugins: 1 success / 0 failed.(.*)"))),
+                    () -> assertTrue(Files.exists(targetPath.resolve(".github").resolve("dependabot.yml"))),
+                    () -> assertTrue(Files.exists(targetPath.resolve(ArchetypeCommonFile.WORKFLOW_SECURITY.getPath()))),
+                    () -> assertTrue(Files.exists(reportPath)),
+                    () -> assertEquals(1, report.getSuccessfulPlugins()),
+                    () -> assertEquals(2, report.getSuccessfulStages()),
+                    () -> assertEquals(
+                            targetPath.toAbsolutePath().toString(),
+                            report.getPlugins().get(0).getFinalLocalRepository()));
         }
     }
 

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -573,9 +573,7 @@ public class CommandLineITCase {
         Git.init().setDirectory(targetPath.toFile()).call().close();
 
         Path campaignFile = cachePath.resolve("campaign.yaml");
-        Files.writeString(
-                campaignFile,
-                """
+        Files.writeString(campaignFile, """
                 plugins:
                   localPaths:
                     - %s
@@ -588,8 +586,7 @@ public class CommandLineITCase {
                   skipMetadata: true
                 output:
                   reportJson: reports/campaign.json
-                """
-                        .formatted(targetPath.toAbsolutePath()));
+                """.formatted(targetPath.toAbsolutePath()));
 
         try (GitHubServerContainer gitRemote = new GitHubServerContainer(wmRuntimeInfo, keysPath, plugin, "main")) {
 
@@ -611,8 +608,7 @@ public class CommandLineITCase {
                     --jenkins-plugin-info %s
                     --plugin-health-score %s
                     --jenkins-plugins-stats-installations-url %s
-                    """
-                            .formatted(
+                    """.formatted(
                                     campaignFile.toAbsolutePath(),
                                     getModernizerMavenHome(),
                                     keysPath.resolve(plugin),
@@ -632,7 +628,8 @@ public class CommandLineITCase {
             assertAll(
                     () -> assertEquals(0, result.getExitCode()),
                     () -> assertTrue(Files.readAllLines(logFile).stream()
-                            .anyMatch(line -> line.matches("(.*)Campaign finished. Plugins: 1 success / 0 failed.(.*)"))),
+                            .anyMatch(
+                                    line -> line.matches("(.*)Campaign finished. Plugins: 1 success / 0 failed.(.*)"))),
                     () -> assertTrue(Files.exists(targetPath.resolve(".github").resolve("dependabot.yml"))),
                     () -> assertTrue(Files.exists(targetPath.resolve(ArchetypeCommonFile.WORKFLOW_SECURITY.getPath()))),
                     () -> assertTrue(Files.exists(reportPath)),

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/GuiceModule.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/GuiceModule.java
@@ -1,6 +1,8 @@
 package io.jenkins.tools.pluginmodernizer.core;
 
 import com.google.inject.AbstractModule;
+import io.jenkins.tools.pluginmodernizer.core.campaign.CampaignModernizerRunner;
+import io.jenkins.tools.pluginmodernizer.core.campaign.DefaultCampaignModernizerRunner;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.github.GHService;
 import io.jenkins.tools.pluginmodernizer.core.impl.CacheManager;
@@ -21,6 +23,7 @@ public class GuiceModule extends AbstractModule {
     @Override
     protected void configure() {
         bind(Invoker.class).to(DefaultInvoker.class);
+        bind(CampaignModernizerRunner.class).to(DefaultCampaignModernizerRunner.class);
         bind(Config.class).toInstance(config);
         bind(CacheManager.class).toInstance(new CacheManager(config.getCachePath()));
         bind(PluginService.class).toInstance(new PluginService());

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignDefinition.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignDefinition.java
@@ -1,0 +1,48 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * Top-level campaign definition loaded from YAML.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CampaignDefinition {
+
+    private CampaignPluginSource plugins = new CampaignPluginSource();
+    private List<CampaignStage> stages;
+    private CampaignExecution execution = new CampaignExecution();
+    private CampaignOutput output = new CampaignOutput();
+
+    public CampaignPluginSource getPlugins() {
+        return plugins;
+    }
+
+    public void setPlugins(CampaignPluginSource plugins) {
+        this.plugins = plugins;
+    }
+
+    public List<CampaignStage> getStages() {
+        return stages;
+    }
+
+    public void setStages(List<CampaignStage> stages) {
+        this.stages = stages;
+    }
+
+    public CampaignExecution getExecution() {
+        return execution;
+    }
+
+    public void setExecution(CampaignExecution execution) {
+        this.execution = execution;
+    }
+
+    public CampaignOutput getOutput() {
+        return output;
+    }
+
+    public void setOutput(CampaignOutput output) {
+        this.output = output;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignExecution.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignExecution.java
@@ -1,0 +1,38 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Execution settings for a campaign.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CampaignExecution {
+
+    private int concurrency = 1;
+    private boolean continueOnFailure = true;
+    private boolean skipMetadata;
+
+    public int getConcurrency() {
+        return concurrency;
+    }
+
+    public void setConcurrency(int concurrency) {
+        this.concurrency = concurrency;
+    }
+
+    public boolean isContinueOnFailure() {
+        return continueOnFailure;
+    }
+
+    public void setContinueOnFailure(boolean continueOnFailure) {
+        this.continueOnFailure = continueOnFailure;
+    }
+
+    public boolean isSkipMetadata() {
+        return skipMetadata;
+    }
+
+    public void setSkipMetadata(boolean skipMetadata) {
+        this.skipMetadata = skipMetadata;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignFilters.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignFilters.java
@@ -1,0 +1,65 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Optional filters applied to remote plugin selections.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CampaignFilters {
+
+    private Integer minInstallations;
+    private Double maxHealthScore;
+    private boolean excludeDeprecated;
+    private boolean excludeApiPlugins;
+    private boolean requireAdoptThisPlugin;
+    private boolean excludeNoKnownInstallations;
+
+    public Integer getMinInstallations() {
+        return minInstallations;
+    }
+
+    public void setMinInstallations(Integer minInstallations) {
+        this.minInstallations = minInstallations;
+    }
+
+    public Double getMaxHealthScore() {
+        return maxHealthScore;
+    }
+
+    public void setMaxHealthScore(Double maxHealthScore) {
+        this.maxHealthScore = maxHealthScore;
+    }
+
+    public boolean isExcludeDeprecated() {
+        return excludeDeprecated;
+    }
+
+    public void setExcludeDeprecated(boolean excludeDeprecated) {
+        this.excludeDeprecated = excludeDeprecated;
+    }
+
+    public boolean isExcludeApiPlugins() {
+        return excludeApiPlugins;
+    }
+
+    public void setExcludeApiPlugins(boolean excludeApiPlugins) {
+        this.excludeApiPlugins = excludeApiPlugins;
+    }
+
+    public boolean isRequireAdoptThisPlugin() {
+        return requireAdoptThisPlugin;
+    }
+
+    public void setRequireAdoptThisPlugin(boolean requireAdoptThisPlugin) {
+        this.requireAdoptThisPlugin = requireAdoptThisPlugin;
+    }
+
+    public boolean isExcludeNoKnownInstallations() {
+        return excludeNoKnownInstallations;
+    }
+
+    public void setExcludeNoKnownInstallations(boolean excludeNoKnownInstallations) {
+        this.excludeNoKnownInstallations = excludeNoKnownInstallations;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignModernizerRunner.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignModernizerRunner.java
@@ -1,0 +1,11 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+
+/**
+ * Runs one stage against one plugin using the existing PluginModernizer engine.
+ */
+public interface CampaignModernizerRunner {
+
+    CampaignStageReport runStage(Config stageConfig, CampaignStage stage);
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignOutput.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignOutput.java
@@ -1,0 +1,20 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Output configuration for campaign artifacts.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CampaignOutput {
+
+    private String reportJson;
+
+    public String getReportJson() {
+        return reportJson;
+    }
+
+    public void setReportJson(String reportJson) {
+        this.reportJson = reportJson;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignParser.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignParser.java
@@ -55,9 +55,12 @@ public class CampaignParser {
 
     private void validate(CampaignDefinition definition, Path campaignFile) {
         CampaignPluginSource pluginSource = definition.getPlugins();
-        boolean hasNames = pluginSource.getNames() != null && !pluginSource.getNames().isEmpty();
-        boolean hasFile = pluginSource.getFile() != null && !pluginSource.getFile().isBlank();
-        boolean hasLocalPaths = pluginSource.getLocalPaths() != null && !pluginSource.getLocalPaths().isEmpty();
+        boolean hasNames =
+                pluginSource.getNames() != null && !pluginSource.getNames().isEmpty();
+        boolean hasFile =
+                pluginSource.getFile() != null && !pluginSource.getFile().isBlank();
+        boolean hasLocalPaths = pluginSource.getLocalPaths() != null
+                && !pluginSource.getLocalPaths().isEmpty();
         boolean hasTopPlugins = pluginSource.getTopPlugins() != null;
 
         if (!hasNames && !hasFile && !hasLocalPaths && !hasTopPlugins) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignParser.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignParser.java
@@ -1,0 +1,87 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import io.jenkins.tools.pluginmodernizer.core.utils.RecipeResolver;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Loads and validates campaign definitions from YAML files.
+ */
+public class CampaignParser {
+
+    private final ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+    private final RecipeResolver recipeResolver;
+
+    @Inject
+    public CampaignParser(RecipeResolver recipeResolver) {
+        this.recipeResolver = recipeResolver;
+    }
+
+    public CampaignDefinition parse(Path campaignFile) {
+        Path normalized = campaignFile.toAbsolutePath().normalize();
+        if (!Files.isRegularFile(normalized)) {
+            throw new ModernizerException("Campaign file does not exist: " + normalized);
+        }
+        try {
+            CampaignDefinition definition = objectMapper.readValue(normalized.toFile(), CampaignDefinition.class);
+            normalize(definition);
+            validate(definition, normalized);
+            return definition;
+        } catch (IOException e) {
+            throw new ModernizerException("Failed to parse campaign file: " + normalized, e);
+        }
+    }
+
+    private void normalize(CampaignDefinition definition) {
+        if (definition.getPlugins() == null) {
+            definition.setPlugins(new CampaignPluginSource());
+        }
+        if (definition.getPlugins().getFilters() == null) {
+            definition.getPlugins().setFilters(new CampaignFilters());
+        }
+        if (definition.getExecution() == null) {
+            definition.setExecution(new CampaignExecution());
+        }
+        if (definition.getOutput() == null) {
+            definition.setOutput(new CampaignOutput());
+        }
+    }
+
+    private void validate(CampaignDefinition definition, Path campaignFile) {
+        CampaignPluginSource pluginSource = definition.getPlugins();
+        boolean hasNames = pluginSource.getNames() != null && !pluginSource.getNames().isEmpty();
+        boolean hasFile = pluginSource.getFile() != null && !pluginSource.getFile().isBlank();
+        boolean hasLocalPaths = pluginSource.getLocalPaths() != null && !pluginSource.getLocalPaths().isEmpty();
+        boolean hasTopPlugins = pluginSource.getTopPlugins() != null;
+
+        if (!hasNames && !hasFile && !hasLocalPaths && !hasTopPlugins) {
+            throw new ModernizerException(
+                    "Campaign file must define at least one plugin source (names, file, localPaths, or topPlugins): "
+                            + campaignFile);
+        }
+        if (pluginSource.getTopPlugins() != null && pluginSource.getTopPlugins() <= 0) {
+            throw new ModernizerException("Campaign topPlugins must be greater than zero");
+        }
+
+        List<CampaignStage> stages = definition.getStages();
+        if (stages == null || stages.isEmpty()) {
+            throw new ModernizerException("Campaign file must define at least one stage: " + campaignFile);
+        }
+        for (CampaignStage stage : stages) {
+            if (stage.getRecipe() == null || stage.getRecipe().isBlank()) {
+                throw new ModernizerException("Campaign stage is missing a recipe name");
+            }
+            recipeResolver.resolve(stage.getRecipe());
+        }
+
+        if (definition.getExecution().getConcurrency() <= 0) {
+            throw new ModernizerException("Campaign concurrency must be greater than zero");
+        }
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginReport.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginReport.java
@@ -1,0 +1,66 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * Result of all stages executed for one plugin in a campaign.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CampaignPluginReport {
+
+    private String pluginName;
+    private boolean local;
+    private String source;
+    private String finalLocalRepository;
+    private boolean success;
+    private List<CampaignStageReport> stages;
+
+    public String getPluginName() {
+        return pluginName;
+    }
+
+    public void setPluginName(String pluginName) {
+        this.pluginName = pluginName;
+    }
+
+    public boolean isLocal() {
+        return local;
+    }
+
+    public void setLocal(boolean local) {
+        this.local = local;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+
+    public String getFinalLocalRepository() {
+        return finalLocalRepository;
+    }
+
+    public void setFinalLocalRepository(String finalLocalRepository) {
+        this.finalLocalRepository = finalLocalRepository;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public List<CampaignStageReport> getStages() {
+        return stages;
+    }
+
+    public void setStages(List<CampaignStageReport> stages) {
+        this.stages = stages;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginSelector.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginSelector.java
@@ -1,0 +1,153 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import io.jenkins.tools.pluginmodernizer.core.utils.PluginPathResolver;
+import io.jenkins.tools.pluginmodernizer.core.utils.PluginService;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * Resolves campaign plugin sources to concrete plugins and applies remote filters.
+ */
+public class CampaignPluginSelector {
+
+    private final PluginService pluginService;
+    private final PluginPathResolver pluginPathResolver = new PluginPathResolver();
+
+    @Inject
+    public CampaignPluginSelector(PluginService pluginService) {
+        this.pluginService = pluginService;
+    }
+
+    public List<Plugin> selectPlugins(CampaignDefinition definition, Path campaignFile) {
+        CampaignPluginSource source = definition.getPlugins();
+        Path baseDir = campaignFile.toAbsolutePath().normalize().getParent();
+        LinkedHashMap<String, Plugin> plugins = new LinkedHashMap<>();
+
+        addNamedPlugins(plugins, source.getNames());
+        addPluginFile(plugins, source.getFile(), baseDir);
+        addLocalPaths(plugins, source.getLocalPaths(), baseDir);
+        addTopPlugins(plugins, source.getTopPlugins());
+
+        List<Plugin> selectedPlugins = plugins.values().stream()
+                .filter(plugin -> keepPlugin(plugin, source.getFilters()))
+                .toList();
+
+        if (selectedPlugins.isEmpty()) {
+            throw new ModernizerException("Campaign selection returned no plugins after applying filters");
+        }
+        return selectedPlugins;
+    }
+
+    private void addNamedPlugins(Map<String, Plugin> plugins, List<String> names) {
+        if (names == null) {
+            return;
+        }
+        for (String name : names) {
+            if (name != null && !name.isBlank()) {
+                Plugin plugin = Plugin.build(name.trim());
+                plugins.putIfAbsent(key(plugin), plugin);
+            }
+        }
+    }
+
+    private void addPluginFile(Map<String, Plugin> plugins, String pluginFile, Path baseDir) {
+        if (pluginFile == null || pluginFile.isBlank()) {
+            return;
+        }
+        Path file = resolveRelative(baseDir, pluginFile);
+        try (Stream<String> lines = Files.lines(file)) {
+            lines.filter(line -> !line.trim().isEmpty())
+                    .map(line -> line.split(":")[0].trim())
+                    .filter(line -> !line.isEmpty())
+                    .map(Plugin::build)
+                    .forEach(plugin -> plugins.putIfAbsent(key(plugin), plugin));
+        } catch (IOException e) {
+            throw new ModernizerException("Failed to read campaign plugin file: " + file, e);
+        }
+    }
+
+    private void addLocalPaths(Map<String, Plugin> plugins, List<String> localPaths, Path baseDir) {
+        if (localPaths == null) {
+            return;
+        }
+        for (String localPath : localPaths) {
+            if (localPath == null || localPath.isBlank()) {
+                continue;
+            }
+            Path path = resolveRelative(baseDir, localPath);
+            try {
+                Plugin plugin = pluginPathResolver.resolve(path);
+                plugins.putIfAbsent(key(plugin), plugin);
+            } catch (IOException e) {
+                throw new ModernizerException("Failed to resolve local campaign plugin path: " + path, e);
+            }
+        }
+    }
+
+    private void addTopPlugins(Map<String, Plugin> plugins, Integer topPlugins) {
+        if (topPlugins == null) {
+            return;
+        }
+        pluginService.getPluginInstallationStatsData().getPlugins().entrySet().stream()
+                .sorted(Map.Entry.<String, Integer>comparingByValue(Comparator.nullsLast(Comparator.reverseOrder())))
+                .limit(topPlugins)
+                .map(Map.Entry::getKey)
+                .map(Plugin::build)
+                .forEach(plugin -> plugins.putIfAbsent(key(plugin), plugin));
+    }
+
+    private boolean keepPlugin(Plugin plugin, CampaignFilters filters) {
+        if (filters == null || plugin.isLocal()) {
+            return true;
+        }
+        if (filters.isExcludeDeprecated() && pluginService.isDeprecated(plugin)) {
+            return false;
+        }
+        if (filters.isExcludeApiPlugins() && pluginService.isApiPlugin(plugin)) {
+            return false;
+        }
+        if (filters.isRequireAdoptThisPlugin() && !pluginService.isForAdoption(plugin)) {
+            return false;
+        }
+        if (filters.isExcludeNoKnownInstallations() && pluginService.hasNoKnownInstallations(plugin)) {
+            return false;
+        }
+        if (filters.getMinInstallations() != null) {
+            Integer installations = pluginService.extractInstallationStats(plugin);
+            if (installations == null || installations < filters.getMinInstallations()) {
+                return false;
+            }
+        }
+        if (filters.getMaxHealthScore() != null) {
+            Double score = pluginService.extractScore(plugin);
+            if (score == null || score > filters.getMaxHealthScore()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private Path resolveRelative(Path baseDir, String value) {
+        Path path = Path.of(value);
+        if (path.isAbsolute()) {
+            return path.normalize();
+        }
+        return baseDir.resolve(path).normalize();
+    }
+
+    private String key(Plugin plugin) {
+        if (plugin.isLocal()) {
+            return "local:" + plugin.getLocalRepository().toAbsolutePath().normalize();
+        }
+        return "remote:" + plugin.getName();
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginSource.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginSource.java
@@ -1,0 +1,57 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * Plugin selection inputs for a campaign.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CampaignPluginSource {
+
+    private List<String> names;
+    private String file;
+    private List<String> localPaths;
+    private Integer topPlugins;
+    private CampaignFilters filters = new CampaignFilters();
+
+    public List<String> getNames() {
+        return names;
+    }
+
+    public void setNames(List<String> names) {
+        this.names = names;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public List<String> getLocalPaths() {
+        return localPaths;
+    }
+
+    public void setLocalPaths(List<String> localPaths) {
+        this.localPaths = localPaths;
+    }
+
+    public Integer getTopPlugins() {
+        return topPlugins;
+    }
+
+    public void setTopPlugins(Integer topPlugins) {
+        this.topPlugins = topPlugins;
+    }
+
+    public CampaignFilters getFilters() {
+        return filters;
+    }
+
+    public void setFilters(CampaignFilters filters) {
+        this.filters = filters;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignReport.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignReport.java
@@ -1,0 +1,129 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * Final structured report for a campaign execution.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CampaignReport {
+
+    private String campaignFile;
+    private boolean dryRun;
+    private int concurrency;
+    private String startedAt;
+    private String finishedAt;
+    private int totalPlugins;
+    private int successfulPlugins;
+    private int failedPlugins;
+    private int totalStages;
+    private int successfulStages;
+    private int failedStages;
+    private String reportJson;
+    private List<CampaignPluginReport> plugins;
+
+    public String getCampaignFile() {
+        return campaignFile;
+    }
+
+    public void setCampaignFile(String campaignFile) {
+        this.campaignFile = campaignFile;
+    }
+
+    public boolean isDryRun() {
+        return dryRun;
+    }
+
+    public void setDryRun(boolean dryRun) {
+        this.dryRun = dryRun;
+    }
+
+    public int getConcurrency() {
+        return concurrency;
+    }
+
+    public void setConcurrency(int concurrency) {
+        this.concurrency = concurrency;
+    }
+
+    public String getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(String startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public String getFinishedAt() {
+        return finishedAt;
+    }
+
+    public void setFinishedAt(String finishedAt) {
+        this.finishedAt = finishedAt;
+    }
+
+    public int getTotalPlugins() {
+        return totalPlugins;
+    }
+
+    public void setTotalPlugins(int totalPlugins) {
+        this.totalPlugins = totalPlugins;
+    }
+
+    public int getSuccessfulPlugins() {
+        return successfulPlugins;
+    }
+
+    public void setSuccessfulPlugins(int successfulPlugins) {
+        this.successfulPlugins = successfulPlugins;
+    }
+
+    public int getFailedPlugins() {
+        return failedPlugins;
+    }
+
+    public void setFailedPlugins(int failedPlugins) {
+        this.failedPlugins = failedPlugins;
+    }
+
+    public int getTotalStages() {
+        return totalStages;
+    }
+
+    public void setTotalStages(int totalStages) {
+        this.totalStages = totalStages;
+    }
+
+    public int getSuccessfulStages() {
+        return successfulStages;
+    }
+
+    public void setSuccessfulStages(int successfulStages) {
+        this.successfulStages = successfulStages;
+    }
+
+    public int getFailedStages() {
+        return failedStages;
+    }
+
+    public void setFailedStages(int failedStages) {
+        this.failedStages = failedStages;
+    }
+
+    public String getReportJson() {
+        return reportJson;
+    }
+
+    public void setReportJson(String reportJson) {
+        this.reportJson = reportJson;
+    }
+
+    public List<CampaignPluginReport> getPlugins() {
+        return plugins;
+    }
+
+    public void setPlugins(List<CampaignPluginReport> plugins) {
+        this.plugins = plugins;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignService.java
@@ -1,0 +1,227 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
+import io.jenkins.tools.pluginmodernizer.core.utils.RecipeResolver;
+import jakarta.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Orchestrates campaign execution on top of the existing single-recipe engine.
+ */
+public class CampaignService {
+
+    private final Config baseConfig;
+    private final CampaignParser campaignParser;
+    private final CampaignPluginSelector campaignPluginSelector;
+    private final CampaignModernizerRunner campaignModernizerRunner;
+    private final RecipeResolver recipeResolver;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Inject
+    public CampaignService(
+            Config baseConfig,
+            CampaignParser campaignParser,
+            CampaignPluginSelector campaignPluginSelector,
+            CampaignModernizerRunner campaignModernizerRunner,
+            RecipeResolver recipeResolver) {
+        this.baseConfig = baseConfig;
+        this.campaignParser = campaignParser;
+        this.campaignPluginSelector = campaignPluginSelector;
+        this.campaignModernizerRunner = campaignModernizerRunner;
+        this.recipeResolver = recipeResolver;
+    }
+
+    public CampaignReport run(Path campaignFile) {
+        Path normalizedCampaignFile = campaignFile.toAbsolutePath().normalize();
+        CampaignDefinition definition = campaignParser.parse(normalizedCampaignFile);
+        List<Plugin> selectedPlugins = campaignPluginSelector.selectPlugins(definition, normalizedCampaignFile);
+
+        Instant startedAt = Instant.now();
+        List<CampaignPluginReport> pluginReports = executePlugins(definition, selectedPlugins);
+        Instant finishedAt = Instant.now();
+
+        CampaignReport report = buildReport(definition, normalizedCampaignFile, startedAt, finishedAt, pluginReports);
+        Path reportPath = resolveReportPath(definition, normalizedCampaignFile);
+        writeReport(report, reportPath);
+        report.setReportJson(reportPath.toAbsolutePath().toString());
+        return report;
+    }
+
+    private List<CampaignPluginReport> executePlugins(CampaignDefinition definition, List<Plugin> selectedPlugins) {
+        ExecutorService executorService = Executors.newFixedThreadPool(definition.getExecution().getConcurrency());
+        try {
+            List<Future<CampaignPluginReport>> futures = selectedPlugins.stream()
+                    .map(plugin -> executorService.submit(new CampaignPluginTask(definition, plugin)))
+                    .toList();
+
+            List<CampaignPluginReport> reports = new ArrayList<>();
+            for (Future<CampaignPluginReport> future : futures) {
+                reports.add(future.get());
+            }
+            return reports;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Campaign execution was interrupted", e);
+        } catch (ExecutionException e) {
+            throw new RuntimeException("Campaign execution failed", e.getCause());
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private CampaignReport buildReport(
+            CampaignDefinition definition,
+            Path campaignFile,
+            Instant startedAt,
+            Instant finishedAt,
+            List<CampaignPluginReport> pluginReports) {
+        int totalStages = pluginReports.stream().mapToInt(report -> report.getStages().size()).sum();
+        int successfulStages = pluginReports.stream()
+                .flatMap(report -> report.getStages().stream())
+                .mapToInt(stage -> stage.isSuccess() ? 1 : 0)
+                .sum();
+        int failedStages = totalStages - successfulStages;
+        int successfulPlugins = (int) pluginReports.stream().filter(CampaignPluginReport::isSuccess).count();
+
+        CampaignReport report = new CampaignReport();
+        report.setCampaignFile(campaignFile.toString());
+        report.setDryRun(true);
+        report.setConcurrency(definition.getExecution().getConcurrency());
+        report.setStartedAt(startedAt.toString());
+        report.setFinishedAt(finishedAt.toString());
+        report.setTotalPlugins(pluginReports.size());
+        report.setSuccessfulPlugins(successfulPlugins);
+        report.setFailedPlugins(pluginReports.size() - successfulPlugins);
+        report.setTotalStages(totalStages);
+        report.setSuccessfulStages(successfulStages);
+        report.setFailedStages(failedStages);
+        report.setPlugins(pluginReports);
+        return report;
+    }
+
+    private void writeReport(CampaignReport report, Path reportPath) {
+        try {
+            Path parent = reportPath.toAbsolutePath().getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            objectMapper.writerWithDefaultPrettyPrinter().writeValue(reportPath.toFile(), report);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to write campaign report to " + reportPath, e);
+        }
+    }
+
+    private Path resolveReportPath(CampaignDefinition definition, Path campaignFile) {
+        String reportJson = definition.getOutput().getReportJson();
+        if (reportJson == null || reportJson.isBlank()) {
+            return campaignFile.getParent().resolve("campaign-report.json").normalize();
+        }
+        Path configuredPath = Path.of(reportJson);
+        if (configuredPath.isAbsolute()) {
+            return configuredPath.normalize();
+        }
+        return campaignFile.getParent().resolve(configuredPath).normalize();
+    }
+
+    private Config buildStageConfig(Plugin plugin, CampaignDefinition definition, CampaignStage stage) {
+        Recipe recipe = recipeResolver.resolve(stage.getRecipe());
+        boolean skipMetadata = stage.getSkipMetadata() != null
+                ? stage.getSkipMetadata()
+                : definition.getExecution().isSkipMetadata();
+
+        Path mavenHome = baseConfig.getConfiguredMavenHome() != null
+                ? baseConfig.getConfiguredMavenHome()
+                : baseConfig.getDetectedMavenHome();
+
+        return Config.builder()
+                .withVersion(baseConfig.getVersion())
+                .withGitHubOwner(baseConfig.getGithubOwner())
+                .withGitHubAppId(baseConfig.getGithubAppId())
+                .withGitHubAppSourceInstallationId(baseConfig.getGithubAppSourceInstallationId())
+                .withGitHubAppTargetInstallationId(baseConfig.getGithubAppTargetInstallationId())
+                .withSshPrivateKey(baseConfig.getSshPrivateKey())
+                .withPlugins(List.of(plugin))
+                .withRecipe(recipe)
+                .withJenkinsUpdateCenter(baseConfig.getJenkinsUpdateCenter())
+                .withJenkinsPluginVersions(baseConfig.getJenkinsPluginVersions())
+                .withPluginHealthScore(baseConfig.getPluginHealthScore())
+                .withPluginStatsInstallations(baseConfig.getPluginStatsInstallations())
+                .withOptOutPlugins(baseConfig.getOptOutPlugins())
+                .withGithubApiUrl(baseConfig.getGithubApiUrl())
+                .withCachePath(baseConfig.getCachePath())
+                .withMavenHome(mavenHome)
+                .withMavenLocalRepo(baseConfig.getMavenLocalRepo())
+                .withSkipMetadata(skipMetadata)
+                .withOverrideOptOutPlugins(baseConfig.isOverrideOptOutPlugins())
+                .withDryRun(true)
+                .withDraft(false)
+                .withRemoveForks(false)
+                .withAllowDeprecatedPlugins(baseConfig.isAllowDeprecatedPlugins())
+                .withDuplicatePrStrategy(baseConfig.getDuplicatePrStrategy())
+                .build();
+    }
+
+    private final class CampaignPluginTask implements Callable<CampaignPluginReport> {
+
+        private final CampaignDefinition definition;
+        private final Plugin initialPlugin;
+
+        private CampaignPluginTask(CampaignDefinition definition, Plugin initialPlugin) {
+            this.definition = definition;
+            this.initialPlugin = initialPlugin;
+        }
+
+        @Override
+        public CampaignPluginReport call() {
+            List<CampaignStageReport> stageReports = new ArrayList<>();
+            Plugin currentPlugin = initialPlugin;
+
+            for (CampaignStage stage : definition.getStages()) {
+                Config stageConfig = buildStageConfig(currentPlugin, definition, stage);
+                CampaignStageReport stageReport = campaignModernizerRunner.runStage(stageConfig, stage);
+                stageReports.add(stageReport);
+
+                if (stageReport.getLocalRepository() != null
+                        && !stageReport.getLocalRepository().isBlank()) {
+                    Path nextRepository = Path.of(stageReport.getLocalRepository());
+                    if (Files.isDirectory(nextRepository)) {
+                        currentPlugin = Plugin.build(initialPlugin.getName(), nextRepository);
+                    }
+                }
+
+                if (!stageReport.isSuccess() && !definition.getExecution().isContinueOnFailure()) {
+                    break;
+                }
+            }
+
+            CampaignPluginReport report = new CampaignPluginReport();
+            report.setPluginName(initialPlugin.getName());
+            report.setLocal(initialPlugin.isLocal());
+            report.setSource(initialPlugin.isLocal()
+                    ? initialPlugin.getLocalRepository().toAbsolutePath().toString()
+                    : initialPlugin.getName());
+            if (currentPlugin.isLocal() && currentPlugin.getLocalRepository() != null) {
+                report.setFinalLocalRepository(
+                        currentPlugin.getLocalRepository().toAbsolutePath().toString());
+            } else {
+                report.setFinalLocalRepository(null);
+            }
+            report.setSuccess(stageReports.stream().allMatch(CampaignStageReport::isSuccess));
+            report.setStages(stageReports);
+            return report;
+        }
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignService.java
@@ -61,7 +61,8 @@ public class CampaignService {
     }
 
     private List<CampaignPluginReport> executePlugins(CampaignDefinition definition, List<Plugin> selectedPlugins) {
-        ExecutorService executorService = Executors.newFixedThreadPool(definition.getExecution().getConcurrency());
+        ExecutorService executorService =
+                Executors.newFixedThreadPool(definition.getExecution().getConcurrency());
         try {
             List<Future<CampaignPluginReport>> futures = selectedPlugins.stream()
                     .map(plugin -> executorService.submit(new CampaignPluginTask(definition, plugin)))
@@ -88,13 +89,16 @@ public class CampaignService {
             Instant startedAt,
             Instant finishedAt,
             List<CampaignPluginReport> pluginReports) {
-        int totalStages = pluginReports.stream().mapToInt(report -> report.getStages().size()).sum();
+        int totalStages = pluginReports.stream()
+                .mapToInt(report -> report.getStages().size())
+                .sum();
         int successfulStages = pluginReports.stream()
                 .flatMap(report -> report.getStages().stream())
                 .mapToInt(stage -> stage.isSuccess() ? 1 : 0)
                 .sum();
         int failedStages = totalStages - successfulStages;
-        int successfulPlugins = (int) pluginReports.stream().filter(CampaignPluginReport::isSuccess).count();
+        int successfulPlugins = (int)
+                pluginReports.stream().filter(CampaignPluginReport::isSuccess).count();
 
         CampaignReport report = new CampaignReport();
         report.setCampaignFile(campaignFile.toString());
@@ -210,9 +214,13 @@ public class CampaignService {
             CampaignPluginReport report = new CampaignPluginReport();
             report.setPluginName(initialPlugin.getName());
             report.setLocal(initialPlugin.isLocal());
-            report.setSource(initialPlugin.isLocal()
-                    ? initialPlugin.getLocalRepository().toAbsolutePath().toString()
-                    : initialPlugin.getName());
+            report.setSource(
+                    initialPlugin.isLocal()
+                            ? initialPlugin
+                                    .getLocalRepository()
+                                    .toAbsolutePath()
+                                    .toString()
+                            : initialPlugin.getName());
             if (currentPlugin.isLocal() && currentPlugin.getLocalRepository() != null) {
                 report.setFinalLocalRepository(
                         currentPlugin.getLocalRepository().toAbsolutePath().toString());

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignService.java
@@ -129,15 +129,16 @@ public class CampaignService {
     }
 
     private Path resolveReportPath(CampaignDefinition definition, Path campaignFile) {
+        Path parent = campaignFile.toAbsolutePath().getParent();
         String reportJson = definition.getOutput().getReportJson();
         if (reportJson == null || reportJson.isBlank()) {
-            return campaignFile.getParent().resolve("campaign-report.json").normalize();
+            return parent.resolve("campaign-report.json").normalize();
         }
         Path configuredPath = Path.of(reportJson);
         if (configuredPath.isAbsolute()) {
             return configuredPath.normalize();
         }
-        return campaignFile.getParent().resolve(configuredPath).normalize();
+        return parent.resolve(configuredPath).normalize();
     }
 
     private Config buildStageConfig(Plugin plugin, CampaignDefinition definition, CampaignStage stage) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignStage.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignStage.java
@@ -1,0 +1,38 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * A single campaign stage mapped to one modernization recipe.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CampaignStage {
+
+    private String name;
+    private String recipe;
+    private Boolean skipMetadata;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getRecipe() {
+        return recipe;
+    }
+
+    public void setRecipe(String recipe) {
+        this.recipe = recipe;
+    }
+
+    public Boolean getSkipMetadata() {
+        return skipMetadata;
+    }
+
+    public void setSkipMetadata(Boolean skipMetadata) {
+        this.skipMetadata = skipMetadata;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignStageReport.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignStageReport.java
@@ -1,0 +1,93 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/**
+ * Result of a single stage execution for a plugin.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class CampaignStageReport {
+
+    private String stageName;
+    private String recipe;
+    private boolean success;
+    private String startedAt;
+    private String finishedAt;
+    private long durationMillis;
+    private String localRepository;
+    private List<String> modifiedFiles;
+    private List<String> errors;
+
+    public String getStageName() {
+        return stageName;
+    }
+
+    public void setStageName(String stageName) {
+        this.stageName = stageName;
+    }
+
+    public String getRecipe() {
+        return recipe;
+    }
+
+    public void setRecipe(String recipe) {
+        this.recipe = recipe;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public String getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(String startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public String getFinishedAt() {
+        return finishedAt;
+    }
+
+    public void setFinishedAt(String finishedAt) {
+        this.finishedAt = finishedAt;
+    }
+
+    public long getDurationMillis() {
+        return durationMillis;
+    }
+
+    public void setDurationMillis(long durationMillis) {
+        this.durationMillis = durationMillis;
+    }
+
+    public String getLocalRepository() {
+        return localRepository;
+    }
+
+    public void setLocalRepository(String localRepository) {
+        this.localRepository = localRepository;
+    }
+
+    public List<String> getModifiedFiles() {
+        return modifiedFiles;
+    }
+
+    public void setModifiedFiles(List<String> modifiedFiles) {
+        this.modifiedFiles = modifiedFiles;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors;
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/DefaultCampaignModernizerRunner.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/DefaultCampaignModernizerRunner.java
@@ -36,30 +36,32 @@ public class DefaultCampaignModernizerRunner implements CampaignModernizerRunner
                 .map(PluginProcessingException::getMessage)
                 .collect(LinkedHashSet::new, LinkedHashSet::add, LinkedHashSet::addAll));
         if (plugin.hasPreconditionErrors()) {
-            plugin.getPreconditionErrors().stream()
-                    .map(Object::toString)
-                    .forEach(errors::add);
+            plugin.getPreconditionErrors().stream().map(Object::toString).forEach(errors::add);
         }
 
         Instant finishedAt = Instant.now();
         CampaignStageReport report = new CampaignStageReport();
-        report.setStageName(stage.getName() != null && !stage.getName().isBlank()
-                ? stage.getName()
-                : stage.getRecipe());
+        report.setStageName(
+                stage.getName() != null && !stage.getName().isBlank() ? stage.getName() : stage.getRecipe());
         report.setRecipe(stageConfig.getRecipe().getName());
         report.setSuccess(errors.isEmpty());
         report.setStartedAt(startedAt.toString());
         report.setFinishedAt(finishedAt.toString());
         report.setDurationMillis(finishedAt.toEpochMilli() - startedAt.toEpochMilli());
         if (plugin.getLocalRepository() != null) {
-            report.setLocalRepository(plugin.getLocalRepository().toAbsolutePath().toString());
+            report.setLocalRepository(
+                    plugin.getLocalRepository().toAbsolutePath().toString());
         }
-        report.setModifiedFiles(plugin.getModifiedFiles().stream().sorted(Comparator.naturalOrder()).toList());
+        report.setModifiedFiles(plugin.getModifiedFiles().stream()
+                .sorted(Comparator.naturalOrder())
+                .toList());
         report.setErrors(List.copyOf(errors));
         return report;
     }
 
     private String messageOf(Exception e) {
-        return e.getMessage() != null && !e.getMessage().isBlank() ? e.getMessage() : e.getClass().getName();
+        return e.getMessage() != null && !e.getMessage().isBlank()
+                ? e.getMessage()
+                : e.getClass().getName();
     }
 }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/DefaultCampaignModernizerRunner.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/campaign/DefaultCampaignModernizerRunner.java
@@ -1,0 +1,65 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import com.google.inject.Guice;
+import io.jenkins.tools.pluginmodernizer.core.GuiceModule;
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import io.jenkins.tools.pluginmodernizer.core.model.PluginProcessingException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Default stage runner backed by the existing PluginModernizer orchestration.
+ */
+public class DefaultCampaignModernizerRunner implements CampaignModernizerRunner {
+
+    @Override
+    public CampaignStageReport runStage(Config stageConfig, CampaignStage stage) {
+        Instant startedAt = Instant.now();
+        Plugin plugin = stageConfig.getPlugins().get(0);
+        List<String> errors = new ArrayList<>();
+
+        try {
+            PluginModernizer modernizer =
+                    Guice.createInjector(new GuiceModule(stageConfig)).getInstance(PluginModernizer.class);
+            modernizer.validate();
+            modernizer.start();
+        } catch (Exception e) {
+            errors.add(messageOf(e));
+        }
+
+        errors.addAll(plugin.getErrors().stream()
+                .map(PluginProcessingException::getMessage)
+                .collect(LinkedHashSet::new, LinkedHashSet::add, LinkedHashSet::addAll));
+        if (plugin.hasPreconditionErrors()) {
+            plugin.getPreconditionErrors().stream()
+                    .map(Object::toString)
+                    .forEach(errors::add);
+        }
+
+        Instant finishedAt = Instant.now();
+        CampaignStageReport report = new CampaignStageReport();
+        report.setStageName(stage.getName() != null && !stage.getName().isBlank()
+                ? stage.getName()
+                : stage.getRecipe());
+        report.setRecipe(stageConfig.getRecipe().getName());
+        report.setSuccess(errors.isEmpty());
+        report.setStartedAt(startedAt.toString());
+        report.setFinishedAt(finishedAt.toString());
+        report.setDurationMillis(finishedAt.toEpochMilli() - startedAt.toEpochMilli());
+        if (plugin.getLocalRepository() != null) {
+            report.setLocalRepository(plugin.getLocalRepository().toAbsolutePath().toString());
+        }
+        report.setModifiedFiles(plugin.getModifiedFiles().stream().sorted(Comparator.naturalOrder()).toList());
+        report.setErrors(List.copyOf(errors));
+        return report;
+    }
+
+    private String messageOf(Exception e) {
+        return e.getMessage() != null && !e.getMessage().isBlank() ? e.getMessage() : e.getClass().getName();
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginPathResolver.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginPathResolver.java
@@ -1,0 +1,94 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolves a local filesystem path to a Jenkins plugin.
+ */
+public class PluginPathResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PluginPathResolver.class);
+
+    public Plugin resolve(String value) throws IOException {
+        return resolve(Path.of(value));
+    }
+
+    public Plugin resolve(Path path) throws IOException {
+        if (!Files.isDirectory(path)) {
+            throw new IllegalArgumentException("Path is not a directory: " + path);
+        }
+
+        Path pom = path.resolve("pom.xml");
+        if (!Files.exists(pom)) {
+            throw new IllegalArgumentException("Path does not contain a pom.xml: " + path);
+        }
+
+        StaticPomParser rootPomParser = new StaticPomParser(pom.toString());
+        String packaging = rootPomParser.getPackaging();
+
+        // Check if this is a single-module Jenkins plugin
+        if ("hpi".equals(packaging)) {
+            String artifactId = rootPomParser.getArtifactId();
+            if (artifactId == null) {
+                throw new IllegalArgumentException("Path does not contain a valid Jenkins plugin: " + path);
+            }
+            LOG.info("Found single-module plugin '{}' at root level", artifactId);
+            return Plugin.build(artifactId, path);
+        }
+
+        // Check if this is a multi-module project (packaging = pom)
+        if ("pom".equals(packaging) || packaging == null || packaging.isEmpty()) {
+            LOG.info("Detected multi-module project, searching for Jenkins plugin module...");
+            Path pluginPath = findJenkinsPluginModule(path);
+            if (pluginPath != null) {
+                StaticPomParser pluginPomParser = new StaticPomParser(pluginPath.resolve("pom.xml").toString());
+                String artifactId = pluginPomParser.getArtifactId();
+                if (artifactId == null) {
+                    throw new IllegalArgumentException("Plugin module does not contain valid artifactId: " + pluginPath);
+                }
+                LOG.info("Found Jenkins plugin module '{}' at: {}", artifactId, pluginPath);
+                return Plugin.build(artifactId, pluginPath);
+            }
+            throw new IllegalArgumentException(
+                    "Multi-module project detected but no module with packaging 'hpi' found" + path);
+        }
+
+        throw new IllegalArgumentException(
+                "Path does not contain a Jenkins plugin (packaging must be 'hpi' or a multi-module project with an hpi module): "
+                        + path);
+    }
+
+    /**
+     * Find the Jenkins plugin module in a multi-module project.
+     * Searches all subdirectories for a pom.xml with packaging 'hpi'.
+     *
+     * @param rootPath The root path of the multi-module project
+     * @return The path to the plugin module, or null if not found
+     * @throws IOException if an I/O error occurs
+     */
+    private Path findJenkinsPluginModule(Path rootPath) throws IOException {
+        try (Stream<Path> paths = Files.walk(rootPath, 2)) { // Search up to 2 levels deep
+            return paths.filter(Files::isDirectory)
+                    .filter(dir -> !dir.equals(rootPath)) // Skip root directory
+                    .filter(dir -> Files.exists(dir.resolve("pom.xml")))
+                    .filter(dir -> {
+                        try {
+                            StaticPomParser parser = new StaticPomParser(dir.resolve("pom.xml").toString());
+                            String packaging = parser.getPackaging();
+                            return "hpi".equals(packaging);
+                        } catch (Exception e) {
+                            LOG.debug("Failed to parse pom.xml in {}: {}", dir, e.getMessage());
+                            return false;
+                        }
+                    })
+                    .findFirst()
+                    .orElse(null);
+        }
+    }
+}

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginPathResolver.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginPathResolver.java
@@ -47,10 +47,12 @@ public class PluginPathResolver {
             LOG.info("Detected multi-module project, searching for Jenkins plugin module...");
             Path pluginPath = findJenkinsPluginModule(path);
             if (pluginPath != null) {
-                StaticPomParser pluginPomParser = new StaticPomParser(pluginPath.resolve("pom.xml").toString());
+                StaticPomParser pluginPomParser =
+                        new StaticPomParser(pluginPath.resolve("pom.xml").toString());
                 String artifactId = pluginPomParser.getArtifactId();
                 if (artifactId == null) {
-                    throw new IllegalArgumentException("Plugin module does not contain valid artifactId: " + pluginPath);
+                    throw new IllegalArgumentException(
+                            "Plugin module does not contain valid artifactId: " + pluginPath);
                 }
                 LOG.info("Found Jenkins plugin module '{}' at: {}", artifactId, pluginPath);
                 return Plugin.build(artifactId, pluginPath);
@@ -79,7 +81,8 @@ public class PluginPathResolver {
                     .filter(dir -> Files.exists(dir.resolve("pom.xml")))
                     .filter(dir -> {
                         try {
-                            StaticPomParser parser = new StaticPomParser(dir.resolve("pom.xml").toString());
+                            StaticPomParser parser =
+                                    new StaticPomParser(dir.resolve("pom.xml").toString());
                             String packaging = parser.getPackaging();
                             return "hpi".equals(packaging);
                         } catch (Exception e) {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/RecipeResolver.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/RecipeResolver.java
@@ -12,7 +12,9 @@ public class RecipeResolver {
     public Recipe resolve(String value) {
         return Settings.AVAILABLE_RECIPES.stream()
                 .filter(recipe -> recipe.getName().equals(value)
-                        || recipe.getName().replace(Settings.RECIPE_FQDN_PREFIX + ".", "").equals(value))
+                        || recipe.getName()
+                                .replace(Settings.RECIPE_FQDN_PREFIX + ".", "")
+                                .equals(value))
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("Invalid recipe name: " + value));
     }

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/RecipeResolver.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/utils/RecipeResolver.java
@@ -1,0 +1,25 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
+import java.util.List;
+
+/**
+ * Resolves recipe names using either the fully qualified name or the short CLI name.
+ */
+public class RecipeResolver {
+
+    public Recipe resolve(String value) {
+        return Settings.AVAILABLE_RECIPES.stream()
+                .filter(recipe -> recipe.getName().equals(value)
+                        || recipe.getName().replace(Settings.RECIPE_FQDN_PREFIX + ".", "").equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Invalid recipe name: " + value));
+    }
+
+    public List<String> candidates() {
+        return Settings.AVAILABLE_RECIPES.stream()
+                .map(recipe -> recipe.getName().replace(Settings.RECIPE_FQDN_PREFIX + ".", ""))
+                .toList();
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignParserTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignParserTest.java
@@ -19,9 +19,7 @@ class CampaignParserTest {
     @Test
     void shouldParseValidCampaignFile() throws Exception {
         Path campaignFile = tempDir.resolve("campaign.yaml");
-        Files.writeString(
-                campaignFile,
-                """
+        Files.writeString(campaignFile, """
                 plugins:
                   names:
                     - git
@@ -59,17 +57,14 @@ class CampaignParserTest {
     @Test
     void shouldRejectCampaignWithoutStages() throws Exception {
         Path campaignFile = tempDir.resolve("invalid-campaign.yaml");
-        Files.writeString(
-                campaignFile,
-                """
+        Files.writeString(campaignFile, """
                 plugins:
                   names:
                     - git
                 """);
 
         CampaignParser parser = new CampaignParser(new RecipeResolver());
-        ModernizerException exception =
-                assertThrows(ModernizerException.class, () -> parser.parse(campaignFile));
+        ModernizerException exception = assertThrows(ModernizerException.class, () -> parser.parse(campaignFile));
 
         assertTrue(exception.getMessage().contains("at least one stage"));
     }
@@ -77,16 +72,13 @@ class CampaignParserTest {
     @Test
     void shouldRejectCampaignWithNoPluginSource() throws Exception {
         Path campaignFile = tempDir.resolve("no-source.yaml");
-        Files.writeString(
-                campaignFile,
-                """
+        Files.writeString(campaignFile, """
                 stages:
                   - recipe: SetupDependabot
                 """);
 
         CampaignParser parser = new CampaignParser(new RecipeResolver());
-        ModernizerException exception =
-                assertThrows(ModernizerException.class, () -> parser.parse(campaignFile));
+        ModernizerException exception = assertThrows(ModernizerException.class, () -> parser.parse(campaignFile));
 
         assertTrue(exception.getMessage().contains("at least one plugin source"));
     }
@@ -94,9 +86,7 @@ class CampaignParserTest {
     @Test
     void shouldRejectCampaignWithZeroTopPlugins() throws Exception {
         Path campaignFile = tempDir.resolve("bad-top.yaml");
-        Files.writeString(
-                campaignFile,
-                """
+        Files.writeString(campaignFile, """
                 plugins:
                   topPlugins: 0
                 stages:
@@ -104,8 +94,7 @@ class CampaignParserTest {
                 """);
 
         CampaignParser parser = new CampaignParser(new RecipeResolver());
-        ModernizerException exception =
-                assertThrows(ModernizerException.class, () -> parser.parse(campaignFile));
+        ModernizerException exception = assertThrows(ModernizerException.class, () -> parser.parse(campaignFile));
 
         assertTrue(exception.getMessage().contains("topPlugins must be greater than zero"));
     }
@@ -113,9 +102,7 @@ class CampaignParserTest {
     @Test
     void shouldRejectCampaignWithUnknownRecipe() throws Exception {
         Path campaignFile = tempDir.resolve("bad-recipe.yaml");
-        Files.writeString(
-                campaignFile,
-                """
+        Files.writeString(campaignFile, """
                 plugins:
                   names:
                     - git

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignParserTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignParserTest.java
@@ -1,0 +1,129 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import io.jenkins.tools.pluginmodernizer.core.utils.RecipeResolver;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CampaignParserTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void shouldParseValidCampaignFile() throws Exception {
+        Path campaignFile = tempDir.resolve("campaign.yaml");
+        Files.writeString(
+                campaignFile,
+                """
+                plugins:
+                  names:
+                    - git
+                    - git-client
+                  topPlugins: 5
+                  filters:
+                    minInstallations: 100
+                    maxHealthScore: 80
+                    excludeDeprecated: true
+                stages:
+                  - recipe: SetupDependabot
+                  - name: Upgrade parent
+                    recipe: UpgradeParent6Version
+                    skipMetadata: true
+                execution:
+                  concurrency: 2
+                  continueOnFailure: false
+                  skipMetadata: true
+                output:
+                  reportJson: reports/campaign.json
+                """);
+
+        CampaignParser parser = new CampaignParser(new RecipeResolver());
+        CampaignDefinition definition = parser.parse(campaignFile);
+
+        assertEquals(2, definition.getStages().size());
+        assertEquals("git", definition.getPlugins().getNames().get(0));
+        assertEquals(5, definition.getPlugins().getTopPlugins());
+        assertTrue(definition.getPlugins().getFilters().isExcludeDeprecated());
+        assertEquals(2, definition.getExecution().getConcurrency());
+        assertEquals(false, definition.getExecution().isContinueOnFailure());
+        assertEquals("reports/campaign.json", definition.getOutput().getReportJson());
+    }
+
+    @Test
+    void shouldRejectCampaignWithoutStages() throws Exception {
+        Path campaignFile = tempDir.resolve("invalid-campaign.yaml");
+        Files.writeString(
+                campaignFile,
+                """
+                plugins:
+                  names:
+                    - git
+                """);
+
+        CampaignParser parser = new CampaignParser(new RecipeResolver());
+        ModernizerException exception =
+                assertThrows(ModernizerException.class, () -> parser.parse(campaignFile));
+
+        assertTrue(exception.getMessage().contains("at least one stage"));
+    }
+
+    @Test
+    void shouldRejectCampaignWithNoPluginSource() throws Exception {
+        Path campaignFile = tempDir.resolve("no-source.yaml");
+        Files.writeString(
+                campaignFile,
+                """
+                stages:
+                  - recipe: SetupDependabot
+                """);
+
+        CampaignParser parser = new CampaignParser(new RecipeResolver());
+        ModernizerException exception =
+                assertThrows(ModernizerException.class, () -> parser.parse(campaignFile));
+
+        assertTrue(exception.getMessage().contains("at least one plugin source"));
+    }
+
+    @Test
+    void shouldRejectCampaignWithZeroTopPlugins() throws Exception {
+        Path campaignFile = tempDir.resolve("bad-top.yaml");
+        Files.writeString(
+                campaignFile,
+                """
+                plugins:
+                  topPlugins: 0
+                stages:
+                  - recipe: SetupDependabot
+                """);
+
+        CampaignParser parser = new CampaignParser(new RecipeResolver());
+        ModernizerException exception =
+                assertThrows(ModernizerException.class, () -> parser.parse(campaignFile));
+
+        assertTrue(exception.getMessage().contains("topPlugins must be greater than zero"));
+    }
+
+    @Test
+    void shouldRejectCampaignWithUnknownRecipe() throws Exception {
+        Path campaignFile = tempDir.resolve("bad-recipe.yaml");
+        Files.writeString(
+                campaignFile,
+                """
+                plugins:
+                  names:
+                    - git
+                stages:
+                  - recipe: NotARealRecipe
+                """);
+
+        CampaignParser parser = new CampaignParser(new RecipeResolver());
+        assertThrows(IllegalArgumentException.class, () -> parser.parse(campaignFile));
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginSelectorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginSelectorTest.java
@@ -43,8 +43,8 @@ class CampaignPluginSelectorTest {
         definition.setPlugins(pluginSource);
 
         CampaignPluginSelector selector = new CampaignPluginSelector(pluginService);
-        assertThrows(ModernizerException.class,
-                () -> selector.selectPlugins(definition, tempDir.resolve("campaign.yaml")));
+        assertThrows(
+                ModernizerException.class, () -> selector.selectPlugins(definition, tempDir.resolve("campaign.yaml")));
     }
 
     @Test
@@ -73,9 +73,7 @@ class CampaignPluginSelectorTest {
 
         Path localPlugin = tempDir.resolve("local-plugin");
         Files.createDirectories(localPlugin);
-        Files.writeString(
-                localPlugin.resolve("pom.xml"),
-                """
+        Files.writeString(localPlugin.resolve("pom.xml"), """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>test</groupId>

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginSelectorTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignPluginSelectorTest.java
@@ -1,0 +1,174 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import io.jenkins.tools.pluginmodernizer.core.model.PluginInstallationStatsData;
+import io.jenkins.tools.pluginmodernizer.core.utils.PluginService;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CampaignPluginSelectorTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void shouldThrowWhenAllPluginsFilteredOut() {
+        PluginInstallationStatsData statsData = new PluginInstallationStatsData(null);
+        statsData.setPlugins(Map.of("tiny-plugin", 50));
+        FakePluginService pluginService = new FakePluginService(
+                statsData,
+                Map.of("tiny-plugin", 50),
+                Map.of("tiny-plugin", 30d),
+                Set.of(),
+                Set.of(),
+                Set.of(),
+                Set.of());
+
+        CampaignDefinition definition = new CampaignDefinition();
+        CampaignPluginSource pluginSource = new CampaignPluginSource();
+        pluginSource.setNames(List.of("tiny-plugin"));
+        CampaignFilters filters = new CampaignFilters();
+        filters.setMinInstallations(10_000);
+        pluginSource.setFilters(filters);
+        definition.setPlugins(pluginSource);
+
+        CampaignPluginSelector selector = new CampaignPluginSelector(pluginService);
+        assertThrows(ModernizerException.class,
+                () -> selector.selectPlugins(definition, tempDir.resolve("campaign.yaml")));
+    }
+
+    @Test
+    void shouldResolveNamesFilesLocalPathsAndTopPluginsWithFilters() throws Exception {
+        PluginInstallationStatsData statsData = new PluginInstallationStatsData(null);
+        statsData.setPlugins(Map.of("healthy-plugin", 2_000, "deprecated-plugin", 1_500, "unhealthy-plugin", 1_000));
+        FakePluginService pluginService = new FakePluginService(
+                statsData,
+                Map.of(
+                        "healthy-plugin", 2_000,
+                        "deprecated-plugin", 1_500,
+                        "explicit-plugin", 1_200,
+                        "file-plugin", 1_200),
+                Map.of(
+                        "healthy-plugin", 60d,
+                        "deprecated-plugin", 50d,
+                        "explicit-plugin", 70d,
+                        "file-plugin", 70d),
+                Set.of("deprecated-plugin"),
+                Set.of(),
+                Set.of(),
+                Set.of());
+
+        Path pluginFile = tempDir.resolve("plugins.txt");
+        Files.writeString(pluginFile, "file-plugin\n");
+
+        Path localPlugin = tempDir.resolve("local-plugin");
+        Files.createDirectories(localPlugin);
+        Files.writeString(
+                localPlugin.resolve("pom.xml"),
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>test</groupId>
+                  <artifactId>local-plugin</artifactId>
+                  <version>1.0</version>
+                  <packaging>hpi</packaging>
+                </project>
+                """);
+
+        CampaignDefinition definition = new CampaignDefinition();
+        CampaignPluginSource pluginSource = new CampaignPluginSource();
+        pluginSource.setNames(List.of("explicit-plugin"));
+        pluginSource.setFile(pluginFile.getFileName().toString());
+        pluginSource.setLocalPaths(List.of(localPlugin.getFileName().toString()));
+        pluginSource.setTopPlugins(2);
+
+        CampaignFilters filters = new CampaignFilters();
+        filters.setMinInstallations(1_000);
+        filters.setMaxHealthScore(80d);
+        filters.setExcludeDeprecated(true);
+        pluginSource.setFilters(filters);
+        definition.setPlugins(pluginSource);
+
+        CampaignPluginSelector selector = new CampaignPluginSelector(pluginService);
+        List<Plugin> selected = selector.selectPlugins(definition, tempDir.resolve("campaign.yaml"));
+
+        assertEquals(4, selected.size());
+        assertTrue(selected.stream().anyMatch(plugin -> plugin.getName().equals("explicit-plugin")));
+        assertTrue(selected.stream().anyMatch(plugin -> plugin.getName().equals("file-plugin")));
+        assertTrue(selected.stream().anyMatch(plugin -> plugin.getName().equals("healthy-plugin")));
+        assertTrue(selected.stream().anyMatch(plugin -> plugin.getName().equals("local-plugin") && plugin.isLocal()));
+    }
+
+    private static final class FakePluginService extends PluginService {
+
+        private final PluginInstallationStatsData installationStatsData;
+        private final Map<String, Integer> installations;
+        private final Map<String, Double> scores;
+        private final Set<String> deprecatedPlugins;
+        private final Set<String> apiPlugins;
+        private final Set<String> adoptablePlugins;
+        private final Set<String> noInstallationsPlugins;
+
+        private FakePluginService(
+                PluginInstallationStatsData installationStatsData,
+                Map<String, Integer> installations,
+                Map<String, Double> scores,
+                Set<String> deprecatedPlugins,
+                Set<String> apiPlugins,
+                Set<String> adoptablePlugins,
+                Set<String> noInstallationsPlugins) {
+            this.installationStatsData = installationStatsData;
+            this.installations = installations;
+            this.scores = scores;
+            this.deprecatedPlugins = deprecatedPlugins;
+            this.apiPlugins = apiPlugins;
+            this.adoptablePlugins = adoptablePlugins;
+            this.noInstallationsPlugins = noInstallationsPlugins;
+        }
+
+        @Override
+        public PluginInstallationStatsData getPluginInstallationStatsData() {
+            return installationStatsData;
+        }
+
+        @Override
+        public Integer extractInstallationStats(Plugin plugin) {
+            return installations.get(plugin.getName());
+        }
+
+        @Override
+        public Double extractScore(Plugin plugin) {
+            return scores.get(plugin.getName());
+        }
+
+        @Override
+        public boolean isDeprecated(Plugin plugin) {
+            return deprecatedPlugins.contains(plugin.getName());
+        }
+
+        @Override
+        public boolean isApiPlugin(Plugin plugin) {
+            return apiPlugins.contains(plugin.getName());
+        }
+
+        @Override
+        public boolean isForAdoption(Plugin plugin) {
+            return adoptablePlugins.contains(plugin.getName());
+        }
+
+        @Override
+        public boolean hasNoKnownInstallations(Plugin plugin) {
+            return noInstallationsPlugins.contains(plugin.getName());
+        }
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignServiceTest.java
@@ -1,0 +1,186 @@
+package io.jenkins.tools.pluginmodernizer.core.campaign;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jenkins.tools.pluginmodernizer.core.config.Config;
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import io.jenkins.tools.pluginmodernizer.core.utils.RecipeResolver;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class CampaignServiceTest {
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void shouldStopAfterFailedStageWhenContinueOnFailureIsDisabled() throws Exception {
+        CampaignDefinition definition = buildDefinition(false);
+        Path campaignFile = tempDir.resolve("campaign.yaml");
+        Files.writeString(campaignFile, "ignored");
+
+        Path workspace = tempDir.resolve("workspace");
+        Files.createDirectories(workspace);
+        AtomicInteger callCount = new AtomicInteger();
+        CampaignModernizerRunner runner = (stageConfig, stage) -> {
+            callCount.incrementAndGet();
+            CampaignStageReport report = new CampaignStageReport();
+            report.setStageName(stage.getRecipe());
+            report.setRecipe(stageConfig.getRecipe().getName());
+            report.setSuccess(false);
+            report.setLocalRepository(workspace.toString());
+            report.setModifiedFiles(List.of());
+            report.setErrors(List.of("boom"));
+            return report;
+        };
+
+        CampaignParser parser = new StubCampaignParser(definition);
+        CampaignPluginSelector selector = new StubCampaignPluginSelector(List.of(Plugin.build("git")));
+        CampaignService service = new CampaignService(baseConfig(), parser, selector, runner, new RecipeResolver());
+        CampaignReport report = service.run(campaignFile);
+
+        assertEquals(1, callCount.get());
+        assertEquals(1, report.getFailedPlugins());
+        assertEquals(1, report.getFailedStages());
+        assertTrue(Files.exists(tempDir.resolve("reports").resolve("campaign.json")));
+    }
+
+    @Test
+    void shouldReuseLocalWorkspaceAcrossStages() throws Exception {
+        CampaignDefinition definition = buildDefinition(true);
+        Path campaignFile = tempDir.resolve("campaign.yaml");
+        Files.writeString(campaignFile, "ignored");
+
+        Path workspace = tempDir.resolve("workspace");
+        Files.createDirectories(workspace);
+        AtomicInteger callCount = new AtomicInteger();
+        CampaignModernizerRunner runner = (stageConfig, stage) -> {
+            int invocation = callCount.incrementAndGet();
+            CampaignStageReport report = new CampaignStageReport();
+            report.setStageName(stage.getRecipe());
+            report.setRecipe(stageConfig.getRecipe().getName());
+            report.setSuccess(true);
+            report.setLocalRepository(workspace.toString());
+            report.setModifiedFiles(List.of("pom.xml"));
+            report.setErrors(List.of());
+
+            assertTrue(stageConfig.isDryRun());
+            if (invocation == 2) {
+                Plugin plugin = stageConfig.getPlugins().get(0);
+                assertTrue(plugin.isLocal());
+                assertEquals(workspace.toAbsolutePath(), plugin.getLocalRepository().toAbsolutePath());
+            }
+            return report;
+        };
+
+        CampaignParser parser = new StubCampaignParser(definition);
+        CampaignPluginSelector selector = new StubCampaignPluginSelector(List.of(Plugin.build("git")));
+        CampaignService service = new CampaignService(baseConfig(), parser, selector, runner, new RecipeResolver());
+        CampaignReport report = service.run(campaignFile);
+
+        assertEquals(2, callCount.get());
+        assertEquals(1, report.getSuccessfulPlugins());
+        assertEquals(2, report.getSuccessfulStages());
+        assertEquals(workspace.toAbsolutePath().toString(), report.getPlugins().get(0).getFinalLocalRepository());
+    }
+
+    @Test
+    void shouldHandleFailedStageWithoutLocalRepository() throws Exception {
+        CampaignDefinition definition = buildDefinition(false);
+        Path campaignFile = tempDir.resolve("campaign.yaml");
+        Files.writeString(campaignFile, "ignored");
+
+        CampaignModernizerRunner runner = (stageConfig, stage) -> {
+            CampaignStageReport report = new CampaignStageReport();
+            report.setStageName(stage.getRecipe());
+            report.setRecipe(stageConfig.getRecipe().getName());
+            report.setSuccess(false);
+            report.setLocalRepository(null);
+            report.setModifiedFiles(List.of());
+            report.setErrors(List.of("stage failed before checkout"));
+            return report;
+        };
+
+        CampaignParser parser = new StubCampaignParser(definition);
+        CampaignPluginSelector selector = new StubCampaignPluginSelector(List.of(Plugin.build("git")));
+        CampaignService service = new CampaignService(baseConfig(), parser, selector, runner, new RecipeResolver());
+        CampaignReport report = service.run(campaignFile);
+
+        assertEquals(1, report.getFailedPlugins());
+        assertNull(report.getPlugins().get(0).getFinalLocalRepository());
+        assertEquals(
+                "stage failed before checkout",
+                report.getPlugins().get(0).getStages().get(0).getErrors().get(0));
+    }
+
+    private CampaignDefinition buildDefinition(boolean continueOnFailure) {
+        CampaignStage stage1 = new CampaignStage();
+        stage1.setRecipe("SetupDependabot");
+        CampaignStage stage2 = new CampaignStage();
+        stage2.setRecipe("SetupSecurityScan");
+
+        CampaignExecution execution = new CampaignExecution();
+        execution.setConcurrency(1);
+        execution.setContinueOnFailure(continueOnFailure);
+
+        CampaignOutput output = new CampaignOutput();
+        output.setReportJson("reports/campaign.json");
+
+        CampaignDefinition definition = new CampaignDefinition();
+        definition.setStages(List.of(stage1, stage2));
+        definition.setExecution(execution);
+        definition.setOutput(output);
+        return definition;
+    }
+
+    private Config baseConfig() throws Exception {
+        Path cachePath = tempDir.resolve("cache");
+        Path mavenHome = tempDir.resolve("maven-home");
+        Path mavenLocalRepo = tempDir.resolve("m2");
+        Files.createDirectories(cachePath);
+        Files.createDirectories(mavenHome);
+        Files.createDirectories(mavenLocalRepo);
+        return Config.builder()
+                .withVersion("999999-SNAPSHOT")
+                .withCachePath(cachePath)
+                .withMavenHome(mavenHome)
+                .withMavenLocalRepo(mavenLocalRepo)
+                .build();
+    }
+
+    private static final class StubCampaignParser extends CampaignParser {
+
+        private final CampaignDefinition definition;
+
+        private StubCampaignParser(CampaignDefinition definition) {
+            super(new RecipeResolver());
+            this.definition = definition;
+        }
+
+        @Override
+        public CampaignDefinition parse(Path campaignFile) {
+            return definition;
+        }
+    }
+
+    private static final class StubCampaignPluginSelector extends CampaignPluginSelector {
+
+        private final List<Plugin> plugins;
+
+        private StubCampaignPluginSelector(List<Plugin> plugins) {
+            super(new io.jenkins.tools.pluginmodernizer.core.utils.PluginService());
+            this.plugins = plugins;
+        }
+
+        @Override
+        public List<Plugin> selectPlugins(CampaignDefinition definition, Path campaignFile) {
+            return plugins;
+        }
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignServiceTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/campaign/CampaignServiceTest.java
@@ -74,7 +74,8 @@ class CampaignServiceTest {
             if (invocation == 2) {
                 Plugin plugin = stageConfig.getPlugins().get(0);
                 assertTrue(plugin.isLocal());
-                assertEquals(workspace.toAbsolutePath(), plugin.getLocalRepository().toAbsolutePath());
+                assertEquals(
+                        workspace.toAbsolutePath(), plugin.getLocalRepository().toAbsolutePath());
             }
             return report;
         };
@@ -87,7 +88,9 @@ class CampaignServiceTest {
         assertEquals(2, callCount.get());
         assertEquals(1, report.getSuccessfulPlugins());
         assertEquals(2, report.getSuccessfulStages());
-        assertEquals(workspace.toAbsolutePath().toString(), report.getPlugins().get(0).getFinalLocalRepository());
+        assertEquals(
+                workspace.toAbsolutePath().toString(),
+                report.getPlugins().get(0).getFinalLocalRepository());
     }
 
     @Test

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginPathResolverTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginPathResolverTest.java
@@ -1,0 +1,78 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class PluginPathResolverTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private final PluginPathResolver resolver = new PluginPathResolver();
+
+    @Test
+    void shouldResolveSingleModulePlugin() throws Exception {
+        Files.writeString(
+                tempDir.resolve("pom.xml"),
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>test</groupId>
+                  <artifactId>my-plugin</artifactId>
+                  <version>1.0</version>
+                  <packaging>hpi</packaging>
+                </project>
+                """);
+        Plugin plugin = resolver.resolve(tempDir);
+        assertEquals("my-plugin", plugin.getName());
+        assertTrue(plugin.isLocal());
+    }
+
+    @Test
+    void shouldResolveMultiModulePlugin() throws Exception {
+        Files.writeString(
+                tempDir.resolve("pom.xml"),
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>test</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0</version>
+                  <packaging>pom</packaging>
+                </project>
+                """);
+        Path sub = tempDir.resolve("my-plugin");
+        Files.createDirectories(sub);
+        Files.writeString(
+                sub.resolve("pom.xml"),
+                """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>test</groupId>
+                  <artifactId>my-plugin</artifactId>
+                  <version>1.0</version>
+                  <packaging>hpi</packaging>
+                </project>
+                """);
+        Plugin plugin = resolver.resolve(tempDir);
+        assertEquals("my-plugin", plugin.getName());
+        assertTrue(plugin.isLocal());
+    }
+
+    @Test
+    void shouldThrowForNonExistentDirectory() {
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(tempDir.resolve("missing")));
+    }
+
+    @Test
+    void shouldThrowForMissingPom() {
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve(tempDir));
+    }
+}

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginPathResolverTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/PluginPathResolverTest.java
@@ -19,9 +19,7 @@ class PluginPathResolverTest {
 
     @Test
     void shouldResolveSingleModulePlugin() throws Exception {
-        Files.writeString(
-                tempDir.resolve("pom.xml"),
-                """
+        Files.writeString(tempDir.resolve("pom.xml"), """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>test</groupId>
@@ -37,9 +35,7 @@ class PluginPathResolverTest {
 
     @Test
     void shouldResolveMultiModulePlugin() throws Exception {
-        Files.writeString(
-                tempDir.resolve("pom.xml"),
-                """
+        Files.writeString(tempDir.resolve("pom.xml"), """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>test</groupId>
@@ -50,9 +46,7 @@ class PluginPathResolverTest {
                 """);
         Path sub = tempDir.resolve("my-plugin");
         Files.createDirectories(sub);
-        Files.writeString(
-                sub.resolve("pom.xml"),
-                """
+        Files.writeString(sub.resolve("pom.xml"), """
                 <project>
                   <modelVersion>4.0.0</modelVersion>
                   <groupId>test</groupId>

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/RecipeResolverTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/RecipeResolverTest.java
@@ -1,0 +1,37 @@
+package io.jenkins.tools.pluginmodernizer.core.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
+import org.junit.jupiter.api.Test;
+
+class RecipeResolverTest {
+
+    private final RecipeResolver resolver = new RecipeResolver();
+
+    @Test
+    void shouldResolveByShortName() {
+        Recipe recipe = resolver.resolve("SetupDependabot");
+        assertTrue(recipe.getName().endsWith("SetupDependabot"));
+    }
+
+    @Test
+    void shouldResolveByFullyQualifiedName() {
+        Recipe recipe = resolver.resolve("io.jenkins.tools.pluginmodernizer.SetupDependabot");
+        assertEquals("io.jenkins.tools.pluginmodernizer.SetupDependabot", recipe.getName());
+    }
+
+    @Test
+    void shouldThrowForUnknownRecipe() {
+        assertThrows(IllegalArgumentException.class, () -> resolver.resolve("NotARealRecipe"));
+    }
+
+    @Test
+    void shouldReturnNonEmptyCandidates() {
+        assertFalse(resolver.candidates().isEmpty());
+        assertTrue(resolver.candidates().contains("SetupDependabot"));
+    }
+}


### PR DESCRIPTION

The tool today runs one recipe, one invocation. If you want to modernize a plugin properly - Dependabot, security scan, parent POM upgrade - that's three separate runs, three separate outputs, no connection between them.

Campaign mode fixes that. One YAML file, one run, one report.

Adds a `campaign` subcommand. It reads a YAML file that defines plugin sources, an ordered list of recipe stages, and execution settings. Each stage runs on the local workspace left by the previous one - no re-clone between stages. Always runs in dry-run mode: no commits, forks, or PRs are created.

Plugin sources can be combined: explicit names, a file, local paths, or the top N by install count. Filters on health score, install count, and deprecation status narrow the set before execution begins.

## Testing done
Ran against `permissive-script-security` (health score 71, no `.github/` dir):
<img width="1280" height="86" alt="photo_2026-04-15_14-59-58" src="https://github.com/user-attachments/assets/f307f806-aa88-486d-bd13-a5a8946967a1" />

<img width="2118" height="249" alt="image" src="https://github.com/user-attachments/assets/0ea3efe6-4ad3-4e98-bfe6-793a3eef73e7" />


<img width="1724" height="1508" alt="image" src="https://github.com/user-attachments/assets/a52ba0e2-69bd-4dc2-b0d4-910583c69fa8" />


## Submitter checklist
 

- [x] Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
- [x]  Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x]  Ensure you have provided tests - that demonstrates feature works or fixes the issue


 
 
 
