### PR TITLE
fix: match SDKMAN Temurin identifiers that carry a build suffix

### DIFF
--- a/updatecli/scripts/get-jdk-versions.sh
+++ b/updatecli/scripts/get-jdk-versions.sh
@@ -35,8 +35,10 @@ cd "$current_dir" || exit
 # Initialize SDKMAN
 source "$HOME/.sdkman/bin/sdkman-init.sh"
 
-# Find and output the Temurin JDK version identifier for the given major version
-identifier=$(PAGER=cat sdk list java | grep -E " $major_version(\.[0-9]+)*-tem" | awk -v ver="$major_version" '$0 ~ " " ver "(\\.[0-9]+)*-tem" {print $NF}' | head -n 1)
+# Find and output the Temurin JDK version identifier for the given major version.
+# Identifiers may carry a build suffix after a "+", for example "21.0.12+1.1-tem",
+# so the optional (\+[0-9.]+) group is required to match those as well as "21.0.12-tem".
+identifier=$(PAGER=cat sdk list java | grep -E " $major_version(\.[0-9]+)*(\+[0-9.]+)?-tem" | awk -v ver="$major_version" '$0 ~ " " ver "(\\.[0-9]+)*(\\+[0-9.]+)?-tem" {print $NF}' | head -n 1)
 
 if [ -n "$identifier" ]; then
     echo "$identifier"


### PR DESCRIPTION
Fixes #1894

`sdk list java` now reports some Temurin identifiers with a build suffix:

```
 Temurin        |     | 26.0.2+1.1         | 26.0.2+1.1-tem
                |     | 25.0.4             | 25.0.4-tem
                |     | 21.0.12+1.1        | 21.0.12+1.1-tem
                |     | 17.0.20            | 17.0.20-tem
                |     | 11.0.32+1.1        | 11.0.32+1.1-tem
                |     | 8.0.504+1          | 8.0.504+1-tem
```

`get-jdk-versions.sh` allowed only digits and dots before `-tem`, so 8, 11 and 21 matched
nothing and the script exited 2 with `No Temurin JDK version found for Java <n>`. 17 and 25
have no suffix today, which is why those two kept working.

Once the `JDK21` source failed, the pipeline stopped and the remaining 14 targets were all
reported as `parent source "JDK21" failed` — including the 8, 17 and 25 ones, which made it
look specific to 21.

This allows an optional `+<build>` group in both the `grep` and the `awk` on that line.

I checked it by running the modified selection line against the current `sdk list java`
output:

| major | before | after |
|---|---|---|
| 8  | exit 2        | `8.0.504+1-tem`   |
| 11 | exit 2        | `11.0.32+1.1-tem` |
| 17 | `17.0.20-tem` | `17.0.20-tem`     |
| 21 | exit 2        | `21.0.12+1.1-tem` |
| 25 | `25.0.4-tem`  | `25.0.4-tem`      |

It still matches suffix-free identifiers such as `21.0.12-tem`, and it doesn't pick up other
vendors that carry a suffix on the same version (`21.0.12+1.1-librca`, `21.0.12-graal`).

`SDKMAN-TEMURIN.YAML` is the only failing pipeline of the 16 — the other 15 are `✔` or `⚠`,
and the four `⚠` ones show that drift alone doesn't fail `updatecli diff`.

### Why this matters beyond the red check

The `Apply mode` step is gated on `github.ref == 'refs/heads/main'`, which is implicitly
ANDed with `success()`, so the failing `Dry Run` step skips it. In the last scheduled run:

```
6. Run Updatecli in Dry Run mode: failure
7. Run Updatecli in Apply mode: skipped
```

There's no successful run on `main` in the last 60, and the last bot-authored version-bump
commits are from 2026-08-15, so the automated bumps have not been landing. One of the pending
changes is:

```diff
-bom.version = 6931.vea_a_b_c6fd017d
+bom.version = 7002.v028a_3607ddc8
```

`6931` is what's currently committed, and the recipe tests that compare against
`versions.properties` are failing on that gap. I haven't verified that end to end, but if it
holds, unblocking `apply` should clear those too rather than just the updatecli check.

### Caveat

I don't have SDKMAN installed locally, so I tested the identifier selection against the real
table rather than running the script end to end. The install path is untested from my side.
`install-jdk-versions.sh` already uses the looser `" $version\.0.*-tem"` pattern, so it was
resolving the suffixed identifiers fine and isn't affected.

### Left out deliberately, happy to fold in either

- `get-java-home.sh` uses the same looser pattern, which already matched the suffix. That's
  why the failing run still moved `JAVA_11_HOME` to `11.0.32+1.1-tem` while `JDK11_PACKAGE`
  stayed at `11.0.32-tem`. With this fix both resolve the same identifier again, so aligning
  the two patterns is consistency rather than a bug.
- `JDK8_PACKAGE`, `JDK11_PACKAGE` and `JDK21_PACKAGE` in `sdkman.properties` are pinned to
  versions that are no longer listed, and the Dockerfiles run `sdk install java
  $JDKn_PACKAGE`. I assumed you'd rather updatecli bump those itself on the next run on
  `main` than have me hand-edit them.
