### PR TITLE
feat: record failure reasons in modernization metadata

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/ModernizationMetadata.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/extractor/ModernizationMetadata.java
@@ -82,6 +82,12 @@ public class ModernizationMetadata extends CacheEntry<ModernizationMetadata> {
     private String migrationStatus;
 
     /**
+     * Reasons why the migration failed, if any.
+     * Null when migration succeeded (omitted from JSON).
+     */
+    private List<String> failureReasons;
+
+    /**
      * Number of deprecated APIs removed by the migration
      */
     private Integer removedDeprecatedApis;
@@ -259,6 +265,14 @@ public class ModernizationMetadata extends CacheEntry<ModernizationMetadata> {
 
     public void setMigrationStatus(String migrationStatus) {
         this.migrationStatus = migrationStatus;
+    }
+
+    public List<String> getFailureReasons() {
+        return failureReasons;
+    }
+
+    public void setFailureReasons(List<String> failureReasons) {
+        this.failureReasons = failureReasons;
     }
 
     public String getJenkinsBaseline() {

--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizer.java
@@ -11,10 +11,12 @@ import io.jenkins.tools.pluginmodernizer.core.model.JDK;
 import io.jenkins.tools.pluginmodernizer.core.model.ModernizerException;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
 import io.jenkins.tools.pluginmodernizer.core.model.PluginProcessingException;
+import io.jenkins.tools.pluginmodernizer.core.model.PreconditionError;
 import io.jenkins.tools.pluginmodernizer.core.model.RepoType;
 import io.jenkins.tools.pluginmodernizer.core.utils.PluginService;
 import io.jenkins.tools.pluginmodernizer.core.utils.StaticPomParser;
 import jakarta.inject.Inject;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.slf4j.Logger;
@@ -534,6 +536,12 @@ public class PluginModernizer {
         modernizationMetadata.setChangedFiles(diffStats.changedFiles());
         if (plugin.hasErrors() || plugin.hasPreconditionErrors()) {
             modernizationMetadata.setMigrationStatus("fail");
+            List<String> reasons = new ArrayList<>();
+            plugin.getPreconditionErrors().stream()
+                    .map(PreconditionError::getError)
+                    .forEach(reasons::add);
+            plugin.getErrors().stream().map(Throwable::getMessage).forEach(reasons::add);
+            modernizationMetadata.setFailureReasons(reasons);
         } else {
             modernizationMetadata.setMigrationStatus("success");
         }

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizerTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/impl/PluginModernizerTest.java
@@ -1,6 +1,8 @@
 package io.jenkins.tools.pluginmodernizer.core.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -8,9 +10,14 @@ import static org.mockito.Mockito.*;
 
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.config.Settings;
+import io.jenkins.tools.pluginmodernizer.core.extractor.ModernizationMetadata;
+import io.jenkins.tools.pluginmodernizer.core.extractor.PluginMetadata;
 import io.jenkins.tools.pluginmodernizer.core.github.GHService;
+import io.jenkins.tools.pluginmodernizer.core.model.DiffStats;
 import io.jenkins.tools.pluginmodernizer.core.model.Plugin;
+import io.jenkins.tools.pluginmodernizer.core.model.PluginProcessingException;
 import io.jenkins.tools.pluginmodernizer.core.model.PluginVersionData;
+import io.jenkins.tools.pluginmodernizer.core.model.PreconditionError;
 import io.jenkins.tools.pluginmodernizer.core.model.Recipe;
 import io.jenkins.tools.pluginmodernizer.core.utils.PluginService;
 import java.net.URL;
@@ -18,9 +25,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -359,6 +368,109 @@ class PluginModernizerTest {
         verify(plugin, never()).commitMetadata(any());
         verify(plugin, never()).pushMetadata(any());
         verify(plugin, never()).openMetadataPullRequest(any());
+    }
+
+    @Test
+    void testCollectModernizationMetadata_WithPreconditionErrors_ShouldRecordFailureReasons() throws Exception {
+        // Arrange
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata pluginMetadata = mock(PluginMetadata.class);
+        Config pluginConfig = mock(Config.class);
+        Recipe recipe = mock(Recipe.class);
+
+        when(plugin.getName()).thenReturn("test-plugin");
+        when(plugin.getMetadata()).thenReturn(pluginMetadata);
+        when(pluginMetadata.getPluginName()).thenReturn("test-plugin");
+        when(pluginMetadata.getJenkinsVersion()).thenReturn(null);
+        when(plugin.getJenkinsBaseline()).thenReturn("2.361");
+        when(plugin.getJenkinsVersion()).thenReturn("2.361.1");
+        when(plugin.getEffectiveBaseline()).thenReturn("2.361");
+        when(plugin.getConfig()).thenReturn(pluginConfig);
+        when(pluginConfig.getRecipe()).thenReturn(recipe);
+        when(recipe.getDisplayName()).thenReturn("Test Recipe");
+        when(recipe.getDescription()).thenReturn("Test description");
+        when(recipe.getTags()).thenReturn(Set.of());
+        when(recipe.getName()).thenReturn("test-recipe");
+        when(plugin.getPullRequestUrl()).thenReturn(null);
+        when(pluginService.extractVersion(plugin)).thenReturn("1.0");
+        when(config.isDryRun()).thenReturn(false);
+        when(plugin.getDiffStats(ghService, false)).thenReturn(new DiffStats(0, 0, 0));
+        when(plugin.hasErrors()).thenReturn(false);
+        when(plugin.hasPreconditionErrors()).thenReturn(true);
+        when(plugin.getPreconditionErrors()).thenReturn(Set.of(PreconditionError.PARENT_POM_1X));
+        when(plugin.getErrors()).thenReturn(List.of());
+        // GHService is not needed here; the existing try-catch in collectModernizationMetadata handles this
+        doThrow(new PluginProcessingException("no gh", plugin)).when(ghService).getRepository(any(), any());
+        // Allow save() to proceed without NPE
+        when(cacheManager.getLocation()).thenReturn(Path.of("target/test-cache"));
+
+        java.lang.reflect.Method method =
+                PluginModernizer.class.getDeclaredMethod("collectModernizationMetadata", Plugin.class);
+        method.setAccessible(true);
+
+        // Act
+        method.invoke(pluginModernizer, plugin);
+
+        // Assert
+        ArgumentCaptor<ModernizationMetadata> captor = ArgumentCaptor.forClass(ModernizationMetadata.class);
+        verify(plugin).setModernizationMetadata(captor.capture());
+        ModernizationMetadata saved = captor.getValue();
+
+        assertEquals("fail", saved.getMigrationStatus());
+        assertNotNull(saved.getFailureReasons());
+        assertTrue(saved.getFailureReasons().contains(PreconditionError.PARENT_POM_1X.getError()));
+    }
+
+    @Test
+    void testCollectModernizationMetadata_WithRuntimeErrors_ShouldRecordFailureReasons() throws Exception {
+        // Arrange
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata pluginMetadata = mock(PluginMetadata.class);
+        Config pluginConfig = mock(Config.class);
+        Recipe recipe = mock(Recipe.class);
+
+        when(plugin.getName()).thenReturn("test-plugin");
+        when(plugin.getMetadata()).thenReturn(pluginMetadata);
+        when(pluginMetadata.getPluginName()).thenReturn("test-plugin");
+        when(pluginMetadata.getJenkinsVersion()).thenReturn(null);
+        when(plugin.getJenkinsBaseline()).thenReturn("2.361");
+        when(plugin.getJenkinsVersion()).thenReturn("2.361.1");
+        when(plugin.getEffectiveBaseline()).thenReturn("2.361");
+        when(plugin.getConfig()).thenReturn(pluginConfig);
+        when(pluginConfig.getRecipe()).thenReturn(recipe);
+        when(recipe.getDisplayName()).thenReturn("Test Recipe");
+        when(recipe.getDescription()).thenReturn("Test description");
+        when(recipe.getTags()).thenReturn(Set.of());
+        when(recipe.getName()).thenReturn("test-recipe");
+        when(plugin.getPullRequestUrl()).thenReturn(null);
+        when(pluginService.extractVersion(plugin)).thenReturn("1.0");
+        when(config.isDryRun()).thenReturn(false);
+        when(plugin.getDiffStats(ghService, false)).thenReturn(new DiffStats(0, 0, 0));
+        when(plugin.hasErrors()).thenReturn(true);
+        when(plugin.hasPreconditionErrors()).thenReturn(false);
+        when(plugin.getPreconditionErrors()).thenReturn(Set.of());
+        when(plugin.getErrors())
+                .thenReturn(List.of(new PluginProcessingException("Build failed with code: 1", plugin)));
+        // GHService is not needed here; the existing try-catch in collectModernizationMetadata handles this
+        doThrow(new PluginProcessingException("no gh", plugin)).when(ghService).getRepository(any(), any());
+        // Allow save() to proceed without NPE
+        when(cacheManager.getLocation()).thenReturn(Path.of("target/test-cache"));
+
+        java.lang.reflect.Method method =
+                PluginModernizer.class.getDeclaredMethod("collectModernizationMetadata", Plugin.class);
+        method.setAccessible(true);
+
+        // Act
+        method.invoke(pluginModernizer, plugin);
+
+        // Assert
+        ArgumentCaptor<ModernizationMetadata> captor = ArgumentCaptor.forClass(ModernizationMetadata.class);
+        verify(plugin).setModernizationMetadata(captor.capture());
+        ModernizationMetadata saved = captor.getValue();
+
+        assertEquals("fail", saved.getMigrationStatus());
+        assertNotNull(saved.getFailureReasons());
+        assertTrue(saved.getFailureReasons().contains("Build failed with code: 1"));
     }
 
     private Recipe createMockRecipe(String name, String description) {


### PR DESCRIPTION
When a plugin migration fails, the tool writes "migrationStatus": "fail" to the modernization metadata JSON but provides no explanation. So 46% of all records in the metadata repository are failures with no descriptive information and maintainers cannot tell whether the failure was due to a precondition (e.g. parent POM 1.x, HTTP repositories) or runtime build error.

This PR adds a failureReasons field to ModernizationMetadata that takes the error messages at the time of failure. Precondition errors (e.g. "Found parent version starting with 1. in pom file preventing modernization") are recorded first, and then any runtime exception messages. This field is not there in JSON entirely when the migration succeeds, so existing successful records will not be affected.

### Testing done

Two unit tests added to PluginModernizerTest:

- testCollectModernizationMetadata_WithPreconditionErrors_ShouldRecordFailureReasons: this verifies that a precondition  failure (PARENT_POM_1X) is captured in failureReasons and migrationStatus is "fail"
- testCollectModernizationMetadata_WithRuntimeErrors_ShouldRecordFailureReasons: this verifies that a runtime build error message is captured in failureReasons

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
