### PR TITLE
fix: enable --help and -h flags on all subcommands

### DIFF
--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/BuildMetadataCommand.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
+import io.jenkins.tools.pluginmodernizer.cli.VersionProvider;
 import io.jenkins.tools.pluginmodernizer.cli.options.EnvOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.PluginOptions;
@@ -18,6 +19,8 @@ import picocli.CommandLine;
 @CommandLine.Command(
         name = "build-metadata",
         aliases = {"fetch-metadata"},
+        mixinStandardHelpOptions = true,
+        versionProvider = VersionProvider.class,
         description = "Build local metadata")
 public class BuildMetadataCommand implements ICommand {
 

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CleanupCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/CleanupCommand.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
+import io.jenkins.tools.pluginmodernizer.cli.VersionProvider;
 import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
@@ -10,7 +11,7 @@ import picocli.CommandLine;
 /**
  * Cleanup command
  */
-@CommandLine.Command(name = "cleanup", description = "Cleanup local cache data")
+@CommandLine.Command(name = "cleanup", mixinStandardHelpOptions = true, versionProvider = VersionProvider.class, description = "Cleanup local cache data")
 public class CleanupCommand implements ICommand {
 
     /**

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/DryRunCommand.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
+import io.jenkins.tools.pluginmodernizer.cli.VersionProvider;
 import io.jenkins.tools.pluginmodernizer.cli.converter.RecipeConverter;
 import io.jenkins.tools.pluginmodernizer.cli.options.EnvOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.GitHubOptions;
@@ -16,7 +17,7 @@ import picocli.CommandLine;
 /**
  * Dry Run command
  */
-@CommandLine.Command(name = "dry-run", description = "Dry Run")
+@CommandLine.Command(name = "dry-run", mixinStandardHelpOptions = true, versionProvider = VersionProvider.class, description = "Dry Run")
 public class DryRunCommand implements ICommand {
 
     /**

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ListRecipesCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ListRecipesCommand.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
+import io.jenkins.tools.pluginmodernizer.cli.VersionProvider;
 import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
 import io.jenkins.tools.pluginmodernizer.core.config.Config;
 import io.jenkins.tools.pluginmodernizer.core.impl.PluginModernizer;
@@ -8,7 +9,7 @@ import picocli.CommandLine;
 /**
  * A command to list available recipes
  */
-@CommandLine.Command(name = "recipes", description = "List recipes")
+@CommandLine.Command(name = "recipes", mixinStandardHelpOptions = true, versionProvider = VersionProvider.class, description = "List recipes")
 public class ListRecipesCommand implements ICommand {
 
     @CommandLine.Mixin

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/RunCommand.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
+import io.jenkins.tools.pluginmodernizer.cli.VersionProvider;
 import io.jenkins.tools.pluginmodernizer.cli.converter.RecipeConverter;
 import io.jenkins.tools.pluginmodernizer.cli.options.EnvOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.GitHubOptions;
@@ -16,7 +17,7 @@ import picocli.CommandLine;
 /**
  * Run command
  */
-@CommandLine.Command(name = "run", description = "Run")
+@CommandLine.Command(name = "run", mixinStandardHelpOptions = true, versionProvider = VersionProvider.class, description = "Run")
 public class RunCommand implements ICommand {
 
     /**

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ValidateCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/ValidateCommand.java
@@ -1,5 +1,6 @@
 package io.jenkins.tools.pluginmodernizer.cli.command;
 
+import io.jenkins.tools.pluginmodernizer.cli.VersionProvider;
 import io.jenkins.tools.pluginmodernizer.cli.options.EnvOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.GitHubOptions;
 import io.jenkins.tools.pluginmodernizer.cli.options.GlobalOptions;
@@ -15,7 +16,7 @@ import picocli.CommandLine;
 /**
  * Validate command
  */
-@CommandLine.Command(name = "validate", description = "Validate")
+@CommandLine.Command(name = "validate", mixinStandardHelpOptions = true, versionProvider = VersionProvider.class, description = "Validate")
 public class ValidateCommand implements ICommand {
 
     /**

--- a/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/VersionCommand.java
+++ b/plugin-modernizer-cli/src/main/java/io/jenkins/tools/pluginmodernizer/cli/command/VersionCommand.java
@@ -10,7 +10,7 @@ import picocli.CommandLine;
 /**
  * Version command
  */
-@CommandLine.Command(name = "version", description = "Display version information")
+@CommandLine.Command(name = "version", mixinStandardHelpOptions = true, versionProvider = VersionProvider.class, description = "Display version information")
 @SuppressFBWarnings(value = "CRLF_INJECTION_LOGS", justification = "safe because versions from pom.xml")
 public class VersionCommand implements ICommand {
 

--- a/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
+++ b/plugin-modernizer-cli/src/test/java/io/jenkins/tools/pluginmodernizer/cli/CommandLineITCase.java
@@ -176,6 +176,31 @@ public class CommandLineITCase {
     @Test
     @Tag("Slow")
     @Execution(ExecutionMode.CONCURRENT)
+    public void testSubcommandHelp() throws Exception {
+        Invoker invoker = buildInvoker();
+
+        // Test --help on all subcommands
+        for (String subcommand : List.of("validate", "run", "dry-run", "cleanup", "recipes", "build-metadata", "version")) {
+            Path logFile = setupLogs("testSubcommandHelp-" + subcommand);
+            InvocationResult result = invoker.execute(buildRequest(subcommand + " --help", logFile));
+            assertAll(
+                    () -> assertEquals(0, result.getExitCode(), subcommand + " --help should exit 0"),
+                    () -> assertTrue(
+                            Files.readAllLines(logFile).stream()
+                                    .anyMatch(line -> line.contains("Usage:")
+                                            || line.contains("plugin-modernizer " + subcommand)),
+                            subcommand + " --help should print usage"));
+        }
+
+        // Test -h on validate
+        Path logFileShort = setupLogs("testSubcommandHelp-validate-h");
+        InvocationResult resultShort = invoker.execute(buildRequest("validate -h", logFileShort));
+        assertEquals(0, resultShort.getExitCode(), "validate -h should exit 0");
+    }
+
+    @Test
+    @Tag("Slow")
+    @Execution(ExecutionMode.CONCURRENT)
     public void testCleanupWithDryRun() throws Exception {
         Path logFile = setupLogs("testCleanupWithDryRun");
         Invoker invoker = buildInvoker();


### PR DESCRIPTION
Add mixinStandardHelpOptions = true to all subcommand @Command annotations so that --help/-h works consistently across the CLI.

Previously, only the top-level command supported --help. Subcommands (validate, run, dry-run, cleanup, recipes, build-metadata, version) would fail with 'Unknown option: --help' and exit with code 2.

Now all subcommands display usage information and exit cleanly (code 0) when --help or -h is passed, matching the behavior of the top-level command.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
