### PR TITLE
Add recipe to include `ban-deprecated-stapler.skip` in pom

### DIFF
--- a/plugin-modernizer-core/src/main/jte/pr-body-BanJavaxServletClasses.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-BanJavaxServletClasses.jte
@@ -1,0 +1,18 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+Hello `${plugin.getName()}` developers! :wave:
+
+This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool) tool. The tool has applied the following recipes to modernize the plugin:
+<details aria-label="Recipe details for ${recipe.getDisplayName()}">
+    <summary>${recipe.getDisplayName()}</summary>
+    <p><em>${recipe.getName()}</em></p>
+    <blockquote>${recipe.getDescription()}</blockquote>
+</details>
+
+## Why is this important?
+
+The `javax.servlet` API is deprecated in Jenkins plugins.
+
+Ensure to update the pom.xml with `<ban-deprecated-stapler.skip>false</ban-deprecated-stapler.skip>` to prevent regressions.

--- a/plugin-modernizer-core/src/main/jte/pr-title-BanJavaxServletClasses.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-BanJavaxServletClasses.jte
@@ -1,0 +1,1 @@
+Ban deprecated javax.servlet classes

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -860,3 +860,13 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.core.recipes.AddProperty:
       key: hpi.strictBundledArtifacts
       value: true
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses
+displayName: Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`
+description: Ensure the pom.xml contains the property `ban-deprecated-stapler.skip` set to `false`.
+tags: ['dependencies', 'migration']
+recipeList:
+  - io.jenkins.tools.pluginmodernizer.core.recipes.AddProperty:
+      key: ban-deprecated-stapler.skip
+      value: false

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -4385,6 +4385,66 @@ public class DeclarativeRecipesTest implements RewriteTest {
                   """));
     }
 
+    @Test
+    void shouldSetBanJavaxServletProperty() {
+        rewriteRun(
+                spec -> spec.recipeFromResource(
+                        "/META-INF/rewrite/recipes.yml", "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses"),
+                // language=xml
+                pomXml("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                        <groupId>org.jenkins-ci.plugins</groupId>
+                        <artifactId>plugin</artifactId>
+                        <version>4.87</version>
+                        <relativePath />
+                      </parent>
+                      <artifactId>plugin</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <packaging>hpi</packaging>
+                      <name>Test Plugin</name>
+                      <properties>
+                          <jenkins.version>2.452.4</jenkins.version>
+                      </properties>
+                      <repositories>
+                          <repository>
+                              <id>repo.jenkins-ci.org</id>
+                              <url>https://repo.jenkins-ci.org/public/</url>
+                          </repository>
+                      </repositories>
+                  </project>
+                  """, """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                        <groupId>org.jenkins-ci.plugins</groupId>
+                        <artifactId>plugin</artifactId>
+                        <version>4.87</version>
+                        <relativePath />
+                      </parent>
+                      <artifactId>plugin</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <packaging>hpi</packaging>
+                      <name>Test Plugin</name>
+                      <properties>
+                          <jenkins.version>2.452.4</jenkins.version>
+                          <ban-deprecated-stapler.skip>false</ban-deprecated-stapler.skip>
+                      </properties>
+                      <repositories>
+                          <repository>
+                              <id>repo.jenkins-ci.org</id>
+                              <url>https://repo.jenkins-ci.org/public/</url>
+                          </repository>
+                      </repositories>
+                  </project>
+                  """));
+    }
+
     /**
      * Note this test need to be adapted to fix the .gitignore to ensure entries are merged
      */

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -627,6 +627,47 @@ public class TemplateUtilsTest {
     }
 
     @Test
+    public void testFriendlyPrBodyBanJavaxServletClasses() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata metadata = mock(PluginMetadata.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn(metadata).when(plugin).getMetadata();
+        doReturn("io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestBody(plugin, recipe);
+
+        // Assert
+        assertTrue(result.contains("Why is this important?"), "Missing 'Why is this important?' section");
+        assertTrue(result.contains("ban-deprecated-stapler.skip"), "Missing property name");
+    }
+
+    @Test
+    public void testFriendlyPrTitleBanJavaxServletClasses() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata metadata = mock(PluginMetadata.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn(metadata).when(plugin).getMetadata();
+        doReturn("io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
+
+        // Assert
+        assertEquals("Ban deprecated javax.servlet classes", result);
+    }
+
+    @Test
     public void testFriendlyPrTitleEnsureRelativePath() {
 
         // Mocks

--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -117,6 +117,7 @@ valid_migration_ids = [
     "io.jenkins.tools.pluginmodernizer.EnableCD",
     "io.jenkins.tools.pluginmodernizer.AutoMergeWorkflows",
     "io.jenkins.tools.pluginmodernizer.StrictBundledArtifacts",
+    "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
 ]
 
 


### PR DESCRIPTION
Add recipe to include `ban-deprecated-stapler.skip` in pom

Included in https://github.com/jenkinsci/plugin-pom/releases/tag/6.2152.ve00a_731c3ce9

### Testing done

mvn clean install

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

