### PR TITLE
Add -p flag to scripts while creating scripts dir

### DIFF
--- a/.github/workflows/consolidate-metadata.yml
+++ b/.github/workflows/consolidate-metadata.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Download consolidate_metadata.py script
         run: |
-          mkdir scripts
+          mkdir -p scripts
           curl -sSL https://raw.githubusercontent.com/jenkins-infra/plugin-modernizer-tool/main/scripts/consolidate_metadata.py -o scripts/consolidate_metadata.py
 
 

--- a/.github/workflows/generate-reports.yml
+++ b/.github/workflows/generate-reports.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Download generate_reports.py script
         run: |
-          mkdir scripts
+          mkdir -p scripts
           curl -sSL https://raw.githubusercontent.com/jenkins-infra/plugin-modernizer-tool/main/scripts/generate_reports.py -o scripts/generate_reports.py
 
       - name: Generate report script

--- a/.github/workflows/update-metadata.yml
+++ b/.github/workflows/update-metadata.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Download update_metadata.py script
         run: |
-          mkdir scripts
+          mkdir -p scripts
           curl -sSL https://raw.githubusercontent.com/jenkins-infra/plugin-modernizer-tool/main/scripts/update_metadata.py -o scripts/update_metadata.py
 
       - name: Run updation script


### PR DESCRIPTION
Added -p flag to all three scripts to avoid "scripts/ dir already exists" error for gh actions in [metadata-plugin-modernizer](https://github.com/jenkins-infra/metadata-plugin-modernizer/actions/runs/26790787934/job/78976530807)

### Testing done

temporarily, i pointed this branch in my metadata-plugin-modernizer forks [main branch](https://github.com/jenkins-infra/metadata-plugin-modernizer/compare/main...PratikMane0112:metadata-plugin-modernizer:main) & then [Update metadata](https://github.com/PratikMane0112/metadata-plugin-modernizer/actions/runs/26799913167) gh actions from my fork works fine.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
