### PR TITLE
docs: fix README documentation inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ With over 2000 plugins in Jenkins, keeping them updated manually is a daunting t
 ## Getting Started
 
 ### Requirements
-- Maven version 3.9.14 or later, or mvnd
+- Maven 3.9.14 or later, or mvnd
 - Java 25 ([Eclipse Temurin](https://adoptium.net/temurin/releases) recommended)
 
 ### Build
@@ -217,13 +217,10 @@ source <(plugin-modernizer generate-completion)
 - `--cache-path`: (optional) Custom path to the cache directory. Defaults to `${user.home}/.cache/jenkins-plugin-modernizer-cli`.
 
 
-- `--maven-home`: (optional) Path to the Maven home directory. Required if both `MAVEN_HOME` and `M2_HOME` environment variables are not set. The minimum required version is 3.9.11.
+- `--maven-home`: (optional) Path to the Maven home directory. Required if both `MAVEN_HOME` and `M2_HOME` environment variables are not set. The minimum required version is 3.9.14.
 
 
-- `--clean-local-data` (optional) Deletes the local plugin directory before running the tool.
-
-
-- `--version` or `-v`: (optional) Displays the version of the Plugin Modernizer tool.
+- `--version` or `-V`: (optional) Displays the version of the Plugin Modernizer tool.
 
 
 - `--help` or `-h`: (optional) Displays the help
@@ -291,7 +288,7 @@ Pass the plugin names directly using the `-p` or `--plugins option`. The expecte
 ```shell
 plugin-modernizer --plugins git,git-client,jobcacher --recipe AddPluginsBom
 ```
-Here, `git`, `git-client`, and `jobcacher` are plugin artifact IDs (also known as plugin names), while `AddPluginsBom` and `AddCodeOwners` are recipe names. For more details about available recipes, refer to the [recipe_data.yaml](plugin-modernizer-core/src/main/resources/recipe_data.yaml) file.
+Here, `git`, `git-client`, and `jobcacher` are plugin artifact IDs (also known as plugin names), while `AddPluginsBom` is a recipe name. For more details about available recipes, refer to the [recipes.yml](plugin-modernizer-core/src/main/resources/META-INF/rewrite/recipes.yml) file or run `plugin-modernizer recipes`.
 
 ### Plugin file option
 
@@ -315,9 +312,9 @@ plugin-modernizer run --plugin-file path/to/plugin-file --recipe AddPluginsBom
 
 - `OPT_OUT_PLUGINS_URL`: (optional) Opt Out Plugins URL (.json file containing list of plugins that have opted out for receiving PRs). Can also be passed through the CLI option `--opt-out-plugins-url`. Defaults to this [url](https://raw.githubusercontent.com/jenkins-infra/metadata-plugin-modernizer/main/opt-out-plugins.json) .
 
-- `MAVEN_HOME` or `M2_HOME`: (required) Path to Maven home directory. Can also be passed through the CLI option `-m` or `--maven-home`.
+- `MAVEN_HOME` or `M2_HOME`: (required) Path to Maven home directory. Can also be passed through the CLI option `--maven-home`.
 
-- `CACHE_DIR`: (optional) Path to cache directory. Can also be passed through the CLI option `-c` or `--cache-path`.
+- `CACHE_DIR`: (optional) Path to cache directory. Can also be passed through the CLI option `--cache-path`.
 
 ## Examples
 


### PR DESCRIPTION
Fix several documentation inconsistencies in README.md where the documented CLI options don't match the actual implementation.

### Changes

- Remove non-existent `--clean-local-data` option (no such flag exists in CLI code)
- Fix `--version` short flag: `-v` → `-V` (matches actual picocli annotation in `Main.java`)
- Fix Maven minimum version reference: `3.9.11` → `3.9.14` (matches `Settings.MAVEN_MINIMAL_VERSION`)
- Remove non-existent `-m` and `-c` short flags for `--maven-home` and `--cache-path`
- Fix broken `recipe_data.yaml` link → point to actual `META-INF/rewrite/recipes.yml` path
- Remove reference to non-existent `AddCodeOwners` recipe in example text

### Testing done

Documentation-only change. All corrections verified by:
1. Running `java -jar plugin-modernizer-cli/target/jenkins-plugin-modernizer-999999-SNAPSHOT.jar --help` and subcommand `--help` outputs
2. Cross-referencing picocli annotations in source code (`PluginOptions.java`, `Main.java`)
3. Checking `Settings.MAVEN_MINIMAL_VERSION` constant in `Settings.java`
4. Confirming `recipe_data.yaml` does not exist and `META-INF/rewrite/recipes.yml` is the actual file

No automated tests needed for a docs-only change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
