### PR TITLE
Add new recipe to migrate plugin to minium Java 21 (2.555.1)

### DIFF
--- a/plugin-modernizer-core/src/main/jte/pr-body-BaseLineToJenkinsMinimumRequiredJava21Version.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-body-BaseLineToJenkinsMinimumRequiredJava21Version.jte
@@ -1,0 +1,16 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+Hello `${plugin.getName()}` developers! :wave:
+
+This is an automated pull request created by the [Jenkins Plugin Modernizer](https://github.com/jenkins-infra/plugin-modernizer-tool) tool. The tool has applied the following recipes to modernize the plugin:
+<details aria-label="Recipe details for ${recipe.getDisplayName()}">
+    <summary>${recipe.getDisplayName()}</summary>
+    <p><em>${recipe.getName()}</em></p>
+    <blockquote>${recipe.getDescription()}</blockquote>
+</details>
+
+#### Why Upgrade to Java 21 and Jenkins 2.555.x?
+
+- Use Java 21 feature and APIs on your plugin

--- a/plugin-modernizer-core/src/main/jte/pr-title-BaseLineToJenkinsMinimumRequiredJava21Version.jte
+++ b/plugin-modernizer-core/src/main/jte/pr-title-BaseLineToJenkinsMinimumRequiredJava21Version.jte
@@ -1,0 +1,5 @@
+@import io.jenkins.tools.pluginmodernizer.core.model.Plugin
+@import io.jenkins.tools.pluginmodernizer.core.model.Recipe
+@param Plugin plugin
+@param Recipe recipe
+feat(java): Require Jenkins core ${plugin.getMetadata().getJenkinsVersion()} and Java 21

--- a/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
+++ b/plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml
@@ -633,6 +633,21 @@ recipeList:
   - io.jenkins.tools.pluginmodernizer.SetupJenkinsfile
 ---
 type: specs.openrewrite.org/v1beta/recipe
+name: io.jenkins.tools.pluginmodernizer.BaseLineToJenkinsMinimumRequiredJava21Version
+displayName: Baseline a plugin to the minimum required Jenkins version for Java 21 (2.555.1)
+description: Baseline a plugin to the minimum required Jenkins version for Java 21 (2.555.1) in order to use Java 21 features.
+tags: ['dependencies', 'chore']
+recipeList:
+  - io.jenkins.tools.pluginmodernizer.UpgradeParent6Version
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpgradeJenkinsVersion:
+      minimumVersion: 2.555.1
+  - io.jenkins.tools.pluginmodernizer.UpgradeBomVersion
+  - io.jenkins.tools.pluginmodernizer.core.recipes.MigrateStaplerAndJavaxToJakarta
+  - io.jenkins.tools.pluginmodernizer.core.recipes.UpdateJenkinsfileForJavaVersion:
+      javaVersion: 25
+      jdksToRemove: [8, 11, 17]
+---
+type: specs.openrewrite.org/v1beta/recipe
 name: io.jenkins.tools.pluginmodernizer.UpgradeToLatestJava11CoreVersion
 displayName: Upgrade to latest LTS core version supporting Java 11
 description: Upgrade to latest LTS core version supporting Java 11.

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/recipes/DeclarativeRecipesTest.java
@@ -4386,6 +4386,83 @@ public class DeclarativeRecipesTest implements RewriteTest {
     }
 
     @Test
+    void shouldBaseLineToJenkinsMinimumRequiredJava21Version() {
+        rewriteRun(
+                spec -> spec.recipeFromResource(
+                        "/META-INF/rewrite/recipes.yml",
+                        "io.jenkins.tools.pluginmodernizer.BaseLineToJenkinsMinimumRequiredJava21Version"),
+                // language=groovy
+                groovy(
+                        EXPECTED_MODERN_JENKINSFILE,
+                        """
+                        /*
+                         See the documentation for more options:
+                         https://github.com/jenkins-infra/pipeline-library/
+                        */
+                        buildPlugin(
+                            forkCount: '1C', // Run a JVM per core in tests
+                            useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
+                          configurations: [
+                            [platform: 'linux', jdk: 25],
+                            [platform: 'windows', jdk: 21],
+                        ])
+                        """,
+                        s -> s.path(ArchetypeCommonFile.JENKINSFILE.getPath().getFileName())),
+                // language=xml
+                pomXml("""
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                        <groupId>org.jenkins-ci.plugins</groupId>
+                        <artifactId>plugin</artifactId>
+                        <version>4.87</version>
+                        <relativePath />
+                      </parent>
+                      <artifactId>plugin</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <packaging>hpi</packaging>
+                      <name>Test Plugin</name>
+                      <properties>
+                          <jenkins.version>2.452.4</jenkins.version>
+                      </properties>
+                      <repositories>
+                          <repository>
+                              <id>repo.jenkins-ci.org</id>
+                              <url>https://repo.jenkins-ci.org/public/</url>
+                          </repository>
+                      </repositories>
+                  </project>
+                  """, """
+                  <?xml version="1.0" encoding="UTF-8"?>
+                  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      <modelVersion>4.0.0</modelVersion>
+                      <parent>
+                        <groupId>org.jenkins-ci.plugins</groupId>
+                        <artifactId>plugin</artifactId>
+                        <version>%s</version>
+                        <relativePath />
+                      </parent>
+                      <artifactId>plugin</artifactId>
+                      <version>0.0.1-SNAPSHOT</version>
+                      <packaging>hpi</packaging>
+                      <name>Test Plugin</name>
+                      <properties>
+                          <jenkins.version>2.555.1</jenkins.version>
+                      </properties>
+                      <repositories>
+                          <repository>
+                              <id>repo.jenkins-ci.org</id>
+                              <url>https://repo.jenkins-ci.org/public/</url>
+                          </repository>
+                      </repositories>
+                  </project>
+                  """.formatted(Settings.getJenkinsParentVersion())));
+    }
+
+    @Test
     void shouldSetBanJavaxServletProperty() {
         rewriteRun(
                 spec -> spec.recipeFromResource(

--- a/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
+++ b/plugin-modernizer-core/src/test/java/io/jenkins/tools/pluginmodernizer/core/utils/TemplateUtilsTest.java
@@ -306,6 +306,27 @@ public class TemplateUtilsTest {
     }
 
     @Test
+    public void testFriendlyPrTitleBaseLineToJenkinsMinimumRequiredJava21Version() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata metadata = mock(PluginMetadata.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn(metadata).when(plugin).getMetadata();
+        doReturn("2.555.1").when(metadata).getJenkinsVersion();
+        doReturn("io.jenkins.tools.pluginmodernizer.BaseLineToJenkinsMinimumRequiredJava21Version")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestTitle(plugin, recipe);
+
+        // Assert
+        assertEquals("feat(java): Require Jenkins core 2.555.1 and Java 21", result);
+    }
+
+    @Test
     public void testFriendlyPrTitleMigrateToJenkinsBaseLineProperty() {
 
         // Mocks
@@ -645,6 +666,28 @@ public class TemplateUtilsTest {
         // Assert
         assertTrue(result.contains("Why is this important?"), "Missing 'Why is this important?' section");
         assertTrue(result.contains("ban-deprecated-stapler.skip"), "Missing property name");
+    }
+
+    @Test
+    public void testFriendlyPrBodyBaseLineToJenkinsMinimumRequiredJava21Version() {
+
+        // Mocks
+        Plugin plugin = mock(Plugin.class);
+        PluginMetadata metadata = mock(PluginMetadata.class);
+        Recipe recipe = mock(Recipe.class);
+
+        doReturn(metadata).when(plugin).getMetadata();
+        doReturn("io.jenkins.tools.pluginmodernizer.BaseLineToJenkinsMinimumRequiredJava21Version")
+                .when(recipe)
+                .getName();
+
+        // Test
+        String result = TemplateUtils.renderPullRequestBody(plugin, recipe);
+
+        // Assert
+        assertTrue(
+                result.contains("Use Java 21 feature and APIs on your plugin"),
+                "Missing 'Use Java 21 feature and APIs on your plugin' message");
     }
 
     @Test

--- a/scripts/validate_metadata.py
+++ b/scripts/validate_metadata.py
@@ -118,6 +118,7 @@ valid_migration_ids = [
     "io.jenkins.tools.pluginmodernizer.AutoMergeWorkflows",
     "io.jenkins.tools.pluginmodernizer.StrictBundledArtifacts",
     "io.jenkins.tools.pluginmodernizer.BanJavaxServletClasses",
+    "io.jenkins.tools.pluginmodernizer.BaseLineToJenkinsMinimumRequiredJava21Version",
 ]
 
 


### PR DESCRIPTION
Add new recipe to migrate plugin to minium Java 21 (2.555.1)

### Testing done

One declarative test + template

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
