### PR TITLE
fix: use configured cache path in getDiffStats instead of hardcoded default

### DIFF
--- a/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
+++ b/plugin-modernizer-core/src/main/java/io/jenkins/tools/pluginmodernizer/core/github/GHService.java
@@ -1237,7 +1237,7 @@ public class GHService {
      * @return DiffStats (no. of additions, deletions and changed files)
      */
     public DiffStats getDiffStats(Plugin plugin, boolean dryRun) {
-        Path gitDirPath = Settings.DEFAULT_CACHE_PATH
+        Path gitDirPath = config.getCachePath()
                 .resolve(plugin.getName())
                 .resolve("sources")
                 .resolve(".git")


### PR DESCRIPTION
`getDiffStats()` was resolving the .git directory against `Settings.DEFAULT_CACHE_PATH` instead of `config.getCachePath()`. So running with `--cache-path /tmp/my-cache` would clone the plugin correctly there but then fail to read it back when building the PR description. One-line fix.

---

## Testing Done
I tested it locally, and here is the before and after 


**Before** (`main` — `GHServiceTest`):

```java
[INFO] Running io.jenkins.tools.pluginmodernizer.core.github.GHServiceTest
[INFO] Tests run: 48, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.46 s
```

**After** (`fix/get-diff-stats-cache-path` — `mvn clean test -pl plugin-modernizer-core`):

```java
[INFO] Tests run: 432, Failures: 0, Errors: 0, Skipped: 1
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  02:55 min
[INFO] Finished at: 2026-04-17T09:11:14+02:00
```

## Submitter checklist

- [x]  Make sure you are opening from a topic/feature/bugfix branch (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue